### PR TITLE
add `@sanity/debug-live-sync-tags`

### DIFF
--- a/.changeset/dry-melons-stare.md
+++ b/.changeset/dry-melons-stare.md
@@ -1,0 +1,5 @@
+---
+"@sanity/debug-live-sync-tags": major
+---
+
+Initial release

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -15,6 +15,7 @@
     "@sanity/assist": "workspace:*",
     "@sanity/code-input": "workspace:*",
     "@sanity/color-input": "workspace:*",
+    "@sanity/debug-live-sync-tags": "workspace:*",
     "@sanity/debug-preview-url-secret-plugin": "workspace:*",
     "@sanity/document-internationalization": "workspace:*",
     "@sanity/icons": "^3.7.4",

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -11,6 +11,7 @@ import {assistExample} from '#assist'
 import {bynderExample} from '#bynder'
 import {codeInputExample} from '#code-input'
 import {colorExample} from '#color'
+import {debugLiveSyncTagsExample} from '#debug-live-sync-tags'
 import {documentInternationalizationExample} from '#document-internationalization'
 import {iframePaneExample} from '#iframe-pane'
 import {internationalizedArrayExample} from '#internationalized-array'
@@ -51,6 +52,7 @@ export default defineConfig([
       structureTool(),
       assistExample(),
       // add new plugins here
+      debugLiveSyncTagsExample(),
       studioSecretsExample(),
       documentInternationalizationExample(),
       internationalizedArrayExample(),

--- a/dev/test-studio/src/debug-live-sync-tags/index.tsx
+++ b/dev/test-studio/src/debug-live-sync-tags/index.tsx
@@ -1,0 +1,6 @@
+import {debugLiveSyncTags} from '@sanity/debug-live-sync-tags'
+import {definePlugin} from 'sanity'
+
+export const debugLiveSyncTagsExample = definePlugin(() => ({
+  plugins: [debugLiveSyncTags()],
+}))

--- a/dev/test-studio/src/markdown/index.tsx
+++ b/dev/test-studio/src/markdown/index.tsx
@@ -7,6 +7,14 @@ const markdownTest = defineType({
   title: 'Markdown',
   fields: [
     {type: 'string', name: 'title', title: 'Title'},
+    {
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+      },
+    },
     {type: 'markdown', name: 'markdown', title: 'Markdown'},
   ],
 })

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -142,6 +142,15 @@
       ],
     },
     // add new plugin workspaces here
+    "plugins/@sanity/debug-live-sync-tags": {
+      "entry": ["package.config.ts"],
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": [
+        // Used by @sanity/pkg-utils babel transform, not directly imported
+        "babel-plugin-styled-components",
+      ],
+    },
+
     "plugins/@sanity/presets": {
       "entry": ["package.config.ts"],
       "project": ["src/**/*.{ts,tsx}"],

--- a/plugins/@sanity/debug-live-sync-tags/README.md
+++ b/plugins/@sanity/debug-live-sync-tags/README.md
@@ -1,0 +1,33 @@
+# @sanity/debug-live-sync-tags
+
+## Installation
+
+```bash
+npm install --save @sanity/debug-live-sync-tags
+```
+
+or
+
+```bash
+pnpm add @sanity/debug-live-sync-tags
+```
+
+or
+
+```
+yarn add @sanity/debug-live-sync-tags
+```
+
+## Usage
+
+Add it as a plugin in sanity.config.ts:
+
+```js
+import {defineConfig} from 'sanity'
+import {debugLiveSyncTags} from '@sanity/debug-live-sync-tags'
+
+export default defineConfig({
+  // ...
+  plugins: [debugLiveSyncTags()],
+})
+```

--- a/plugins/@sanity/debug-live-sync-tags/package.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/package.config.ts
@@ -1,0 +1,8 @@
+import config from '@repo/package.config'
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  ...config,
+  babel: {reactCompiler: true, styledComponents: true},
+  reactCompilerOptions: {target: '19'},
+})

--- a/plugins/@sanity/debug-live-sync-tags/package.json
+++ b/plugins/@sanity/debug-live-sync-tags/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@sanity/debug-live-sync-tags",
+  "version": "0.0.1",
+  "description": "",
+  "keywords": [
+    "sanity",
+    "sanity-plugin"
+  ],
+  "homepage": "https://github.com/sanity-io/plugins/tree/main/plugins/@sanity/debug-live-sync-tags#readme",
+  "bugs": {
+    "url": "https://github.com/sanity-io/plugins/issues"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/sanity-io/plugins.git",
+    "directory": "plugins/@sanity/debug-live-sync-tags"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "prepack": "turbo run build"
+  },
+  "dependencies": {
+    "@sanity/client": "catalog:",
+    "@sanity/ui": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/package.config": "workspace:*",
+    "@repo/tsconfig": "workspace:*",
+    "@sanity/pkg-utils": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
+    "babel-plugin-styled-components": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "sanity": "catalog:",
+    "styled-components": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "^19.2",
+    "react-dom": "^19.2",
+    "sanity": "^5",
+    "styled-components": "^6.1"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  }
+}

--- a/plugins/@sanity/debug-live-sync-tags/src/components/Tool.tsx
+++ b/plugins/@sanity/debug-live-sync-tags/src/components/Tool.tsx
@@ -1,0 +1,571 @@
+import {type LiveEvent} from '@sanity/client'
+import {Checkbox, Flex, Label, Stack} from '@sanity/ui'
+import {Activity, Fragment, startTransition, useEffect, useState} from 'react'
+import {useClient, useProjectId, useDataset, type SanityClient} from 'sanity'
+import {styled} from 'styled-components'
+
+const Layout = styled(Flex)`
+  height: 100%;
+  width: 100%;
+`
+
+const Sidebar = styled(Stack)`
+  flex-shrink: 0;
+  width: 200px;
+  padding: 16px;
+  border-right: 1px solid var(--card-border-color, #ddd);
+  overflow-y: auto;
+`
+
+const Main = styled.div`
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+`
+
+const StyledTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-family: monospace;
+  font-size: 13px;
+
+  thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--card-bg-color, #fff);
+    box-shadow: inset 0 -2px 0 var(--card-border-color, #ddd);
+  }
+
+  th,
+  td {
+    padding: 4px 8px;
+    text-align: left;
+    vertical-align: top;
+    white-space: nowrap;
+  }
+
+  th {
+    font-weight: 600;
+  }
+`
+
+const TagGrid = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0 12px;
+`
+
+function EventTable({
+  events,
+  findResolvedTag,
+  showTimestamp,
+  showEventId,
+}: {
+  events: Map<string, LiveEvent & {timestamp: string}>
+  findResolvedTag: (tag: string) => string
+  showTimestamp: boolean
+  showEventId: boolean
+}) {
+  const rows = Array.from(events.values())
+  if (rows.length === 0) return null
+
+  return (
+    <StyledTable>
+      <thead>
+        <tr>
+          {showTimestamp && <th>time</th>}
+          {showEventId && <th>id</th>}
+          <th>type</th>
+          <th>tags</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((event, i) => {
+          const tags = 'tags' in event ? event.tags : []
+          const time = new Date(event.timestamp).toLocaleTimeString()
+          const eventId = 'id' in event ? event.id : null
+          const bg =
+            i % 2 !== 0
+              ? 'color-mix(in srgb, var(--card-border-color, #ddd) 15%, transparent)'
+              : undefined
+          return (
+            <tr key={event.timestamp} style={{background: bg}}>
+              {showTimestamp && <td>{time}</td>}
+              {showEventId && <td>{eventId}</td>}
+              <td style={{fontWeight: 600}}>{event.type}</td>
+              <td style={{whiteSpace: 'normal'}}>
+                {tags.length > 0 && (
+                  <TagGrid>
+                    {tags.map((tag) => (
+                      <Fragment key={tag}>
+                        <span title={tag}>{tag}</span>
+                        <span>{findResolvedTag(tag)}</span>
+                      </Fragment>
+                    ))}
+                  </TagGrid>
+                )}
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </StyledTable>
+  )
+}
+
+export default function Tool() {
+  const client = useClient({apiVersion: '2026-03-17'})
+  const projectId = useProjectId()
+  const dataset = useDataset()
+  const [liveEvents, setLiveEvents] = useState<Map<string, LiveEvent & {timestamp: string}>>(
+    () => new Map(),
+  )
+  const [liveEventsIncludingAllDocuments, setLiveEventsIncludingAllDocuments] = useState<
+    Map<string, LiveEvent & {timestamp: string}>
+  >(() => new Map())
+
+  useEffect(() => {
+    const subscription = client.live.events({tag: 'debug-live-sync-tags'}).subscribe({
+      next: (event) => {
+        startTransition(() =>
+          setLiveEvents((prev) => {
+            const next = new Map(prev)
+            next.set('id' in event ? event.id : new Date().toJSON(), {
+              ...event,
+              timestamp: new Date().toJSON(),
+            })
+            return next
+          }),
+        )
+      },
+      error: console.error,
+    })
+    return () => subscription.unsubscribe()
+  }, [client])
+
+  useEffect(() => {
+    const subscription = client.live
+      .events({tag: 'debug-live-sync-tags', includeDrafts: true})
+      .subscribe({
+        next: (event) => {
+          startTransition(() =>
+            setLiveEventsIncludingAllDocuments((prev) => {
+              const next = new Map(prev)
+              next.set('id' in event ? event.id : new Date().toJSON(), {
+                ...event,
+                timestamp: new Date().toJSON(),
+              })
+              return next
+            }),
+          )
+        },
+        error: console.error,
+      })
+    return () => subscription.unsubscribe()
+  }, [client])
+
+  const [syncTagForEverything, setSyncTagForEverything] = useState<string | null>(null)
+  const [allDocumentTypes, setAllDocumentTypes] = useState<Map<string, string | null>>(
+    () => new Map(),
+  )
+  useEffect(() => {
+    const controller = new AbortController()
+    client
+      .fetch<string[]>(
+        `array::unique(*._type)`,
+        {},
+        {
+          signal: controller.signal,
+          returnQuery: false,
+          tag: 'debug-live-sync-tags',
+          filterResponse: false,
+        },
+      )
+      .then(({result, syncTags}) => {
+        if (controller.signal.aborted) return
+        setSyncTagForEverything(syncTags?.[0] ?? null)
+
+        setAllDocumentTypes((prev) => {
+          const next = new Map(prev)
+          for (const type of result) {
+            if (!next.has(type)) {
+              next.set(type, null)
+            }
+          }
+          return next
+        })
+        return
+      })
+      .catch(console.error)
+    return () => controller.abort()
+  }, [client])
+
+  const [whichList, setWhichList] = useState<'liveEvents' | 'liveEventsIncludingAllDocuments'>(
+    'liveEventsIncludingAllDocuments',
+  )
+  const [showTimestamp, setShowTimestamp] = useState(true)
+  const [showEventId, setShowEventId] = useState(false)
+
+  const unknownDocumentTypes: string[] = []
+  for (const [documentType, resolvedDocumentType] of allDocumentTypes.entries()) {
+    if (resolvedDocumentType === null) {
+      unknownDocumentTypes.push(documentType)
+    }
+  }
+  const setDocumentType = (documentType: string, resolvedDocumentType: string) =>
+    startTransition(() =>
+      setAllDocumentTypes((prev) => {
+        const next = new Map(prev)
+        next.set(documentType, resolvedDocumentType)
+        return next
+      }),
+    )
+  function findResolvedTag(tag: string): string {
+    if (tag === syncTagForEverything) {
+      return 'any:*'
+    }
+    for (const [documentType, resolvedDocumentType] of allDocumentTypes.entries()) {
+      if (resolvedDocumentType === tag) {
+        return `type:${documentType}`
+      }
+    }
+    for (const [documentId, resolvedDocumentId] of documentIdToTagMap.entries()) {
+      if (resolvedDocumentId === tag) {
+        return `id:${documentId}`
+      }
+    }
+    for (const [slug, resolvedSlug] of documentSlugToTagMap.entries()) {
+      if (resolvedSlug === tag) {
+        return `slug:${slug}`
+      }
+    }
+    return tag
+  }
+
+  const allDocumentTypesArray = Array.from(allDocumentTypes.keys())
+  const [documentIdToTagMap, setDocumentIdToTagMap] = useState<Map<string, string | null>>(
+    () => new Map(),
+  )
+  const unknownDocumentIds: string[] = []
+  for (const [documentId, tag] of documentIdToTagMap.entries()) {
+    if (tag === null) {
+      unknownDocumentIds.push(documentId)
+    }
+  }
+  const setDocumentIdTag = (documentId: string, tag: string | null) =>
+    startTransition(() =>
+      setDocumentIdToTagMap((prev) => {
+        const next = new Map(prev)
+        next.set(documentId, tag)
+        return next
+      }),
+    )
+
+  const [documentSlugToTagMap, setDocumentSlugToTagMap] = useState<Map<string, string | null>>(
+    () => new Map(),
+  )
+  const unknownDocumentSlugs: string[] = []
+  for (const [slug, tag] of documentSlugToTagMap.entries()) {
+    if (tag === null) {
+      unknownDocumentSlugs.push(slug)
+    }
+  }
+  const setDocumentSlugTag = (slug: string, tag: string | null) =>
+    startTransition(() =>
+      setDocumentSlugToTagMap((prev) => {
+        const next = new Map(prev)
+        next.set(slug, tag)
+        return next
+      }),
+    )
+
+  useEffect(() => {
+    if (allDocumentTypesArray.length === 0) {
+      return
+    }
+
+    const listener = client
+      .listen(
+        '*[_type in $type]',
+        {type: allDocumentTypesArray},
+        {
+          events: ['mutation'],
+          includePreviousRevision: false,
+          includeResult: true,
+          includeAllVersions: true,
+          includeMutations: false,
+          tag: 'debug-live-sync-tags',
+        },
+      )
+      .subscribe({
+        next: (event) => {
+          startTransition(() => {
+            setDocumentIdToTagMap((prev) => {
+              if (prev.has(event.documentId)) {
+                return prev
+              }
+              const next = new Map(prev)
+              next.set(event.documentId, null)
+              return next
+            })
+
+            const slugField = event.result?.['slug']
+            const slug =
+              slugField &&
+              typeof slugField === 'object' &&
+              'current' in slugField &&
+              typeof slugField.current === 'string'
+                ? slugField.current
+                : null
+            if (slug) {
+              setDocumentSlugToTagMap((prev) => {
+                if (prev.has(slug)) {
+                  return prev
+                }
+                const next = new Map(prev)
+                next.set(slug, null)
+                return next
+              })
+            }
+          })
+        },
+        error: console.error,
+      })
+    return () => listener.unsubscribe()
+  }, [client, allDocumentTypesArray])
+
+  return (
+    <Layout>
+      <Sidebar space={4}>
+        <Flex as="label" align="center" gap={2}>
+          <Checkbox
+            checked={whichList === 'liveEventsIncludingAllDocuments'}
+            onChange={() =>
+              setWhichList((prev) =>
+                prev === 'liveEvents' ? 'liveEventsIncludingAllDocuments' : 'liveEvents',
+              )
+            }
+          />
+          <Label size={1}>Include all documents</Label>
+        </Flex>
+        <Flex as="label" align="center" gap={2}>
+          <Checkbox checked={showTimestamp} onChange={() => setShowTimestamp((prev) => !prev)} />
+          <Label size={1}>Show timestamp</Label>
+        </Flex>
+        <Flex as="label" align="center" gap={2}>
+          <Checkbox checked={showEventId} onChange={() => setShowEventId((prev) => !prev)} />
+          <Label size={1}>Show event ID</Label>
+        </Flex>
+      </Sidebar>
+      <Main>
+        <Activity mode={whichList === 'liveEvents' ? 'visible' : 'hidden'}>
+          <EventTable
+            events={liveEvents}
+            findResolvedTag={findResolvedTag}
+            showTimestamp={showTimestamp}
+            showEventId={showEventId}
+          />
+        </Activity>
+        <Activity mode={whichList === 'liveEventsIncludingAllDocuments' ? 'visible' : 'hidden'}>
+          <EventTable
+            events={liveEventsIncludingAllDocuments}
+            findResolvedTag={findResolvedTag}
+            showTimestamp={showTimestamp}
+            showEventId={showEventId}
+          />
+        </Activity>
+      </Main>
+      {unknownDocumentTypes.map((unknownDocumentType) => (
+        <ResolveDocumentType
+          key={unknownDocumentType}
+          projectId={projectId}
+          dataset={dataset}
+          documentType={unknownDocumentType}
+          client={client}
+          setDocumentType={setDocumentType}
+        />
+      ))}
+      {unknownDocumentIds.map((unknownDocumentId) => (
+        <ResolveDocumentId
+          key={unknownDocumentId}
+          projectId={projectId}
+          dataset={dataset}
+          documentId={unknownDocumentId}
+          client={client}
+          setDocumentIdTag={setDocumentIdTag}
+        />
+      ))}
+      {unknownDocumentSlugs.map((unknownSlug) => (
+        <ResolveDocumentSlug
+          key={unknownSlug}
+          projectId={projectId}
+          dataset={dataset}
+          slug={unknownSlug}
+          client={client}
+          setDocumentSlugTag={setDocumentSlugTag}
+        />
+      ))}
+    </Layout>
+  )
+}
+
+function ResolveDocumentType({
+  projectId,
+  dataset,
+  documentType,
+  client,
+  setDocumentType,
+}: {
+  projectId: string
+  dataset: string
+  documentType: string
+  client: SanityClient
+  setDocumentType: (documentType: string, resolvedDocumentType: string) => void
+}) {
+  useEffect(() => {
+    const localStorageKey = `debug-live-sync-tags-resolved-document-type-${projectId}-${dataset}-${documentType}`
+    const localStorageValue = localStorage.getItem(localStorageKey)
+    if (localStorageValue && typeof localStorageValue === 'string') {
+      setDocumentType(documentType, localStorageValue)
+      return
+    }
+
+    const controller = new AbortController()
+    void client
+      .fetch(
+        `count(*[_type == $type])`,
+        {type: documentType},
+        {
+          filterResponse: false,
+          perspective: 'published',
+          returnQuery: false,
+          resultSourceMap: false,
+          stega: false,
+          useCdn: true,
+        },
+      )
+      .then(({syncTags}) => {
+        if (controller.signal.aborted) return
+        if (!Array.isArray(syncTags)) {
+          throw new TypeError('syncTags is not an array', {cause: {syncTags, documentType}})
+        }
+        if (syncTags.length !== 1) {
+          throw new TypeError('syncTags is not an array of exactly one item', {
+            cause: {syncTags, documentType},
+          })
+        }
+        setDocumentType(documentType, syncTags[0]!)
+        localStorage.setItem(localStorageKey, syncTags[0]!)
+        return
+      })
+    return () => controller.abort()
+  }, [documentType, client, dataset, setDocumentType, projectId])
+
+  return null
+}
+
+function ResolveDocumentId({
+  projectId,
+  dataset,
+  documentId,
+  client,
+  setDocumentIdTag,
+}: {
+  projectId: string
+  dataset: string
+  documentId: string
+  client: SanityClient
+  setDocumentIdTag: (documentId: string, tag: string | null) => void
+}) {
+  useEffect(() => {
+    const localStorageKey = `debug-live-sync-tags-resolved-document-id-${projectId}-${dataset}-${documentId}`
+    const localStorageValue = localStorage.getItem(localStorageKey)
+    if (localStorageValue && typeof localStorageValue === 'string') {
+      setDocumentIdTag(documentId, localStorageValue)
+      return
+    }
+    const controller = new AbortController()
+    void client
+      .fetch(
+        `count(*[_id == $id])`,
+        {id: documentId},
+        {
+          filterResponse: false,
+          // perspective: 'published',
+          returnQuery: false,
+          resultSourceMap: false,
+          stega: false,
+          useCdn: true,
+        },
+      )
+      .then(({syncTags}) => {
+        if (controller.signal.aborted) return
+        if (!Array.isArray(syncTags)) {
+          throw new TypeError('syncTags is not an array', {cause: {syncTags, documentId}})
+        }
+        if (syncTags.length !== 1) {
+          throw new TypeError('syncTags is not an array of exactly one item', {
+            cause: {syncTags, documentId},
+          })
+        }
+        setDocumentIdTag(documentId, syncTags[0]!)
+        localStorage.setItem(localStorageKey, syncTags[0]!)
+        return
+      })
+    return () => controller.abort()
+  }, [documentId, client, dataset, setDocumentIdTag, projectId])
+  return null
+}
+
+function ResolveDocumentSlug({
+  projectId,
+  dataset,
+  slug,
+  client,
+  setDocumentSlugTag,
+}: {
+  projectId: string
+  dataset: string
+  slug: string
+  client: SanityClient
+  setDocumentSlugTag: (slug: string, tag: string | null) => void
+}) {
+  useEffect(() => {
+    const localStorageKey = `debug-live-sync-tags-resolved-document-slug-${projectId}-${dataset}-${slug}`
+    const localStorageValue = localStorage.getItem(localStorageKey)
+    if (localStorageValue && typeof localStorageValue === 'string') {
+      setDocumentSlugTag(slug, localStorageValue)
+      return
+    }
+    const controller = new AbortController()
+    void client
+      .fetch(
+        `count(*[slug.current == $slug])`,
+        {slug},
+        {
+          filterResponse: false,
+          returnQuery: false,
+          resultSourceMap: false,
+          stega: false,
+          useCdn: true,
+        },
+      )
+      .then(({syncTags}) => {
+        if (controller.signal.aborted) return
+        if (!Array.isArray(syncTags)) {
+          throw new TypeError('syncTags is not an array', {cause: {syncTags, slug}})
+        }
+        if (syncTags.length !== 1) {
+          throw new TypeError('syncTags is not an array of exactly one item', {
+            cause: {syncTags, slug},
+          })
+        }
+        setDocumentSlugTag(slug, syncTags[0]!)
+        localStorage.setItem(localStorageKey, syncTags[0]!)
+        return
+      })
+    return () => controller.abort()
+  }, [slug, client, dataset, setDocumentSlugTag, projectId])
+  return null
+}

--- a/plugins/@sanity/debug-live-sync-tags/src/index.test.ts
+++ b/plugins/@sanity/debug-live-sync-tags/src/index.test.ts
@@ -1,0 +1,19 @@
+import {fileURLToPath} from 'node:url'
+
+import {expect, test} from 'vitest'
+import {getPackageExportsManifest} from 'vitest-package-exports'
+
+test('package exports', {timeout: 30_000}, async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: 'dist',
+    cwd: fileURLToPath(import.meta.url),
+  })
+
+  expect(manifest.exports).toMatchInlineSnapshot(`
+    {
+      ".": {
+        "debugLiveSyncTags": "function",
+      },
+    }
+  `)
+})

--- a/plugins/@sanity/debug-live-sync-tags/src/index.ts
+++ b/plugins/@sanity/debug-live-sync-tags/src/index.ts
@@ -1,0 +1,1 @@
+export {debugLiveSyncTags} from './plugin'

--- a/plugins/@sanity/debug-live-sync-tags/src/plugin.tsx
+++ b/plugins/@sanity/debug-live-sync-tags/src/plugin.tsx
@@ -1,0 +1,32 @@
+import {lazy} from 'react'
+import {definePlugin, type Plugin} from 'sanity'
+
+const ToolComponent = lazy(() => import('./components/Tool'))
+
+interface PluginConfig {
+  name?: string
+  title?: string
+  icon?: React.ComponentType
+}
+
+export const debugLiveSyncTags: Plugin<PluginConfig | void> = definePlugin((config) => {
+  const {
+    name = 'debug-live-sync-tags',
+    title = 'Debug Live Sync Tags',
+    icon,
+    ...options
+  } = config || {}
+
+  return {
+    name: '@sanity/debug-live-sync-tags',
+    tools: [
+      {
+        name,
+        title,
+        icon,
+        component: ToolComponent,
+        options,
+      },
+    ],
+  }
+})

--- a/plugins/@sanity/debug-live-sync-tags/tsconfig.build.json
+++ b/plugins/@sanity/debug-live-sync-tags/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/tsconfig/build.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {
+    "isolatedDeclarations": false
+  }
+}

--- a/plugins/@sanity/debug-live-sync-tags/tsconfig.json
+++ b/plugins/@sanity/debug-live-sync-tags/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/tsconfig/check.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/plugins/@sanity/debug-live-sync-tags/vitest.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        inline: ['vitest-package-exports'],
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@sanity/color-input':
         specifier: workspace:*
         version: link:../../plugins/@sanity/color-input
+      '@sanity/debug-live-sync-tags':
+        specifier: workspace:*
+        version: link:../../plugins/@sanity/debug-live-sync-tags
       '@sanity/debug-preview-url-secret-plugin':
         specifier: workspace:*
         version: link:../../plugins/@sanity/debug-preview-url-secret-plugin
@@ -429,6 +432,49 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.4
+      sanity:
+        specifier: 'catalog:'
+        version: 5.17.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.46.0)(typescript@5.9.3)
+
+  plugins/@sanity/debug-live-sync-tags:
+    dependencies:
+      '@sanity/client':
+        specifier: 'catalog:'
+        version: 7.17.0(debug@4.4.3)
+      '@sanity/ui':
+        specifier: 'catalog:'
+        version: 3.1.14(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)
+      styled-components:
+        specifier: npm:@sanity/styled-components@latest
+        version: '@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
+    devDependencies:
+      '@repo/package.config':
+        specifier: workspace:*
+        version: link:../../../packages/@repo/package.config
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../../../packages/@repo/tsconfig
+      '@sanity/pkg-utils':
+        specifier: 'catalog:'
+        version: 10.4.10(@types/babel__core@7.20.5)(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260314.1)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
+      babel-plugin-styled-components:
+        specifier: 'catalog:'
+        version: 2.1.4(@babel/core@7.29.0)(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
       sanity:
         specifier: 'catalog:'
         version: 5.17.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(terser@5.46.0)(typescript@5.9.3)
@@ -11509,7 +11555,7 @@ snapshots:
       '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.8.4
-      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       chokidar: 5.0.0
       console-table-printer: 2.15.0
       date-fns: 4.1.0
@@ -12196,7 +12242,7 @@ snapshots:
       ora: 9.3.0
       tar-stream: 3.1.7
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-tsconfig-paths: 6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
       xdg-basedir: 5.1.0
     transitivePeerDependencies:
@@ -12879,18 +12925,6 @@ snapshots:
       '@babel/runtime': 7.28.6
       global: 4.4.0
       is-function: 1.0.2
-
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -17529,16 +17563,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
Adds a new plugin that helps debugging sync tags used by `<SanityLive />` to mark cache tags. Sync tags are opaque, this plugin makes them "transparent".

<img width="1826" height="1084" alt="image" src="https://github.com/user-attachments/assets/39fcae4e-f0c4-4927-b32f-7fded9a9c813" />
