### PR TITLE
Enhance BynderInput component with improved asset handling and...

### DIFF
--- a/.changeset/issue149-asset-meta-data.md
+++ b/.changeset/issue149-asset-meta-data.md
@@ -1,0 +1,11 @@
+---
+"sanity-plugin-bynder-input": patch
+---
+
+Enhance BynderInput component with improved asset handling and preview options based on issue 149
+
+- Added support for field-level options in Bynder asset configuration.
+- Updated asset handling to safely access nested properties.
+- Improved media data structure for backward compatibility.
+- Adjusted image preview styling and added support for document types.
+- Refactored button text based on asset presence.

--- a/plugins/sanity-plugin-bynder-input/src/schema/bynder.asset.ts
+++ b/plugins/sanity-plugin-bynder-input/src/schema/bynder.asset.ts
@@ -53,9 +53,13 @@ export interface BynderAssetValue {
   aspectRatio?: number
   videoUrl?: string
   selectedUrl?: string
+  width?: number
+  height?: number
+  /** Index signature to allow any additional Bynder asset fields */
+  [key: string]: unknown
 }
 
-export const bynderAssetSchema = defineType({
+export const bynderAssetSchema: ObjectDefinition = defineType({
   name: bynderAssetSchemaName,
   type: 'object',
   title: 'Bynder Asset',


### PR DESCRIPTION
…preview options based on issue 149

### Description
Extends the sanity-plugin-bynder-input plugin to include all Bynder asset metadata fields in the stored document, enabling access to fields like `focusPoint`, `copyright`, `tags`, etc. without additional API calls.

  **Changes:**
  - Spread all raw Bynder asset fields into  `mediaData` while preserving backward-compatible computed fields
  - Add index signature to `BynderAssetValue` interface for type flexibility
  - Fix modal not closing after asset selection (explicitly call `setIsOpen(false)`)
  - Fix `assetTypes` field option not being passed to Bynder CompactView
  - Add null safety for `webImage` access
  - Add explicit type annotation for `bynderAssetSchema` (required for `--isolatedDeclarations`)

  Fixes https://github.com/sanity-io/plugins/issues/149

  ### What to review

  1. **`src/components/BynderInput.tsx`**:
     - `onSuccess` callback now spreads
  `...asset` before setting explicit fields
     - Field-level options (`assetTypes`, `assetFilter`) are merged with global plugin config
     - Modal explicitly closes after selection      

  2. **`src/schema/bynder.asset.ts`**:
     - `BynderAssetValue` interface now has `[key: string]: unknown` index signature
     - Added explicit `ObjectDefinition` type annotation

  ### Testing

  Tested manually by:
  1. Selecting a Bynder asset and verifying additional metadata fields are stored in the document
  2. Verifying modal closes after asset selection
  3. Verifying `assetTypes: ["image"]` field option correctly filters the Bynder CompactView to only show images
  4. Verifying existing fields (`previewUrl`, `aspectRatio`, etc.) still work correctly
  5. Running `pnpm run lint` and `pnpm run typecheck` with no errors
