### PR TITLE
feat: add ability to hide language filter in document bar

### DIFF
--- a/.changeset/document-internationalization-hide-language-filter.md
+++ b/.changeset/document-internationalization-hide-language-filter.md
@@ -1,0 +1,5 @@
+---
+"@sanity/document-internationalization": minor
+---
+
+Add `hideLanguageFilter` config option to hide the language filter in the document editor toolbar. Supports `boolean`, `string[]` (schema type names), or a callback function for dynamic control.

--- a/.changeset/document-internationalization-hide-translations-button.md
+++ b/.changeset/document-internationalization-hide-translations-button.md
@@ -1,5 +1,0 @@
----
-"@sanity/document-internationalization": minor
----
-
-Add `hideTranslationsButton` config option to hide the Translations button in the document editor toolbar

--- a/plugins/@sanity/document-internationalization/README.md
+++ b/plugins/@sanity/document-internationalization/README.md
@@ -163,9 +163,12 @@ export const defineConfig({
       },
 
       // Optional
-      // Hides the "Translations" button in the document editor toolbar.
-      // The language badge will still be shown.
-      hideTranslationsButton: true, // defaults to false
+      // Hides the language filter (Translations button) in the document editor toolbar.
+      // The language badge will still be shown. Accepts:
+      // - A boolean to hide for all types: `hideLanguageFilter: true`
+      // - An array of schema type names: `hideLanguageFilter: ['lesson']`
+      // - A function for dynamic control: `hideLanguageFilter: (ctx) => ctx.schemaType === 'lesson'`
+      hideLanguageFilter: true, // defaults to false
     })
   ]
 })

--- a/plugins/@sanity/document-internationalization/src/constants.ts
+++ b/plugins/@sanity/document-internationalization/src/constants.ts
@@ -13,5 +13,5 @@ export const DEFAULT_CONFIG: PluginConfigContext = {
   apiVersion: API_VERSION,
   allowCreateMetaDoc: false,
   callback: null,
-  hideTranslationsButton: false,
+  hideLanguageFilter: false,
 }

--- a/plugins/@sanity/document-internationalization/src/plugin.tsx
+++ b/plugins/@sanity/document-internationalization/src/plugin.tsx
@@ -22,7 +22,7 @@ export const documentInternationalization = definePlugin<PluginConfig>((config) 
     languageField,
     bulkPublish,
     metadataFields,
-    hideTranslationsButton,
+    hideLanguageFilter,
   } = pluginConfig
 
   if (schemaTypes.length === 0) {
@@ -90,9 +90,15 @@ export const documentInternationalization = definePlugin<PluginConfig>((config) 
     // - The `DeleteMetadataAction` action to the metadata document type
     document: {
       unstable_languageFilter: (prev, ctx) => {
-        if (hideTranslationsButton) return prev
-
         const {schemaType, documentId} = ctx
+
+        if (typeof hideLanguageFilter === 'function') {
+          if (hideLanguageFilter(ctx)) return prev
+        } else if (Array.isArray(hideLanguageFilter)) {
+          if (hideLanguageFilter.includes(schemaType)) return prev
+        } else if (hideLanguageFilter) {
+          return prev
+        }
 
         return schemaTypes.includes(schemaType) && documentId
           ? [...prev, (props) => DocumentInternationalizationMenu({...props, documentId})]

--- a/plugins/@sanity/document-internationalization/src/types.ts
+++ b/plugins/@sanity/document-internationalization/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  DocumentLanguageFilterContext,
   FieldDefinition,
   ObjectSchemaType,
   Reference,
@@ -34,7 +35,7 @@ export type PluginConfig = {
   apiVersion?: string
   allowCreateMetaDoc?: boolean
   callback?: ((args: PluginCallbackArgs) => Promise<void>) | null
-  hideTranslationsButton?: boolean
+  hideLanguageFilter?: boolean | string[] | ((ctx: DocumentLanguageFilterContext) => boolean)
 }
 
 // Context version of config


### PR DESCRIPTION
### Description

Adds a `hideLanguageFilter` config option to `@sanity/document-internationalization` that hides the language filter (Translations button) in the document editor toolbar. The language badge is unaffected.

Supports three forms for flexible control:
- `boolean` — hide for all translated document types
- `string[]` — hide for specific schema types by name
- `(ctx: DocumentLanguageFilterContext) => boolean` — dynamic callback for full control

Useful when you want the plugin's metadata/badge functionality but don't want editors managing translations directly from the document form.

### What to review

- New `hideLanguageFilter` option in `PluginConfig` type, defaults to `false`
- Resolution logic in `plugin.tsx` that handles `boolean`, `string[]`, and callback forms when deciding whether to skip `unstable_languageFilter` registration
- README updated with the new option and all three usage examples in the Advanced configuration section

### Testing

Manually verified the language filter is hidden when `hideLanguageFilter: true` is set and still present when omitted or `false`. No automated test added — the feature gates a UI registration that is not covered by existing unit tests.