### PR TITLE
fix(array-i18n): restore migration skill file

### DIFF
--- a/plugins/sanity-plugin-internationalized-array/README.md
+++ b/plugins/sanity-plugin-internationalized-array/README.md
@@ -368,7 +368,7 @@ Use a backwards compatible query until your migration is ready and has been exec
 }
 ```
 
-If you use AI agents in your code, you can copy [this skill](../../.claude/skills/i18n-array-groq-query-migration/SKILL.md) to your project to guide your agents and help you with the migration.
+If you use AI agents in your code, you can copy [this skill](./skills/i18n-array-groq-query-migration/SKILL.md) to your project to guide your agents and help you with the migration.
 
 Use this pre migration prompt
 
@@ -447,7 +447,7 @@ Before running any migration steps, ask the user to create a backup and confirm 
 Use this context:
 - Document internationalization (v5 -> v6): https://github.com/sanity-io/plugins/blob/main/plugins/%40sanity/document-internationalization/README.md#migrating-to-v6
 - Internationalized array README: https://github.com/sanity-io/plugins/blob/main/plugins/sanity-plugin-internationalized-array/README.md
-- Skill source to copy from: https://github.com/sanity-io/plugins/blob/main/.claude/skills/i18n-array-groq-query-migration/SKILL.md
+- Skill source to copy from: https://github.com/sanity-io/plugins/blob/main/plugins/sanity-plugin-internationalized-array/skills/i18n-array-groq-query-migration/SKILL.md
 
 Then execute this workflow:
 ## Pre migration:

--- a/plugins/sanity-plugin-internationalized-array/skills/i18n-array-groq-query-migration/SKILL.md
+++ b/plugins/sanity-plugin-internationalized-array/skills/i18n-array-groq-query-migration/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: i18n-array-groq-query-migration
+description: Detect and update legacy GROQ patterns where language is read from _key for sanity-plugin-internationalized-array when users mention v4 to v5 migration, or @sanity/document-internationalization from v5 to v6. GROQ query updates, localized arrays, or patterns like `_key == "en"` and `_key == $language`.
+---
+
+# Internationalized Array GROQ Migration
+
+## Goal
+
+Help users find GROQ queries that still read locale from `_key` and rewrite them safely for v5.
+
+## When To Use
+
+Use this skill when a user asks to:
+
+- migrate `sanity-plugin-internationalized-array` from v4 to v5
+- migrate `@sanity/document-internationalization` from v5 to v6 alongside `sanity-plugin-internationalized-array` language field changes
+- find queries that still use `_key` for language lookup
+- update GROQ filters like `_key == "en"` or `_key == $language`
+
+## Detection Workflow
+
+Detection commands below use `grep`. If your environment differs, use your editor's global search with equivalent patterns.
+
+1. Search for direct language comparisons on `_key`:
+
+```bash
+grep -REn --exclude-dir=node_modules "_key[[:space:]]*==[[:space:]]*(\"[^\"]+\"|'[^']+'|\\$[A-Za-z_][A-Za-z0-9_]*)" .
+```
+
+1. Search for any localized-array filters that mention `_key`:
+
+```bash
+grep -REn --exclude-dir=node_modules "\[[^]]*_key[^]]*\]" .
+```
+
+1. Prioritize matches that look like localized-value reads, for example:
+
+- `field[_key == ...][0].value`
+- `select(...)` branches that compare `_key` to a language value
+
+1. Check for uses of `groq` and verify if they use `_key` as the language, if it is using it, update them.
+
+1. Explicitly check for template-interpolated language expressions and keep the same operand, for example:
+   - `_key == "${language}"`
+   - `_key == "${locale}"`
+
+1. Review each match to avoid false positives where `_key` is used for unrelated array item identity.
+
+## Rewrite Rules
+
+Use the same language operand from the original query. The language operand can be a string literal (for example `"en"`), a variable (for example `$language`), or a template-interpolated expression (for example `"${language}"`).
+
+- **Before data migration is executed (backwards compatible):**
+  - `_key == <languageExpr>` -> `language == <languageExpr> || _key == <languageExpr>`
+- **After migration is complete:**
+  - `language == <languageExpr> || _key == <languageExpr>` -> `language == <languageExpr>`
+
+## Examples
+
+Legacy:
+
+```groq
+*[_type == "person"]{
+  "greeting": greeting[_key == $language][0].value
+}
+```
+
+Backwards compatible:
+
+```groq
+*[_type == "person"]{
+  "greeting": greeting[language == $language || _key == $language][0].value
+}
+```
+
+Post-migration final form:
+
+```groq
+*[_type == "person"]{
+  "greeting": greeting[language == $language][0].value
+}
+```
+
+## Response Template
+
+When reporting findings to a user:
+
+1. List each query location that still uses `_key` as language source.
+2. Show the exact replacement using the same language expression.
+3. Label each replacement as:
+   - `backwards-compatible` (pre-migration), or
+   - `final` (post-migration complete).
+4. Label each match category as `runtime`, `docs/example`, or `ambiguous`.
+5. Call out any ambiguous `_key` usage that needs manual review.


### PR DESCRIPTION
### Description
Restores the array internationalization migration skill removed in this [commit](https://github.com/sanity-io/plugins/commit/a3e9fcce00ceed136fe2a48a42e53dd314c9222a#diff-0910de00bec48b98f92b4981d02265ee9feb9a72080cc8f195657a967792cbd7) and moves it to the internationalized array plugin folder 

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
