### PR TITLE
fix(i18n-array): update the migration script to match v5 using langague field

### DIFF
--- a/.changeset/wacky-animals-invite.md
+++ b/.changeset/wacky-animals-invite.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Object to Array Migration script update to match v5

--- a/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
+++ b/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import {getCliClient} from 'sanity/cli'
+import {randomKey} from '@sanity/util/content'
 
 const client = getCliClient({apiVersion: '2023-06-30'})
 
@@ -15,8 +16,8 @@ const client = getCliClient({apiVersion: '2023-06-30'})
 
 // To:
 // "greeting": [
-//   { "_key": "en", "value": "hello" },
-//   { "_key": "fr", "value": "bonjour" },
+//   { "_key": "abc-def-ghi-jkl", "language":"en", "value": "hello" },
+//   { "_key": "zxy-vwx-rst-qpo", "language":"fr", "value": "bonjour" },
 // ]
 
 // This will migrate documents in batches of 100 and continue patching until no more documents are
@@ -66,7 +67,8 @@ const buildPatches = (docs: any[]) =>
         [FIELD_NAME]: Object.keys(doc[FIELD_NAME])
           .filter((key) => key !== '_type')
           .map((key) => ({
-            _key: key,
+            _key: randomKey(),
+            language: key,
             value: doc[FIELD_NAME][key],
           })),
       },

--- a/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
+++ b/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
@@ -16,8 +16,8 @@ const client = getCliClient({apiVersion: '2023-06-30'})
 
 // To:
 // "greeting": [
-//   { "_key": "abc-def-ghi-jkl", "language":"en", "value": "hello" },
-//   { "_key": "zxy-vwx-rst-qpo", "language":"fr", "value": "bonjour" },
+//   { "_key": "abcdefghijkl", "language":"en", "value": "hello" },
+//   { "_key": "zxyvwxrstqpo", "language":"fr", "value": "bonjour" },
 // ]
 
 // This will migrate documents in batches of 100 and continue patching until no more documents are

--- a/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
+++ b/plugins/sanity-plugin-internationalized-array/migrations/transformObjectToArray.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
-import {getCliClient} from 'sanity/cli'
 import {randomKey} from '@sanity/util/content'
+import {getCliClient} from 'sanity/cli'
 
 const client = getCliClient({apiVersion: '2023-06-30'})
 
@@ -45,6 +45,7 @@ const client = getCliClient({apiVersion: '2023-06-30'})
 
 const TYPE = `presenter`
 const FIELD_NAME = `title`
+const ARRAY_ITEM_TYPE = `internationalizedArrayStringValue`
 
 // 3. Run this script with:
 // `npx sanity@latest exec ./migrations/transformObjectToArray.ts --with-user-token`
@@ -68,6 +69,7 @@ const buildPatches = (docs: any[]) =>
           .filter((key) => key !== '_type')
           .map((key) => ({
             _key: randomKey(),
+            _type: ARRAY_ITEM_TYPE,
             language: key,
             value: doc[FIELD_NAME][key],
           })),


### PR DESCRIPTION
### Description

Tweak to migration script from objects to array to use the dedicated language field rather than key. This keeps the migration script up to date with the current implementation of the plugin

### What to review

Confirm that migration output matches the new v5 version

### Testing

I tested the migration on a object of:
```
intTitle: {
  en: "Title",
  fr: "fr title",
  es: "es title",
  de: "de title",
  it: "it title",
}
```
and it converted it to:
```
intTitle: [
    {
      "_key": "4a14d51e9150454c32ff7a9e52e4616f",
      "language": "en",
      "value": "Title"
    },
    {
      "_key": "4a367f77795b178f10664c135aeb75ff",
      "language": "fr",
      "value": "fr Title"
    },
    {
      "_key": "acf6d2fd95e231dec3d450a60427cd45",
      "_type": "internationalizedArrayStringValue",
      "language": "es title"
    },
    {
      "_key": "d1bc5e6c3cb7450a3fb597f1cc211ef1",
      "language": "de",
      "value": "de Title"
    },
    {
      "_key": "fbd9a982777c6a3a28b91061608ebfc8",
      "language": "it",
      "value": "it Title"
    }
]
```

and this displayed correctly in a studio with the v5 plugin