### PR TITLE
feat(@sanity/presets): multiple custom named presets

### DIFF
--- a/.changeset/presets-link-field.md
+++ b/.changeset/presets-link-field.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": minor
+---
+
+Add link field preset and preset composer plugin

--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -1,6 +1,8 @@
 import {linkField, LINK_FIELD_TYPE, presetsComposer} from '@sanity/presets'
 import {definePlugin, defineType} from 'sanity'
 
+const CUSTOM_LINK_TYPE = 'customLink'
+
 const corePresetsTest = defineType({
   name: 'corePresetsTest',
   type: 'document',
@@ -16,10 +18,20 @@ const corePresetsTest = defineType({
       title: 'Link',
       type: LINK_FIELD_TYPE,
     },
+    {
+      name: 'navLink',
+      title: 'Nav Link',
+      type: CUSTOM_LINK_TYPE,
+    },
   ],
 })
 
 export const presetsWorkspace = definePlugin(() => ({
   schema: {types: [corePresetsTest]},
-  plugins: [presetsComposer([linkField({internalTypes: ['corePresetsTest']})])],
+  plugins: [
+    presetsComposer([
+      linkField({internalTypes: ['corePresetsTest']}),
+      linkField({name: CUSTOM_LINK_TYPE, internalTypes: ['corePresetsTest']}),
+    ]),
+  ],
 }))

--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -1,4 +1,4 @@
-import {presetsComposer} from '@sanity/presets'
+import {linkField, LINK_FIELD_TYPE, presetsComposer} from '@sanity/presets'
 import {definePlugin, defineType} from 'sanity'
 
 const corePresetsTest = defineType({
@@ -11,10 +11,15 @@ const corePresetsTest = defineType({
       title: 'Title',
       type: 'string',
     },
+    {
+      name: 'link',
+      title: 'Link',
+      type: LINK_FIELD_TYPE,
+    },
   ],
 })
 
 export const presetsWorkspace = definePlugin(() => ({
   schema: {types: [corePresetsTest]},
-  plugins: [presetsComposer()],
+  plugins: [presetsComposer([linkField({internalTypes: ['corePresetsTest']})])],
 }))

--- a/plugins/@sanity/presets/src/__snapshots__/index.test.ts.snap
+++ b/plugins/@sanity/presets/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`package exports 1`] = `
+{
+  ".": {
+    "LINK_FIELD_TYPE": "string",
+    "linkField": "function",
+    "presetsComposer": "function",
+  },
+}
+`;

--- a/plugins/@sanity/presets/src/composer.test.ts
+++ b/plugins/@sanity/presets/src/composer.test.ts
@@ -46,7 +46,7 @@ describe('collectTypes', () => {
     expect(types).toEqual([])
   })
 
-  test('deduplicates when the same preset appears multiple times', () => {
+  test('deduplicates repeated preset instances', () => {
     const preset = createPreset(['link.type'])
 
     const types = collectTypes([preset, preset])
@@ -80,7 +80,7 @@ describe('collectTypes', () => {
     )
   })
 
-  test('keeps unique names and drops duplicates across three presets', () => {
+  test('deduplicates across three presets with overlapping types', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const types = collectTypes([

--- a/plugins/@sanity/presets/src/composer.test.ts
+++ b/plugins/@sanity/presets/src/composer.test.ts
@@ -1,5 +1,5 @@
 import {defineType} from 'sanity'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 import {collectTypes, presetsComposer} from './composer'
 import type {PresetResult} from './types'
@@ -11,36 +11,35 @@ function createPreset(typeNames: string[]): PresetResult {
 }
 
 describe('presetsComposer', () => {
-  test('returns plugin with no types for empty array', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  test('returns plugin with correct name', () => {
     const result = presetsComposer([])
 
     expect(result.name).toBe('@sanity/presets')
-    expect(result.schema?.types).toEqual([])
   })
 
-  test('aggregates types from a single preset', () => {
+  test('includes schema types from presets', () => {
     const result = presetsComposer([createPreset(['test.type'])])
 
     expect(result.schema?.types).toEqual([expect.objectContaining({name: 'test.type'})])
   })
 
-  test('aggregates types from multiple presets', () => {
-    const result = presetsComposer([
-      createPreset(['type.a']),
-      createPreset(['type.b']),
-      createPreset(['type.c', 'type.d']),
-    ])
+  test('deduplicates types across presets', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const preset = createPreset(['shared.type'])
 
-    expect(result.schema?.types).toEqual([
-      expect.objectContaining({name: 'type.a'}),
-      expect.objectContaining({name: 'type.b'}),
-      expect.objectContaining({name: 'type.c'}),
-      expect.objectContaining({name: 'type.d'}),
-    ])
+    presetsComposer([preset, preset])
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[@sanity/presets] Dropped duplicate type "shared.type". Keeping first definition.',
+    )
   })
 })
 
 describe('collectTypes', () => {
+  afterEach(() => vi.restoreAllMocks())
+
   test('returns empty array for empty input', () => {
     const types = collectTypes([])
 
@@ -56,7 +55,7 @@ describe('collectTypes', () => {
     expect(typeNames).toEqual(['link.type'])
   })
 
-  test('deduplicates separately created presets with matching type names', () => {
+  test('deduplicates matching type names across presets', () => {
     const first = createPreset(['link.type'])
     const second = createPreset(['link.type'])
 
@@ -66,7 +65,7 @@ describe('collectTypes', () => {
     expect(typeNames).toEqual(['link.type'])
   })
 
-  test('deduplicates by type name across different presets and warns', () => {
+  test('deduplicates by type name across presets and warns', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const presetA = createPreset(['shared.type', 'alpha.type'])
@@ -77,13 +76,11 @@ describe('collectTypes', () => {
 
     expect(typeNames).toEqual(['shared.type', 'alpha.type', 'beta.type'])
     expect(warnSpy).toHaveBeenCalledWith(
-      '[@sanity/presets] Duplicate type "shared.type" was dropped. The first definition will be used.',
+      '[@sanity/presets] Dropped duplicate type "shared.type". Keeping first definition.',
     )
-
-    warnSpy.mockRestore()
   })
 
-  test('keeps unique names and drops repeated ones across three presets', () => {
+  test('keeps unique names and drops duplicates across three presets', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const types = collectTypes([
@@ -95,7 +92,5 @@ describe('collectTypes', () => {
 
     expect(typeNames).toEqual(['core.presets.link', 'core.presets.seo'])
     expect(warnSpy).toHaveBeenCalledTimes(3)
-
-    warnSpy.mockRestore()
   })
 })

--- a/plugins/@sanity/presets/src/composer.test.ts
+++ b/plugins/@sanity/presets/src/composer.test.ts
@@ -1,0 +1,101 @@
+import {defineType} from 'sanity'
+import {describe, expect, test, vi} from 'vitest'
+
+import {collectTypes, presetsComposer} from './composer'
+import type {PresetResult} from './types'
+
+function createPreset(typeNames: string[]): PresetResult {
+  return {
+    types: typeNames.map((name) => defineType({name, type: 'object', fields: []})),
+  }
+}
+
+describe('presetsComposer', () => {
+  test('returns plugin with no types for empty array', () => {
+    const result = presetsComposer([])
+
+    expect(result.name).toBe('@sanity/presets')
+    expect(result.schema?.types).toEqual([])
+  })
+
+  test('aggregates types from a single preset', () => {
+    const result = presetsComposer([createPreset(['test.type'])])
+
+    expect(result.schema?.types).toEqual([expect.objectContaining({name: 'test.type'})])
+  })
+
+  test('aggregates types from multiple presets', () => {
+    const result = presetsComposer([
+      createPreset(['type.a']),
+      createPreset(['type.b']),
+      createPreset(['type.c', 'type.d']),
+    ])
+
+    expect(result.schema?.types).toEqual([
+      expect.objectContaining({name: 'type.a'}),
+      expect.objectContaining({name: 'type.b'}),
+      expect.objectContaining({name: 'type.c'}),
+      expect.objectContaining({name: 'type.d'}),
+    ])
+  })
+})
+
+describe('collectTypes', () => {
+  test('returns empty array for empty input', () => {
+    const types = collectTypes([])
+
+    expect(types).toEqual([])
+  })
+
+  test('deduplicates when the same preset appears multiple times', () => {
+    const preset = createPreset(['link.type'])
+
+    const types = collectTypes([preset, preset])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual(['link.type'])
+  })
+
+  test('deduplicates separately created presets with matching type names', () => {
+    const first = createPreset(['link.type'])
+    const second = createPreset(['link.type'])
+
+    const types = collectTypes([first, second])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual(['link.type'])
+  })
+
+  test('deduplicates by type name across different presets and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const presetA = createPreset(['shared.type', 'alpha.type'])
+    const presetB = createPreset(['shared.type', 'beta.type'])
+
+    const types = collectTypes([presetA, presetB])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual(['shared.type', 'alpha.type', 'beta.type'])
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[@sanity/presets] Duplicate type "shared.type" was dropped. The first definition will be used.',
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  test('keeps unique names and drops repeated ones across three presets', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const types = collectTypes([
+      createPreset(['core.presets.link', 'core.presets.seo']),
+      createPreset(['core.presets.link']),
+      createPreset(['core.presets.link', 'core.presets.seo']),
+    ])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual(['core.presets.link', 'core.presets.seo'])
+    expect(warnSpy).toHaveBeenCalledTimes(3)
+
+    warnSpy.mockRestore()
+  })
+})

--- a/plugins/@sanity/presets/src/composer.ts
+++ b/plugins/@sanity/presets/src/composer.ts
@@ -1,4 +1,4 @@
-import {definePlugin, type PluginOptions, type SchemaTypeDefinition} from 'sanity'
+import {definePlugin, type SchemaTypeDefinition} from 'sanity'
 
 import type {PresetResult} from './types'
 
@@ -9,7 +9,7 @@ export function collectTypes(presets: PresetResult[]): SchemaTypeDefinition[] {
     preset.types.filter((typeDef) => {
       if (seen.has(typeDef.name)) {
         console.warn(
-          `[@sanity/presets] Duplicate type "${typeDef.name}" was dropped. The first definition will be used.`,
+          `[@sanity/presets] Dropped duplicate type "${typeDef.name}". Keeping first definition.`,
         )
         return false
       }
@@ -19,11 +19,7 @@ export function collectTypes(presets: PresetResult[]): SchemaTypeDefinition[] {
   )
 }
 
-export function presetsComposer(presets: PresetResult[]): PluginOptions {
-  const types = collectTypes(presets)
-
-  return definePlugin({
-    name: '@sanity/presets',
-    schema: {types},
-  })()
-}
+export const presetsComposer = definePlugin<PresetResult[]>((presetFields) => ({
+  name: '@sanity/presets',
+  schema: {types: collectTypes(presetFields)},
+}))

--- a/plugins/@sanity/presets/src/composer.ts
+++ b/plugins/@sanity/presets/src/composer.ts
@@ -1,0 +1,29 @@
+import {definePlugin, type PluginOptions, type SchemaTypeDefinition} from 'sanity'
+
+import type {PresetResult} from './types'
+
+export function collectTypes(presets: PresetResult[]): SchemaTypeDefinition[] {
+  const seen = new Set<string>()
+
+  return presets.flatMap((preset) =>
+    preset.types.filter((typeDef) => {
+      if (seen.has(typeDef.name)) {
+        console.warn(
+          `[@sanity/presets] Duplicate type "${typeDef.name}" was dropped. The first definition will be used.`,
+        )
+        return false
+      }
+      seen.add(typeDef.name)
+      return true
+    }),
+  )
+}
+
+export function presetsComposer(presets: PresetResult[]): PluginOptions {
+  const types = collectTypes(presets)
+
+  return definePlugin({
+    name: '@sanity/presets',
+    schema: {types},
+  })()
+}

--- a/plugins/@sanity/presets/src/index.test.ts
+++ b/plugins/@sanity/presets/src/index.test.ts
@@ -9,11 +9,5 @@ test('package exports', {timeout: 30_000}, async () => {
     cwd: fileURLToPath(import.meta.url),
   })
 
-  expect(manifest.exports).toMatchInlineSnapshot(`
-    {
-      ".": {
-        "presetsComposer": "function",
-      },
-    }
-  `)
+  expect(manifest.exports).toMatchSnapshot()
 })

--- a/plugins/@sanity/presets/src/index.ts
+++ b/plugins/@sanity/presets/src/index.ts
@@ -1,4 +1,4 @@
 export {presetsComposer} from './composer'
 export {linkField, LINK_FIELD_TYPE} from './presets/link-field'
 export type {LinkFieldConfig} from './presets/link-field'
-export type {PresetResult} from './types'
+export type {BasePresetConfig, PresetResult} from './types'

--- a/plugins/@sanity/presets/src/index.ts
+++ b/plugins/@sanity/presets/src/index.ts
@@ -1,7 +1,4 @@
-import {definePlugin} from 'sanity'
-
-export function presetsComposer() {
-  return definePlugin({
-    name: '@sanity/presets',
-  })()
-}
+export {presetsComposer} from './composer'
+export {linkField, LINK_FIELD_TYPE} from './presets/link-field'
+export type {LinkFieldConfig} from './presets/link-field'
+export type {PresetResult} from './types'

--- a/plugins/@sanity/presets/src/presets/link-field/composer-integration.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/composer-integration.test.ts
@@ -1,0 +1,75 @@
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {collectTypes} from '../../composer'
+import {LINK_FIELD_TYPE} from './constants'
+import {linkField} from './index'
+
+describe('collectTypes with linkField presets', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  test('multiple linkField presets with different names coexist', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const types = collectTypes([
+      linkField({internalTypes: ['page']}),
+      linkField({name: 'navLink', internalTypes: ['post']}),
+    ])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual([LINK_FIELD_TYPE, 'navLink'])
+    expect(warnSpy).toHaveBeenCalledTimes(0)
+  })
+
+  test('duplicate default linkField presets warn and keep first', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const types = collectTypes([
+      linkField({internalTypes: ['page']}),
+      linkField({internalTypes: ['post']}),
+    ])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual([LINK_FIELD_TYPE])
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[@sanity/presets] Dropped duplicate type "${LINK_FIELD_TYPE}". Keeping first definition.`,
+    )
+  })
+
+  test('duplicate custom-named linkField presets warn and keep first', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const types = collectTypes([
+      linkField({name: 'navLink', internalTypes: ['page']}),
+      linkField({name: 'navLink', internalTypes: ['post']}),
+    ])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual(['navLink'])
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[@sanity/presets] Dropped duplicate type "navLink". Keeping first definition.',
+    )
+  })
+
+  test('three linkField variants with mixed duplicates', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const types = collectTypes([
+      linkField({internalTypes: ['page']}),
+      linkField({name: 'navLink', internalTypes: ['post']}),
+      linkField({internalTypes: ['article']}),
+      linkField({name: 'navLink', internalTypes: ['event']}),
+    ])
+    const typeNames = types.map((type) => type.name)
+
+    expect(typeNames).toEqual([LINK_FIELD_TYPE, 'navLink'])
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[@sanity/presets] Dropped duplicate type "${LINK_FIELD_TYPE}". Keeping first definition.`,
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[@sanity/presets] Dropped duplicate type "navLink". Keeping first definition.',
+    )
+  })
+})

--- a/plugins/@sanity/presets/src/presets/link-field/constants.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/constants.ts
@@ -1,0 +1,1 @@
+export const LINK_FIELD_TYPE = 'core.presets.link'

--- a/plugins/@sanity/presets/src/presets/link-field/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/index.ts
@@ -1,9 +1,10 @@
-import type {PresetResult} from '../../types'
+import type {BasePresetConfig, PresetResult} from '../../types'
+import {LINK_FIELD_TYPE} from './constants'
 import {createLinkFieldType} from './schema'
 
-export {LINK_FIELD_TYPE} from './constants'
+export {LINK_FIELD_TYPE}
 
-export interface LinkFieldConfig {
+export interface LinkFieldConfig extends BasePresetConfig {
   internalTypes: string[]
 }
 
@@ -12,7 +13,9 @@ export function linkField(config: LinkFieldConfig): PresetResult {
     throw new Error('[@sanity/presets] linkField requires at least one internalTypes entry.')
   }
 
+  const typeName = config.name ?? LINK_FIELD_TYPE
+
   return {
-    types: [createLinkFieldType(config.internalTypes)],
+    types: [createLinkFieldType(typeName, config.internalTypes)],
   }
 }

--- a/plugins/@sanity/presets/src/presets/link-field/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/index.ts
@@ -4,13 +4,15 @@ import {createLinkFieldType} from './schema'
 export {LINK_FIELD_TYPE} from './constants'
 
 export interface LinkFieldConfig {
-  internalTypes?: string[]
+  internalTypes: string[]
 }
 
-export function linkField(config: LinkFieldConfig = {}): PresetResult {
-  const internalTypes = config.internalTypes ?? []
+export function linkField(config: LinkFieldConfig): PresetResult {
+  if (config.internalTypes.length === 0) {
+    throw new Error('[@sanity/presets] linkField requires at least one internalTypes entry.')
+  }
 
   return {
-    types: [createLinkFieldType(internalTypes)],
+    types: [createLinkFieldType(config.internalTypes)],
   }
 }

--- a/plugins/@sanity/presets/src/presets/link-field/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/index.ts
@@ -1,0 +1,16 @@
+import type {PresetResult} from '../../types'
+import {createLinkFieldType} from './schema'
+
+export {LINK_FIELD_TYPE} from './constants'
+
+export interface LinkFieldConfig {
+  internalTypes?: string[]
+}
+
+export function linkField(config: LinkFieldConfig = {}): PresetResult {
+  const internalTypes = config.internalTypes ?? []
+
+  return {
+    types: [createLinkFieldType(internalTypes)],
+  }
+}

--- a/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
@@ -70,7 +70,7 @@ describe('linkField', () => {
     expect(result.types[0]?.name).toBe('navLink')
   })
 
-  test('custom-named preset retains the same field structure', () => {
+  test('custom-named preset has the same fields', () => {
     const fields = getFields(linkField({name: 'footerLink', internalTypes: ['page', 'post']}))
 
     expect(fields).toHaveLength(4)
@@ -86,7 +86,7 @@ describe('linkField', () => {
     expect(referenceField).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
   })
 
-  test('custom-named preset hidden callbacks behave identically', () => {
+  test('custom-named preset has identical hidden logic', () => {
     const fields = getFields(linkField({name: 'footerLink', internalTypes: ['page']}))
 
     expect(evaluateHidden(getField(fields, 'reference'), {linkType: 'external'})).toBe(true)
@@ -95,7 +95,7 @@ describe('linkField', () => {
     expect(evaluateHidden(getField(fields, 'url'), {linkType: 'external'})).toBe(false)
   })
 
-  test('custom-named preset preview.prepare works correctly', () => {
+  test('custom-named preset resolves preview titles', () => {
     const preset = linkField({name: 'footerLink', internalTypes: ['page']})
 
     const internalResult = callPrepare(preset, {
@@ -126,7 +126,7 @@ describe('linkField', () => {
     expect(referenceField).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
   })
 
-  test('hidden callbacks show correct fields for internal type', () => {
+  test('hides external-only fields for internal type', () => {
     const fields = getFields(linkField(defaultConfig))
     const internalParent = {linkType: 'internal'}
 
@@ -135,7 +135,7 @@ describe('linkField', () => {
     expect(evaluateHidden(getField(fields, 'openInNewTab'), internalParent)).toBe(true)
   })
 
-  test('hidden callbacks show correct fields for external type', () => {
+  test('hides internal-only fields for external type', () => {
     const fields = getFields(linkField(defaultConfig))
     const externalParent = {linkType: 'external'}
 
@@ -144,7 +144,7 @@ describe('linkField', () => {
     expect(evaluateHidden(getField(fields, 'openInNewTab'), externalParent)).toBe(false)
   })
 
-  test('hidden callbacks show conditional fields when linkType is undefined', () => {
+  test('shows all fields when linkType is undefined', () => {
     const fields = getFields(linkField(defaultConfig))
     const emptyParent = {linkType: undefined}
 
@@ -155,7 +155,7 @@ describe('linkField', () => {
 })
 
 describe('linkField preview.select', () => {
-  test('selects correct paths for preview', () => {
+  test('selects preview paths', () => {
     const typeDef = linkField(defaultConfig).types[0]
     const select = typeDef && 'preview' in typeDef ? typeDef.preview?.select : undefined
 
@@ -210,7 +210,7 @@ describe('linkField preview.prepare', () => {
     expect(result).toEqual({title: 'No URL', subtitle: 'External link'})
   })
 
-  test('undefined linkType defaults to internal link fallback', () => {
+  test('falls back to internal link when linkType is undefined', () => {
     const result = callPrepare(preset, {
       linkType: undefined,
       url: undefined,

--- a/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
@@ -63,6 +63,56 @@ describe('linkField', () => {
     expect(fieldNames).toEqual(['linkType', 'reference', 'url', 'openInNewTab'])
   })
 
+  test('uses custom name when provided', () => {
+    const result = linkField({name: 'navLink', internalTypes: ['page']})
+
+    expect(result.types).toHaveLength(1)
+    expect(result.types[0]?.name).toBe('navLink')
+  })
+
+  test('custom-named preset retains the same field structure', () => {
+    const fields = getFields(linkField({name: 'footerLink', internalTypes: ['page', 'post']}))
+
+    expect(fields).toHaveLength(4)
+
+    const fieldNames = fields.map((field) => field.name)
+    expect(fieldNames).toEqual(['linkType', 'reference', 'url', 'openInNewTab'])
+  })
+
+  test('custom-named preset maps internalTypes to reference targets', () => {
+    const fields = getFields(linkField({name: 'footerLink', internalTypes: ['page', 'post']}))
+    const referenceField = getField(fields, 'reference')
+
+    expect(referenceField).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
+  })
+
+  test('custom-named preset hidden callbacks behave identically', () => {
+    const fields = getFields(linkField({name: 'footerLink', internalTypes: ['page']}))
+
+    expect(evaluateHidden(getField(fields, 'reference'), {linkType: 'external'})).toBe(true)
+    expect(evaluateHidden(getField(fields, 'url'), {linkType: 'internal'})).toBe(true)
+    expect(evaluateHidden(getField(fields, 'reference'), {linkType: 'internal'})).toBe(false)
+    expect(evaluateHidden(getField(fields, 'url'), {linkType: 'external'})).toBe(false)
+  })
+
+  test('custom-named preset preview.prepare works correctly', () => {
+    const preset = linkField({name: 'footerLink', internalTypes: ['page']})
+
+    const internalResult = callPrepare(preset, {
+      linkType: 'internal',
+      referenceTitle: 'Home',
+      url: undefined,
+    })
+    expect(internalResult).toEqual({title: 'Home', subtitle: 'Internal link'})
+
+    const externalResult = callPrepare(preset, {
+      linkType: 'external',
+      url: 'https://example.com',
+      referenceTitle: undefined,
+    })
+    expect(externalResult).toEqual({title: 'https://example.com', subtitle: 'External link'})
+  })
+
   test('throws when internalTypes is empty', () => {
     expect(() => linkField({internalTypes: []})).toThrow(
       '[@sanity/presets] linkField requires at least one internalTypes entry.',

--- a/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
@@ -1,8 +1,10 @@
-import type {FieldDefinition} from 'sanity'
+import type {FieldDefinition, PreviewValue} from 'sanity'
 import {describe, expect, test} from 'vitest'
 
 import {LINK_FIELD_TYPE} from './constants'
 import {linkField} from './index'
+
+const defaultConfig = {internalTypes: ['page']}
 
 function getFields(result: ReturnType<typeof linkField>): FieldDefinition[] {
   const typeDef = result.types[0]
@@ -33,31 +35,41 @@ function evaluateHidden(field: FieldDefinition, parent: Record<string, unknown>)
   return field.hidden
 }
 
+function callPrepare(
+  result: ReturnType<typeof linkField>,
+  selection: Record<string, unknown>,
+): PreviewValue {
+  const typeDef = result.types[0]
+  const prepare = typeDef && 'preview' in typeDef ? typeDef.preview?.prepare : undefined
+  if (!prepare) throw new Error('Expected preview.prepare on type definition')
+
+  return prepare(selection)
+}
+
 describe('linkField', () => {
-  test('returns a PresetResult with one type named core.presets.link', () => {
-    const result = linkField()
+  test('returns one type named core.presets.link', () => {
+    const result = linkField(defaultConfig)
 
     expect(result.types).toHaveLength(1)
     expect(result.types[0]?.name).toBe(LINK_FIELD_TYPE)
   })
 
   test('type is an object with 4 fields', () => {
-    const fields = getFields(linkField())
+    const fields = getFields(linkField(defaultConfig))
 
     expect(fields).toHaveLength(4)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['type', 'reference', 'url', 'openInNewTab'])
+    expect(fieldNames).toEqual(['linkType', 'reference', 'url', 'openInNewTab'])
   })
 
-  test('defaults reference targets to document when no internalTypes given', () => {
-    const fields = getFields(linkField())
-    const referenceField = getField(fields, 'reference')
-
-    expect(referenceField).toHaveProperty('to', [{type: 'document'}])
+  test('throws when internalTypes is empty', () => {
+    expect(() => linkField({internalTypes: []})).toThrow(
+      '[@sanity/presets] linkField requires at least one internalTypes entry.',
+    )
   })
 
-  test('maps custom internalTypes to reference targets', () => {
+  test('maps internalTypes to reference targets', () => {
     const fields = getFields(linkField({internalTypes: ['page', 'post']}))
     const referenceField = getField(fields, 'reference')
 
@@ -65,8 +77,8 @@ describe('linkField', () => {
   })
 
   test('hidden callbacks show correct fields for internal type', () => {
-    const fields = getFields(linkField())
-    const internalParent = {type: 'internal'}
+    const fields = getFields(linkField(defaultConfig))
+    const internalParent = {linkType: 'internal'}
 
     expect(evaluateHidden(getField(fields, 'reference'), internalParent)).toBe(false)
     expect(evaluateHidden(getField(fields, 'url'), internalParent)).toBe(true)
@@ -74,11 +86,87 @@ describe('linkField', () => {
   })
 
   test('hidden callbacks show correct fields for external type', () => {
-    const fields = getFields(linkField())
-    const externalParent = {type: 'external'}
+    const fields = getFields(linkField(defaultConfig))
+    const externalParent = {linkType: 'external'}
 
     expect(evaluateHidden(getField(fields, 'reference'), externalParent)).toBe(true)
     expect(evaluateHidden(getField(fields, 'url'), externalParent)).toBe(false)
     expect(evaluateHidden(getField(fields, 'openInNewTab'), externalParent)).toBe(false)
+  })
+
+  test('hidden callbacks show conditional fields when linkType is undefined', () => {
+    const fields = getFields(linkField(defaultConfig))
+    const emptyParent = {linkType: undefined}
+
+    expect(evaluateHidden(getField(fields, 'reference'), emptyParent)).toBe(false)
+    expect(evaluateHidden(getField(fields, 'url'), emptyParent)).toBe(false)
+    expect(evaluateHidden(getField(fields, 'openInNewTab'), emptyParent)).toBe(false)
+  })
+})
+
+describe('linkField preview.select', () => {
+  test('selects correct paths for preview', () => {
+    const typeDef = linkField(defaultConfig).types[0]
+    const select = typeDef && 'preview' in typeDef ? typeDef.preview?.select : undefined
+
+    expect(select).toEqual({
+      linkType: 'linkType',
+      url: 'url',
+      referenceTitle: 'reference.title',
+    })
+  })
+})
+
+describe('linkField preview.prepare', () => {
+  const preset = linkField(defaultConfig)
+
+  test('internal link with a reference title', () => {
+    const result = callPrepare(preset, {
+      linkType: 'internal',
+      referenceTitle: 'About Us',
+      url: undefined,
+    })
+
+    expect(result).toEqual({title: 'About Us', subtitle: 'Internal link'})
+  })
+
+  test('internal link without reference title shows fallback', () => {
+    const result = callPrepare(preset, {
+      linkType: 'internal',
+      referenceTitle: undefined,
+      url: undefined,
+    })
+
+    expect(result).toEqual({title: 'No reference', subtitle: 'Internal link'})
+  })
+
+  test('external link with a URL', () => {
+    const result = callPrepare(preset, {
+      linkType: 'external',
+      url: 'https://example.com',
+      referenceTitle: undefined,
+    })
+
+    expect(result).toEqual({title: 'https://example.com', subtitle: 'External link'})
+  })
+
+  test('external link without URL shows fallback', () => {
+    const result = callPrepare(preset, {
+      linkType: 'external',
+      url: undefined,
+      referenceTitle: undefined,
+    })
+
+    expect(result).toEqual({title: 'No URL', subtitle: 'External link'})
+  })
+
+  test('undefined linkType defaults to internal link fallback', () => {
+    const result = callPrepare(preset, {
+      linkType: undefined,
+      url: undefined,
+      referenceTitle: undefined,
+    })
+
+    expect(result).toEqual({title: 'No reference', subtitle: 'Internal link'})
   })
 })

--- a/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/link-field.test.ts
@@ -1,0 +1,84 @@
+import type {FieldDefinition} from 'sanity'
+import {describe, expect, test} from 'vitest'
+
+import {LINK_FIELD_TYPE} from './constants'
+import {linkField} from './index'
+
+function getFields(result: ReturnType<typeof linkField>): FieldDefinition[] {
+  const typeDef = result.types[0]
+  if (!typeDef || !('fields' in typeDef) || !typeDef.fields) {
+    throw new Error('Expected an object type definition with fields')
+  }
+  return typeDef.fields
+}
+
+function getField(fields: FieldDefinition[], name: string): FieldDefinition {
+  const field = fields.find((entry) => entry.name === name)
+  if (!field) {
+    throw new Error(`Field "${name}" not found`)
+  }
+  return field
+}
+
+function evaluateHidden(field: FieldDefinition, parent: Record<string, unknown>): unknown {
+  if (typeof field.hidden === 'function') {
+    return field.hidden({
+      parent,
+      document: {_id: 'test', _type: 'test', _createdAt: '', _updatedAt: '', _rev: ''},
+      currentUser: null,
+      value: undefined,
+      path: [],
+    })
+  }
+  return field.hidden
+}
+
+describe('linkField', () => {
+  test('returns a PresetResult with one type named core.presets.link', () => {
+    const result = linkField()
+
+    expect(result.types).toHaveLength(1)
+    expect(result.types[0]?.name).toBe(LINK_FIELD_TYPE)
+  })
+
+  test('type is an object with 4 fields', () => {
+    const fields = getFields(linkField())
+
+    expect(fields).toHaveLength(4)
+
+    const fieldNames = fields.map((field) => field.name)
+    expect(fieldNames).toEqual(['type', 'reference', 'url', 'openInNewTab'])
+  })
+
+  test('defaults reference targets to document when no internalTypes given', () => {
+    const fields = getFields(linkField())
+    const referenceField = getField(fields, 'reference')
+
+    expect(referenceField).toHaveProperty('to', [{type: 'document'}])
+  })
+
+  test('maps custom internalTypes to reference targets', () => {
+    const fields = getFields(linkField({internalTypes: ['page', 'post']}))
+    const referenceField = getField(fields, 'reference')
+
+    expect(referenceField).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
+  })
+
+  test('hidden callbacks show correct fields for internal type', () => {
+    const fields = getFields(linkField())
+    const internalParent = {type: 'internal'}
+
+    expect(evaluateHidden(getField(fields, 'reference'), internalParent)).toBe(false)
+    expect(evaluateHidden(getField(fields, 'url'), internalParent)).toBe(true)
+    expect(evaluateHidden(getField(fields, 'openInNewTab'), internalParent)).toBe(true)
+  })
+
+  test('hidden callbacks show correct fields for external type', () => {
+    const fields = getFields(linkField())
+    const externalParent = {type: 'external'}
+
+    expect(evaluateHidden(getField(fields, 'reference'), externalParent)).toBe(true)
+    expect(evaluateHidden(getField(fields, 'url'), externalParent)).toBe(false)
+    expect(evaluateHidden(getField(fields, 'openInNewTab'), externalParent)).toBe(false)
+  })
+})

--- a/plugins/@sanity/presets/src/presets/link-field/schema.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/schema.ts
@@ -1,0 +1,70 @@
+import {defineField, defineType, type SchemaTypeDefinition} from 'sanity'
+
+import {LINK_FIELD_TYPE} from './constants'
+
+export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefinition {
+  const referenceTargets =
+    internalTypes.length > 0
+      ? internalTypes.map((typeName) => ({type: typeName}))
+      : [{type: 'document'}]
+
+  return defineType({
+    name: LINK_FIELD_TYPE,
+    type: 'object',
+    title: 'Link',
+    fields: [
+      defineField({
+        name: 'type',
+        type: 'string',
+        title: 'Link Type',
+        initialValue: 'internal',
+        options: {
+          layout: 'radio',
+          list: [
+            {title: 'Internal', value: 'internal'},
+            {title: 'External', value: 'external'},
+          ],
+        },
+      }),
+      defineField({
+        name: 'reference',
+        type: 'reference',
+        title: 'Internal Link',
+        to: referenceTargets,
+        hidden: ({parent}) => parent?.type !== 'internal',
+      }),
+      defineField({
+        name: 'url',
+        type: 'url',
+        title: 'URL',
+        hidden: ({parent}) => parent?.type !== 'external',
+        validation: (rule) =>
+          rule.uri({
+            scheme: ['http', 'https', 'mailto', 'tel'],
+          }),
+      }),
+      defineField({
+        name: 'openInNewTab',
+        type: 'boolean',
+        title: 'Open in New Tab',
+        initialValue: false,
+        hidden: ({parent}) => parent?.type !== 'external',
+      }),
+    ],
+    preview: {
+      select: {
+        type: 'type',
+        url: 'url',
+        referenceTitle: 'reference.title',
+      },
+      prepare({type, url, referenceTitle}) {
+        const title = type === 'external' ? url || 'No URL' : referenceTitle || 'No reference'
+
+        return {
+          title,
+          subtitle: type === 'external' ? 'External link' : 'Internal link',
+        }
+      },
+    },
+  })
+}

--- a/plugins/@sanity/presets/src/presets/link-field/schema.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/schema.ts
@@ -3,10 +3,7 @@ import {defineField, defineType, type SchemaTypeDefinition} from 'sanity'
 import {LINK_FIELD_TYPE} from './constants'
 
 export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefinition {
-  const referenceTargets =
-    internalTypes.length > 0
-      ? internalTypes.map((typeName) => ({type: typeName}))
-      : [{type: 'document'}]
+  const referenceTargets = internalTypes.map((typeName) => ({type: typeName}))
 
   return defineType({
     name: LINK_FIELD_TYPE,
@@ -14,7 +11,7 @@ export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefiniti
     title: 'Link',
     fields: [
       defineField({
-        name: 'type',
+        name: 'linkType',
         type: 'string',
         title: 'Link Type',
         initialValue: 'internal',
@@ -31,13 +28,13 @@ export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefiniti
         type: 'reference',
         title: 'Internal Link',
         to: referenceTargets,
-        hidden: ({parent}) => parent?.type !== 'internal',
+        hidden: ({parent}) => parent?.linkType === 'external',
       }),
       defineField({
         name: 'url',
         type: 'url',
         title: 'URL',
-        hidden: ({parent}) => parent?.type !== 'external',
+        hidden: ({parent}) => parent?.linkType === 'internal',
         validation: (rule) =>
           rule.uri({
             scheme: ['http', 'https', 'mailto', 'tel'],
@@ -48,21 +45,21 @@ export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefiniti
         type: 'boolean',
         title: 'Open in New Tab',
         initialValue: false,
-        hidden: ({parent}) => parent?.type !== 'external',
+        hidden: ({parent}) => parent?.linkType === 'internal',
       }),
     ],
     preview: {
       select: {
-        type: 'type',
+        linkType: 'linkType',
         url: 'url',
         referenceTitle: 'reference.title',
       },
-      prepare({type, url, referenceTitle}) {
-        const title = type === 'external' ? url || 'No URL' : referenceTitle || 'No reference'
+      prepare({linkType, url, referenceTitle}) {
+        const title = linkType === 'external' ? url || 'No URL' : referenceTitle || 'No reference'
 
         return {
           title,
-          subtitle: type === 'external' ? 'External link' : 'Internal link',
+          subtitle: linkType === 'external' ? 'External link' : 'Internal link',
         }
       },
     },

--- a/plugins/@sanity/presets/src/presets/link-field/schema.ts
+++ b/plugins/@sanity/presets/src/presets/link-field/schema.ts
@@ -1,12 +1,10 @@
 import {defineField, defineType, type SchemaTypeDefinition} from 'sanity'
 
-import {LINK_FIELD_TYPE} from './constants'
-
-export function createLinkFieldType(internalTypes: string[]): SchemaTypeDefinition {
+export function createLinkFieldType(name: string, internalTypes: string[]): SchemaTypeDefinition {
   const referenceTargets = internalTypes.map((typeName) => ({type: typeName}))
 
   return defineType({
-    name: LINK_FIELD_TYPE,
+    name,
     type: 'object',
     title: 'Link',
     fields: [

--- a/plugins/@sanity/presets/src/types.ts
+++ b/plugins/@sanity/presets/src/types.ts
@@ -1,5 +1,9 @@
 import type {SchemaTypeDefinition} from 'sanity'
 
+export interface BasePresetConfig {
+  name?: string
+}
+
 export interface PresetResult {
   types: SchemaTypeDefinition[]
 }

--- a/plugins/@sanity/presets/src/types.ts
+++ b/plugins/@sanity/presets/src/types.ts
@@ -1,0 +1,5 @@
+import type {SchemaTypeDefinition} from 'sanity'
+
+export interface PresetResult {
+  types: SchemaTypeDefinition[]
+}


### PR DESCRIPTION
### Description
Add optional name to linkField so multiple instances with different type names can coexist. A shared BasePresetConfig interface provides the name field, and createLinkFieldType accepts the resolved name directly instead of importing the constant. The test studio demonstrates two link fields side by side - one default, one custom-named.
<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing
Integration tests (extracted from composer.test.ts into link-field/composer-integration.test.ts) verify deduplication across named variants.
<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
