### PR TITLE
feat(@sanity/presets): add map methods for overriding any preset-created property

### DIFF
--- a/.changeset/fast-birds-hunt.md
+++ b/.changeset/fast-birds-hunt.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": minor
+---
+
+Presets now provide methods for extending and overriding the created schema type.

--- a/plugins/@sanity/presets/package.json
+++ b/plugins/@sanity/presets/package.json
@@ -47,6 +47,7 @@
     "@repo/package.config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@sanity/pkg-utils": "catalog:",
+    "@types/react": "catalog:",
     "sanity": "catalog:"
   },
   "peerDependencies": {

--- a/plugins/@sanity/presets/src/definePresetType.ts
+++ b/plugins/@sanity/presets/src/definePresetType.ts
@@ -1,6 +1,6 @@
-import type {SchemaTypeDefinition} from 'sanity'
+import type {IntrinsicTypeName, SchemaTypeDefinition} from 'sanity'
 
-import type {PresetResult} from './types'
+import type {PartialSchemaDefinition, PresetResult} from './types'
 
 /**
  * @internal
@@ -24,9 +24,74 @@ export interface PresetTypeContext {
   composes?: PresetResultFactory[]
 }
 
-export function definePresetType<Context = void>(
-  factory: (context?: Context) => PresetTypeContext,
-): (context?: BaseContext & Context) => PresetResult[] {
+/**
+ * Properties that are never be permitted to be overridden when using any preset.
+ */
+type ProhibitedProperties = 'type'
+
+/**
+ * Prevent excluded properties being assigned to the object.
+ */
+type SanitizeProperties<Properties, ExcludedProperties extends string | undefined> = [
+  ExcludedProperties,
+] extends [PropertyKey]
+  ? Omit<Properties, ExcludedProperties>
+  : Properties
+
+/**
+ * Derive context that may be assigned when preset is used.
+ */
+type DerivedContext<
+  Context,
+  AliasedType extends IntrinsicTypeName | undefined = undefined,
+  LockedProperties extends string | undefined = undefined,
+> = BaseContext &
+  Context &
+  (AliasedType extends string
+    ? SanitizeProperties<
+        PartialSchemaDefinition<AliasedType>,
+        ProhibitedProperties | LockedProperties
+      >
+    : {}) & {
+    /**
+     * Map hooks allow any schema property created by the preset to be
+     * overridden.
+     *
+     * Each hook receives the value created by the preset, and may return any
+     * compatible value.
+     *
+     * Map hooks are able to override any schema option. They always receive
+     * the value produced by the preset, including any other customisations
+     * made in the configuration. For example, if a preset supports appending
+     * fields by specifying the `fields` array, `map.fields` will receive all
+     * of the fields created by the preset in addition to those defined in the
+     * `fields` array.
+     */
+    map?: AliasedType extends string
+      ? {
+          [Key in keyof PartialSchemaDefinition<AliasedType>]?: (
+            input: PartialSchemaDefinition<AliasedType>[Key],
+          ) => PartialSchemaDefinition<AliasedType>[Key]
+        }
+      : {}
+  }
+
+export function definePresetType<
+  Context = undefined,
+  AliasedType extends IntrinsicTypeName | undefined = undefined,
+  /**
+   * If a property is locked, users are not permitted to provide a value for
+   * that property when creating an instance of the preset. This should be used
+   * when a preset does not consider a user-provided property, or does not pass
+   * it to the underlying schema definition.
+   *
+   * Users may still ultimately override any property, including locked
+   * properties, by using the map hooks.
+   */
+  LockedProperties extends string | undefined = undefined,
+>(
+  factory: (context?: DerivedContext<Context, AliasedType, LockedProperties>) => PresetTypeContext,
+): (context?: DerivedContext<Context, AliasedType, LockedProperties>) => PresetResult[] {
   return function define(context) {
     const {schemaType, composes = []} = factory(context)
     const visited = context?.[visitedFactories] ?? new WeakSet()
@@ -43,6 +108,18 @@ export function definePresetType<Context = void>(
         [visitedFactories]: visited,
       }),
     )
+
+    for (const [configName, configValue] of Object.entries(context?.map ?? {})) {
+      if (typeof configValue !== 'function') {
+        continue
+      }
+
+      // oxlint-disable-next-line no-unsafe-type-assertion
+      schemaType[configName as keyof typeof schemaType] = configValue(
+        // oxlint-disable-next-line no-unsafe-type-assertion
+        schemaType[configName as keyof typeof schemaType],
+      )
+    }
 
     return dependencies.concat({
       type: schemaType,

--- a/plugins/@sanity/presets/src/presets/cta-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/cta-type/index.ts
@@ -6,13 +6,16 @@ import {CTA_TYPE_NAME} from './constants'
 
 export {CTA_TYPE_NAME} from './constants'
 
-export const ctaType = definePresetType(() => {
+export const ctaType = definePresetType<{}, 'object'>((context) => {
+  const {fields, ...objectConfig} = context ?? {}
+
   return {
     composes: [linkType],
     schemaType: defineType({
       name: CTA_TYPE_NAME,
-      type: 'object',
       title: 'Call to action',
+      ...objectConfig,
+      type: 'object',
       fields: [
         defineField({
           name: 'link',
@@ -28,6 +31,7 @@ export const ctaType = definePresetType(() => {
             list: [1, 2, 3],
           },
         }),
+        ...(fields ?? []),
       ],
     }),
   }

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -9,15 +9,16 @@ export interface LinkTypeConfig {
   internalTypes?: string[]
 }
 
-export const linkType = definePresetType<LinkTypeConfig>((context) => {
-  const internalTypes = context?.internalTypes ?? []
+export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>((context) => {
+  const {internalTypes, fields, ...objectConfig} = context ?? {}
   const referenceTargets = (internalTypes ?? []).map((typeName) => ({type: typeName}))
 
   return {
     schemaType: defineType({
       name: LINK_TYPE_NAME,
-      type: 'object',
       title: 'Link',
+      ...objectConfig,
+      type: 'object',
       fields: [
         defineField({
           name: 'linkType',
@@ -56,6 +57,7 @@ export const linkType = definePresetType<LinkTypeConfig>((context) => {
           initialValue: false,
           hidden: ({parent}) => parent?.linkType === 'internal',
         }),
+        ...(fields ?? []),
       ],
       preview: {
         select: {

--- a/plugins/@sanity/presets/src/presets/page-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/page-type/index.ts
@@ -10,15 +10,16 @@ export interface PageTypeConfig {
   pageBuilderBlocks: string[]
 }
 
-export const pageType = definePresetType<PageTypeConfig>((context) => {
-  const pageBuilderBlocks = context?.pageBuilderBlocks ?? []
+export const pageType = definePresetType<PageTypeConfig, 'document'>((context) => {
+  const {pageBuilderBlocks, groups, fields, ...documentConfig} = context ?? {}
 
   return {
     composes: [seoType],
     schemaType: defineType({
       name: PAGE_TYPE_NAME,
-      type: 'document',
       title: 'Page',
+      ...documentConfig,
+      type: 'document',
       groups: [
         {
           ...ALL_FIELDS_GROUP,
@@ -33,6 +34,7 @@ export const pageType = definePresetType<PageTypeConfig>((context) => {
           name: 'metadata',
           title: 'Metadata',
         },
+        ...(groups ?? []),
       ],
       fields: [
         defineField({
@@ -56,7 +58,7 @@ export const pageType = definePresetType<PageTypeConfig>((context) => {
           title: 'Content',
           group: 'main',
           type: 'array',
-          of: pageBuilderBlocks.map((typeName) =>
+          of: (pageBuilderBlocks ?? []).map((typeName) =>
             defineArrayMember({
               type: typeName,
             }),
@@ -68,6 +70,7 @@ export const pageType = definePresetType<PageTypeConfig>((context) => {
           type: SEO_TYPE_NAME,
           group: 'metadata',
         }),
+        ...(fields ?? []),
       ],
     }),
   }

--- a/plugins/@sanity/presets/src/presets/seo-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/seo-type/index.ts
@@ -6,12 +6,15 @@ import {SEO_TYPE_NAME} from './constants'
 
 export {SEO_TYPE_NAME} from './constants'
 
-export const seoType = definePresetType(() => {
+export const seoType = definePresetType<{}, 'object'>((context) => {
+  const {fields, ...objectConfig} = context ?? {}
+
   return {
     schemaType: defineType({
       name: SEO_TYPE_NAME,
-      type: 'object',
       title: 'Web page metadata (SEO)',
+      ...objectConfig,
+      type: 'object',
       fields: [
         defineField({
           name: 'title',
@@ -55,6 +58,7 @@ export const seoType = definePresetType(() => {
               return true
             }),
         }),
+        ...(fields ?? []),
       ],
     }),
   }

--- a/plugins/@sanity/presets/src/types.ts
+++ b/plugins/@sanity/presets/src/types.ts
@@ -1,4 +1,4 @@
-import type {SchemaTypeDefinition} from 'sanity'
+import type {DefineSchemaBase, IntrinsicTypeName, PreviewConfig, SchemaTypeDefinition} from 'sanity'
 
 import type {PresetProvider, presetProvider} from './definePresetType'
 
@@ -6,3 +6,7 @@ export interface PresetResult {
   type: SchemaTypeDefinition
   [presetProvider]: PresetProvider
 }
+
+export type PartialSchemaDefinition<TypeName extends IntrinsicTypeName> = Partial<
+  DefineSchemaBase<TypeName, TypeName> & {preview: PreviewConfig}
+>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,6 +641,9 @@ importers:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 10.4.11(@types/babel__core@7.20.5)(@types/node@25.5.0)(@typescript/native-preview@7.0.0-dev.20260405.1)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.19.1)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
       sanity:
         specifier: 'catalog:'
         version: 5.17.1(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.9.0)(@sanity/cli-core@1.1.2(@noble/hashes@2.0.1)(@sanity/telemetry@0.8.1(react@19.2.4))(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(typescript@5.9.3)


### PR DESCRIPTION
### Description

This branch adds capabilities for extending presets.

1. Presets now accept schema type config reflecting the type they alias. For example, the SEO and Page types accept `fields` and `groups` config. These properties shadow the config users would typically pass to the `defineType` helpers. When a user provides a `fields` or `groups` array, the values are appended to the values created by the preset.
   - Users may never override the `type` config.
   - If a preset doesn't allow a config to be extended in this way, it can prevent users from setting it by adding its name to the `LockedProperties` type parameter of the `definePresetType` function. Users will not longer be permitted to set this property.
   - Any config the user provides that does not intersect with properties the preset itself defines should be spread directly into the preset's `defineType` call.
3.  All presets now have a `map` config. This is an object that provides callbacks that can override any config property set by the preset. This is an escape hatch for users who need to modify a config property created by the preset.
     - For example, this allows a user to prepend rather than append a field.

#### Example: append a field to a page using `fields`

```ts
pageType({
  pageBuilderBlocks: ['core.presets.cta', 'blockquote'],
  fields: [
    defineField({
      name: 'extension',
      type: 'string',
      group: 'main',
    }),
  ],
}),
```

#### Example: prepend a field to a page using `map.fields`

```ts
pageType({
  pageBuilderBlocks: ['core.presets.cta', 'blockquote'],
  map: {
    fields: (fields = []) => [
      defineField({
        name: 'extension',
        type: 'string',
        group: 'main',
      }),
      ...fields,
    ],
  },
}),
```

### What to review

Extending and modifying presets: do these new APIs feel right?

### Testing

Not added extensive tests yet as aiming to quickly prove out the API.