### PR TITLE
chore(i18n-doc): export InternationalizedArrayItem

### DIFF
--- a/.changeset/document-i18n-consume-array-item-type.md
+++ b/.changeset/document-i18n-consume-array-item-type.md
@@ -1,0 +1,5 @@
+---
+'@sanity/document-internationalization': patch
+---
+
+Update the plugin to consume the exported `InternationalizedArrayItem` type from `sanity-plugin-internationalized-array`.

--- a/.changeset/internationalized-array-export-array-item.md
+++ b/.changeset/internationalized-array-export-array-item.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-internationalized-array': patch
+---
+
+Export `InternationalizedArrayItem` from the package so it can be imported and reused by consumers.

--- a/plugins/@sanity/document-internationalization/src/types.ts
+++ b/plugins/@sanity/document-internationalization/src/types.ts
@@ -1,12 +1,12 @@
 import type {
   FieldDefinition,
-  KeyedObject,
   ObjectSchemaType,
   Reference,
   SanityClient,
   SanityDocument,
   SanityDocumentLike,
 } from 'sanity'
+import type {InternationalizedArrayItem} from 'sanity-plugin-internationalized-array'
 
 export type Language = {
   id: Intl.UnicodeBCP47LocaleIdentifier
@@ -43,7 +43,7 @@ export type PluginConfigContext = Required<PluginConfig> & {
   supportedLanguages: Language[]
 }
 
-export type TranslationReference = KeyedObject & {
+export type TranslationReference = InternationalizedArrayItem<Reference> & {
   _type: 'internationalizedArrayReferenceValue'
   value: Reference
 }

--- a/plugins/sanity-plugin-internationalized-array/src/components/AddButtons.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/AddButtons.tsx
@@ -1,7 +1,7 @@
 import {AddIcon} from '@sanity/icons'
 import {Button, Grid} from '@sanity/ui'
 
-import type {Language, Value} from '../types'
+import type {Language, InternationalizedArrayItem} from '../types'
 
 import {LANGUAGE_FIELD_NAME, MAX_COLUMNS} from '../constants'
 import {getLanguageDisplay} from '../utils/getLanguageDisplay'
@@ -10,7 +10,7 @@ import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
 type AddButtonsProps = {
   languages: Language[]
   readOnly: boolean
-  value: Value[] | undefined
+  value: InternationalizedArrayItem[] | undefined
   handleClick: (languageId: string) => void
 }
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sanity'
 import {useDocumentPane} from 'sanity/structure'
 
-import type {Value} from '../types'
+import type {InternationalizedArrayItem} from '../types'
 
 import {LANGUAGE_FIELD_NAME} from '../constants'
 import {checkAllLanguagesArePresent} from '../utils/checkAllLanguagesArePresent'
@@ -24,7 +24,7 @@ import AddButtons from './AddButtons'
 import Feedback from './Feedback'
 import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
 
-export type InternationalizedArrayProps = ArrayOfObjectsInputProps<Value>
+export type InternationalizedArrayProps = ArrayOfObjectsInputProps<InternationalizedArrayItem>
 
 /**
  * Main array input component for internationalized array fields.
@@ -49,10 +49,11 @@ export type InternationalizedArrayProps = ArrayOfObjectsInputProps<Value>
  *   no entries and the add buttons are not visible.
  */
 export default function InternationalizedArray(
-  props: InternationalizedArrayProps,
+  props: ArrayOfObjectsInputProps,
 ): React.ReactElement {
-  const {members, value, schemaType, onChange, readOnly: documentReadOnly} = props
-
+  const {members, value: _value, schemaType, onChange, readOnly: documentReadOnly} = props
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const value = _value as InternationalizedArrayItem[]
   const readOnly = typeof schemaType.readOnly === 'boolean' ? schemaType.readOnly : false
   const toast = useToast()
 
@@ -161,7 +162,7 @@ export default function InternationalizedArray(
         }
 
         return acc
-      }, [] as Value[])
+      }, [] as InternationalizedArrayItem[])
       .filter(Boolean)
 
     if (value?.length !== updatedValue.length) {

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'sanity'
 import {useDocumentPane} from 'sanity/structure'
 
-import type {Language, Value} from '../types'
+import type {Language, InternationalizedArrayItem} from '../types'
 
 import {useInternationalizedArrayContext} from '../components/InternationalizedArrayContext'
 import {LANGUAGE_FIELD_NAME} from '../constants'
@@ -27,7 +27,7 @@ const createTranslateFieldActions: (
 ) => DocumentFieldActionItem[] = (fieldActionProps, {languages, filteredLanguages}) =>
   languages.map((language) => {
     // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    const value = useFormValue(fieldActionProps.path) as Value[]
+    const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
     const disabled =
       value && Array.isArray(value)
         ? Boolean(value?.find((item) => item[LANGUAGE_FIELD_NAME] === language.id))
@@ -70,7 +70,7 @@ const AddMissingTranslationsFieldAction: (
   },
 ) => DocumentFieldActionItem = (fieldActionProps, {languages, filteredLanguages}) => {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const value = useFormValue(fieldActionProps.path) as Value[]
+  const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
   const disabled = value && value.length === filteredLanguages.length
   const hidden = checkAllLanguagesArePresent(filteredLanguages, value)
 

--- a/plugins/sanity-plugin-internationalized-array/src/index.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/index.test.ts
@@ -14,6 +14,7 @@ test('package exports', {timeout: 30_000}, async () => {
         "LANGUAGE_FIELD_NAME": "string",
         "clear": "function",
         "internationalizedArray": "function",
+        "isInternationalizedArrayItemType": "function",
       },
     }
   `)

--- a/plugins/sanity-plugin-internationalized-array/src/schema/array.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/schema/array.ts
@@ -1,6 +1,6 @@
 import {defineField, type FieldDefinition, type Rule} from 'sanity'
 
-import type {Language, LanguageCallback, Value} from '../types'
+import type {Language, LanguageCallback, InternationalizedArrayItem} from '../types'
 
 import {getFunctionCache, peek, setFunctionCache} from '../cache'
 import {createFieldName} from '../components/createFieldName'
@@ -47,7 +47,7 @@ export default (config: ArrayFactoryConfig) => {
     ],
     // @ts-expect-error - fix typings
     validation: (rule: Rule) =>
-      rule.custom<Value[]>(async (value, context) => {
+      rule.custom<InternationalizedArrayItem[]>(async (value, context) => {
         if (!value || value.length === 0) {
           return true
         }
@@ -109,7 +109,7 @@ export default (config: ArrayFactoryConfig) => {
 
         // Check for duplicate language keys (more efficient)
         const seenLanguages = new Set<string>()
-        const duplicateValues: Value[] = []
+        const duplicateValues: InternationalizedArrayItem[] = []
 
         for (const item of value) {
           if (item?.[LANGUAGE_FIELD_NAME]) {

--- a/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
@@ -1,5 +1,5 @@
 import type {InternationalizedArrayContextProps} from '../components/InternationalizedArrayContext'
-import type {Language, Value} from '../types'
+import type {Language, InternationalizedArrayItem} from '../types'
 
 import {LANGUAGE_FIELD_NAME} from '../constants'
 
@@ -22,14 +22,14 @@ export const MOCK_LANGUAGES: Language[] = [
  */
 export function createValue(
   languageId: string,
-  opts?: {value?: unknown; type?: string},
-): Value & Record<string, unknown> {
+  opts?: {value?: unknown; type?: InternationalizedArrayItem['_type']},
+): InternationalizedArrayItem {
   return {
     _type: opts?.type ?? 'internationalizedArrayStringValue',
     [LANGUAGE_FIELD_NAME]: languageId,
     ...(LANGUAGE_FIELD_NAME === '_key' ? {} : {_key: `key-${languageId}`}),
     value: opts?.value,
-  } as Value & Record<string, unknown>
+  }
 }
 
 /**
@@ -37,8 +37,8 @@ export function createValue(
  */
 export function createValues(
   languageIds: string[],
-  opts?: {type?: string},
-): (Value & Record<string, unknown>)[] {
+  opts?: {type?: InternationalizedArrayItem['_type']; value?: unknown},
+): (InternationalizedArrayItem & Record<string, unknown>)[] {
   return languageIds.map((id) => createValue(id, opts))
 }
 

--- a/plugins/sanity-plugin-internationalized-array/src/types.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/types.ts
@@ -19,9 +19,27 @@ export type ArrayConfig = {
   field?: {[key: string]: unknown; options: {[key: string]: unknown}}
 }
 
+/**
+ * @deprecated Use InternationalizedArrayItem instead
+ */
 export type Value = {
   _key: string
   value?: unknown
+}
+
+export function isInternationalizedArrayItemType(
+  type: string,
+): type is InternationalizedArrayItem['_type'] {
+  return type.startsWith('internationalizedArray') && type.endsWith('Value')
+}
+
+export type InternationalizedArrayItem<T = unknown> = {
+  _key: string
+  value?: T
+  /**
+   * string that starts with "internationalizedArray" and ends with "Value"
+   */
+  _type: `internationalizedArray${string}Value`
 }
 
 export type LanguageCallback = (

--- a/plugins/sanity-plugin-internationalized-array/src/utils/checkAllLanguagesArePresent.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/checkAllLanguagesArePresent.ts
@@ -1,4 +1,4 @@
-import type {Language, Value} from '../types'
+import type {Language, InternationalizedArrayItem} from '../types'
 
 import {LANGUAGE_FIELD_NAME} from '../constants'
 
@@ -14,7 +14,7 @@ import {LANGUAGE_FIELD_NAME} from '../constants'
  */
 export function checkAllLanguagesArePresent(
   languages: Language[],
-  value: Value[] | undefined,
+  value: InternationalizedArrayItem[] | undefined,
 ): boolean {
   const filteredLanguageIds = new Set(languages.map((l) => l.id))
   const languagesInUseIds = value ? value.map((v) => v[LANGUAGE_FIELD_NAME]) : []

--- a/plugins/sanity-plugin-internationalized-array/src/utils/createAddAllTitle.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/createAddAllTitle.ts
@@ -1,4 +1,4 @@
-import type {Language, Value} from '../types'
+import type {Language, InternationalizedArrayItem} from '../types'
 
 /**
  * Generates the label text for the "add all / add missing languages" button.
@@ -8,7 +8,10 @@ import type {Language, Value} from '../types'
  * - When some values already exist: returns `"Add missing language"` (singular)
  *   or `"Add missing languages"` (plural) depending on how many are left.
  */
-export function createAddAllTitle(value: Value[] | undefined, languages: Language[]): string {
+export function createAddAllTitle(
+  value: InternationalizedArrayItem[] | undefined,
+  languages: Language[],
+): string {
   if (value?.length) {
     return `Add missing ${languages.length - value.length === 1 ? `language` : `languages`}`
   }

--- a/plugins/sanity-plugin-internationalized-array/src/utils/createAddLanguagePatches.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/createAddLanguagePatches.ts
@@ -1,8 +1,11 @@
 import {type FormInsertPatch, insert, type Path} from 'sanity'
 
-import type {Language, Value} from '../types'
-
 import {LANGUAGE_FIELD_NAME} from '../constants'
+import {
+  type Language,
+  type InternationalizedArrayItem,
+  isInternationalizedArrayItemType,
+} from '../types'
 
 type AddConfig = {
   // New keys to add to the field
@@ -14,7 +17,7 @@ type AddConfig = {
   // Languages that are currently visible
   filteredLanguages: Language[]
   // Current value of the internationalizedArray field
-  value?: Value[]
+  value?: InternationalizedArrayItem[]
   // Path to this item
   path?: Path
 }
@@ -38,7 +41,11 @@ type AddConfig = {
 export function createAddLanguagePatches(config: AddConfig): FormInsertPatch[] {
   const {addLanguageKeys, schemaTypeName, languages, filteredLanguages, value, path = []} = config
 
-  const itemBase = {_type: `${schemaTypeName}Value`}
+  const type = `${schemaTypeName}Value`
+  if (!isInternationalizedArrayItemType(type)) {
+    throw new Error(`Invalid internationalized array type: ${type}`)
+  }
+  const itemBase = {_type: type}
 
   // Create new items
   const getNewItems = () => {


### PR DESCRIPTION
### Description

Reducing footprint of https://github.com/sanity-io/plugins/pull/567
Export InternationalizedArrayItem from sanity-plugin-internationalized-array and update @sanity/document-internationalization to consume the shared type.

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
