### PR TITLE
fix(test-studio): add missing `ctaType` preset

### DIFF
--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -1,5 +1,6 @@
 import {
   CTA_TYPE_NAME,
+  ctaType,
   LINK_TYPE_NAME,
   linkType,
   PAGE_TYPE_NAME,
@@ -43,6 +44,7 @@ export const presetsWorkspace = definePlugin(() => ({
       linkType({
         internalTypes: [PAGE_TYPE_NAME],
       }),
+      ctaType(),
       pageType({
         pageBuilderBlocks: ['blockquote'],
       }),


### PR DESCRIPTION
### Description

#811 added a reference to the `core.presets.cta` in the Test Studio schema, but did not create an instance of that type. This causes Studio to crash.

### What to review

Added `ctaType` instanced.

### Testing

Test Studio renders.