### PR TITLE
chore: update current plugins from readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,8 @@ Use the generator:
 pnpm generate "new plugin"
 ```
 
+When adding a new plugin, also update the root `README.md` `## Current Plugins` table so the monorepo plugin list stays current.
+
 Or to migrate an existing plugin:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,7 @@ For any new plugin PR, make sure all of the following are included:
 2. A `.changeset/*.md` file for release automation
 3. A `CODEOWNERS` rule that assigns the plugin path to the owning team
 4. Clear ownership details in the plugin `README.md` (owning team and support expectations)
+5. An entry in the root `README.md` `## Current Plugins` table
 
 Without an explicit owner, new plugins should not be merged.
 
@@ -248,6 +249,8 @@ You can now iterate on the plugin with hot reloading in the test studio:
 ```bash
 pnpm dev
 ```
+
+Before opening your PR, add the new package to the root `README.md` `## Current Plugins` table so the monorepo plugin list stays current.
 
 ### 3. Create the Initial Release Changeset
 

--- a/README.md
+++ b/README.md
@@ -59,17 +59,28 @@ pnpm format
 
 ## Current Plugins
 
-| Plugin                                                                                         | Description                                               |
-| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| [`@sanity/color-input`](./plugins/@sanity/color-input)                                         | Color picker input for Sanity Studio                      |
-| [`@sanity/debug-preview-url-secret-plugin`](./plugins/@sanity/debug-preview-url-secret-plugin) | Debug plugin for preview URL secrets                      |
-| [`@sanity/vercel-protection-bypass`](./plugins/@sanity/vercel-protection-bypass)               | Tool for bypassing Vercel authentication in preview       |
-| [`sanity-plugin-aprimo`](./plugins/sanity-plugin-aprimo)                                       | Aprimo DAM integration                                    |
-| [`sanity-plugin-bynder-input`](./plugins/sanity-plugin-bynder-input)                           | Bynder DAM integration                                    |
-| [`sanity-plugin-graph-view`](./plugins/sanity-plugin-graph-view)                               | Visual graph view of document references                  |
-| [`sanity-plugin-markdown`](./plugins/sanity-plugin-markdown)                                   | Markdown editor input                                     |
-| [`sanity-plugin-workflow`](./plugins/sanity-plugin-workflow)                                   | Custom workflow management example for content publishing |
-| [`sanity-plugin-workspace-home`](./plugins/sanity-plugin-workspace-home)                       | Workspace home screen customization                       |
+| Plugin                                                                                         | Description                                              |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [`@sanity/assist`](./plugins/@sanity/assist)                                                   | AI-powered writing and translation assistance for Studio |
+| [`@sanity/code-input`](./plugins/@sanity/code-input)                                           | Code editor input powered by CodeMirror                  |
+| [`@sanity/color-input`](./plugins/@sanity/color-input)                                         | Color picker input for Sanity Studio                     |
+| [`@sanity/debug-live-sync-tags`](./plugins/@sanity/debug-live-sync-tags)                       | Debug tool for inspecting live sync tags                 |
+| [`@sanity/debug-preview-url-secret-plugin`](./plugins/@sanity/debug-preview-url-secret-plugin) | Debug tool for preview URL secrets and their status      |
+| [`@sanity/document-internationalization`](./plugins/@sanity/document-internationalization)     | Document-level translations linked by a shared reference |
+| [`@sanity/language-filter`](./plugins/@sanity/language-filter)                                 | Filter localized fields by language                      |
+| [`@sanity/presets`](./plugins/@sanity/presets)                                                 | Experimental preset patterns for Sanity Studio           |
+| [`@sanity/rich-date-input`](./plugins/@sanity/rich-date-input)                                 | Timezone-aware datetime input for Sanity Studio          |
+| [`@sanity/studio-secrets`](./plugins/@sanity/studio-secrets)                                   | Manage Studio secrets at runtime                         |
+| [`@sanity/vercel-protection-bypass`](./plugins/@sanity/vercel-protection-bypass)               | Setup tool for Vercel Deployment Protection in previews  |
+| [`sanity-plugin-aprimo`](./plugins/sanity-plugin-aprimo)                                       | Aprimo asset selector integration                        |
+| [`sanity-plugin-asset-source-unsplash`](./plugins/sanity-plugin-asset-source-unsplash)         | Use Unsplash images directly in Sanity Studio            |
+| [`sanity-plugin-bynder-input`](./plugins/sanity-plugin-bynder-input)                           | Bynder asset picker integration                          |
+| [`sanity-plugin-graph-view`](./plugins/sanity-plugin-graph-view)                               | Visual graph tool for exploring content relationships    |
+| [`sanity-plugin-iframe-pane`](./plugins/sanity-plugin-iframe-pane)                             | Display external URLs in a Studio pane                   |
+| [`sanity-plugin-internationalized-array`](./plugins/sanity-plugin-internationalized-array)     | Store localized fields in arrays to save attributes      |
+| [`sanity-plugin-markdown`](./plugins/sanity-plugin-markdown)                                   | Markdown editor input                                    |
+| [`sanity-plugin-workflow`](./plugins/sanity-plugin-workflow)                                   | Custom content publishing workflow example               |
+| [`sanity-plugin-workspace-home`](./plugins/sanity-plugin-workspace-home)                       | Home screen for multi-workspace studios                  |
 
 ## Contributing
 


### PR DESCRIPTION
### Description
Updates the current plugins section in the readme.
Modifies the contributing and agent readme files so they remember to do this.


| Plugin                                                                                         | Description                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`@sanity/assist`](./plugins/@sanity/assist)                                                   | AI-powered writing and translation assistance for Studio |
| [`@sanity/code-input`](./plugins/@sanity/code-input)                                           | Code editor input powered by CodeMirror                  |
| [`@sanity/color-input`](./plugins/@sanity/color-input)                                         | Color picker input for Sanity Studio                     |
| [`@sanity/debug-live-sync-tags`](./plugins/@sanity/debug-live-sync-tags)                       | Debug tool for inspecting live sync tags                 |
| [`@sanity/debug-preview-url-secret-plugin`](./plugins/@sanity/debug-preview-url-secret-plugin) | Debug tool for preview URL secrets and their status      |
| [`@sanity/document-internationalization`](./plugins/@sanity/document-internationalization)     | Document-level translations linked by a shared reference |
| [`@sanity/language-filter`](./plugins/@sanity/language-filter)                                 | Filter localized fields by language                      |
| [`@sanity/presets`](./plugins/@sanity/presets)                                                 | Experimental preset patterns for Sanity Studio           |
| [`@sanity/rich-date-input`](./plugins/@sanity/rich-date-input)                                 | Timezone-aware datetime input for Sanity Studio          |
| [`@sanity/studio-secrets`](./plugins/@sanity/studio-secrets)                                   | Manage Studio secrets at runtime                         |
| [`@sanity/vercel-protection-bypass`](./plugins/@sanity/vercel-protection-bypass)               | Setup tool for Vercel Deployment Protection in previews  |
| [`sanity-plugin-aprimo`](./plugins/sanity-plugin-aprimo)                                       | Aprimo asset selector integration                        |
| [`sanity-plugin-asset-source-unsplash`](./plugins/sanity-plugin-asset-source-unsplash)         | Use Unsplash images directly in Sanity Studio            |
| [`sanity-plugin-bynder-input`](./plugins/sanity-plugin-bynder-input)                           | Bynder asset picker integration                          |
| [`sanity-plugin-graph-view`](./plugins/sanity-plugin-graph-view)                               | Visual graph tool for exploring content relationships    |
| [`sanity-plugin-iframe-pane`](./plugins/sanity-plugin-iframe-pane)                             | Display external URLs in a Studio pane                   |
| [`sanity-plugin-internationalized-array`](./plugins/sanity-plugin-internationalized-array)     | Store localized fields in arrays to save attributes      |
| [`sanity-plugin-markdown`](./plugins/sanity-plugin-markdown)                                   | Markdown editor input                                    |
| [`sanity-plugin-workflow`](./plugins/sanity-plugin-workflow)                                   | Custom content publishing workflow example               |
| [`sanity-plugin-workspace-home`](./plugins/sanity-plugin-workspace-home)                       | Home screen for multi-workspace studios                  |


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->
