### PR TITLE
feat(document-internationalization): add sanity-plugin-internationalized-array as peer dependency

### DIFF
--- a/plugins/@sanity/document-internationalization/package.json
+++ b/plugins/@sanity/document-internationalization/package.json
@@ -46,7 +46,6 @@
     "@sanity/ui": "^3.1.11",
     "@sanity/uuid": "^3.0.2",
     "rxjs": "^7.8.1",
-    "sanity-plugin-internationalized-array": "workspace:^",
     "sanity-plugin-utils": "^1.7.0"
   },
   "devDependencies": {
@@ -58,13 +57,14 @@
     "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "sanity": "catalog:"
+    "sanity": "catalog:",
+    "sanity-plugin-internationalized-array": "workspace:^"
   },
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
     "sanity": "^5",
-    "sanity-plugin-internationalized-array": ">=4.0.1 <5"
+    "sanity-plugin-internationalized-array": "^4.0.1"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,9 +401,6 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
-      sanity-plugin-internationalized-array:
-        specifier: workspace:^
-        version: link:../../sanity-plugin-internationalized-array
       sanity-plugin-utils:
         specifier: ^1.7.0
         version: 1.8.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(rxjs@7.8.2)(sanity@5.8.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.2.0)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.0.18(@types/node@25.2.0)(jiti@2.6.1)(jsdom@28.0.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -435,6 +432,9 @@ importers:
       sanity:
         specifier: 'catalog:'
         version: 5.8.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.2.0)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vitest@4.0.18(@types/node@25.2.0)(jiti@2.6.1)(jsdom@28.0.0(@noble/hashes@2.0.1))(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      sanity-plugin-internationalized-array:
+        specifier: workspace:^
+        version: link:../../sanity-plugin-internationalized-array
 
   plugins/@sanity/rich-date-input:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `sanity-plugin-internationalized-array` with version constraint `>=4.0.1 <5` to `peerDependencies` in `@sanity/document-internationalization`
- Moves the existing `workspace:^` entry to `devDependencies` for local monorepo development

## Test plan
- [ ] Verify the package builds successfully
- [ ] Verify consumers see the peer dependency warning if they don't have `sanity-plugin-internationalized-array` installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)