### PR TITLE
fix(internationalized-array): respect document-level read-only state

### DIFF
--- a/.changeset/i18n-array-readonly-fix.md
+++ b/.changeset/i18n-array-readonly-fix.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Fix document-level read-only state not being respected by add-language buttons and field actions

--- a/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.test.tsx
@@ -9,6 +9,7 @@ import DocumentAddButtons from './DocumentAddButtons'
 const mockOnChange = vi.fn()
 const mockToastPush = vi.fn()
 const mockGetFormValue = vi.fn()
+let mockFormState: Record<string, unknown> | undefined
 
 vi.mock('sanity', () => ({
   isSanityDocument: vi.fn(
@@ -34,6 +35,7 @@ vi.mock('sanity', () => ({
 vi.mock('sanity/structure', () => ({
   useDocumentPane: vi.fn(() => ({
     onChange: mockOnChange,
+    formState: mockFormState,
   })),
 }))
 
@@ -68,6 +70,7 @@ describe('DocumentAddButtons', () => {
     mockOnChange.mockClear()
     mockToastPush.mockClear()
     mockGetFormValue.mockReset()
+    mockFormState = undefined
   })
 
   test('renders heading and add buttons', () => {
@@ -81,8 +84,7 @@ describe('DocumentAddButtons', () => {
     expect(screen.getByTestId('add-de')).toBeInTheDocument()
   })
 
-  test('shows error toast when document has no internationalized fields', async () => {
-    // Document with no internationalized array fields
+  test('shows warning toast when document has no internationalized fields', async () => {
     const docValue = {
       _id: 'doc1',
       _type: 'article',
@@ -124,7 +126,6 @@ describe('DocumentAddButtons', () => {
 
     fireEvent.click(screen.getByTestId('add-fr'))
 
-    // onChange should have been called with patches
     expect(mockOnChange).toHaveBeenCalledWith([
       {
         type: 'setIfMissing',
@@ -174,7 +175,7 @@ describe('DocumentAddButtons', () => {
     mockGetFormValue.mockReturnValue(docValue)
     render(<DocumentAddButtons />, {wrapper: ThemeWrapper})
     fireEvent.click(screen.getByTestId('add-fr'))
-    // onChange should have been called with patches
+
     expect(mockOnChange).toHaveBeenCalledWith([
       {
         type: 'setIfMissing',
@@ -213,6 +214,17 @@ describe('DocumentAddButtons', () => {
     ])
   })
 
+  test('disables add buttons when document formState is readOnly', () => {
+    mockFormState = {readOnly: true}
+    mockGetFormValue.mockReturnValue(undefined)
+    render(<DocumentAddButtons />, {wrapper: ThemeWrapper})
+
+    expect(screen.getByTestId('add-en')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-fr')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-es')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-de')).toHaveAttribute('data-disabled', 'true')
+  })
+
   test('skips fields that already have the selected language translation', async () => {
     const docValue = {
       _id: 'doc1',
@@ -235,8 +247,7 @@ describe('DocumentAddButtons', () => {
     // Add 'en' again - should be filtered out as already existing
     fireEvent.click(screen.getByTestId('add-en'))
 
-    // Since all fields already have 'en', the toast should show an error
-    // (the filter reduces to 0 items)
+    // All fields already have 'en', so no eligible fields remain
     expect(mockToastPush).toHaveBeenCalledWith({
       status: 'warning',
       title: 'No missing translations for English found.',

--- a/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.tsx
@@ -42,10 +42,10 @@ export default function DocumentAddButtons(): ReactElement {
   const {filteredLanguages} = useInternationalizedArrayContext()
 
   const toast = useToast()
-  const {onChange} = useDocumentPane()
+  const {onChange, formState} = useDocumentPane()
   const schema = useSchema()
 
-  // Helper function to determine if a field should be initialized as an array
+  // Array-based types (e.g. Portable Text) need [] as initial value, not undefined
   const getInitialValueForType = useCallback(
     (typeName: string): unknown => {
       if (!typeName) return undefined
@@ -138,13 +138,12 @@ export default function DocumentAddButtons(): ReactElement {
         return
       }
 
-      // Write a new patch for each empty field
+      // Build patches for each field missing the selected language
       const patches: (FormSetIfMissingPatch | FormInsertPatch)[] = []
 
       for (const toTranslate of removeDuplicates) {
         const path = toTranslate.path
 
-        // Get the appropriate initial value for this field type
         const initialValue = getInitialValueForType(toTranslate._type)
 
         const ifMissing = setIfMissing([], path)
@@ -154,7 +153,7 @@ export default function DocumentAddButtons(): ReactElement {
               _key: randomKey(),
               [LANGUAGE_FIELD_NAME]: languageId,
               _type: toTranslate._type,
-              value: initialValue, // Use the determined initial value instead of undefined
+              value: initialValue,
             },
           ],
           'after',
@@ -175,7 +174,11 @@ export default function DocumentAddButtons(): ReactElement {
           Add translation to internationalized fields
         </Text>
       </Box>
-      <AddButtons readOnly={false} handleClick={handleDocumentButtonClick} languagesInUse={[]} />
+      <AddButtons
+        readOnly={Boolean(formState?.readOnly)}
+        handleClick={handleDocumentButtonClick}
+        languagesInUse={[]}
+      />
     </Stack>
   )
 }

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -7,7 +7,6 @@ import {createValues, MOCK_INTERNATIONALIZED_ARRAY_CONTEXT, MOCK_LANGUAGES} from
 const mockToastPush = vi.fn()
 const mockGetFormValue = vi.fn()
 
-// Mock sanity hooks and components
 vi.mock('sanity', () => ({
   useFormValue: vi.fn(() => 'article'),
   useGetFormValue: vi.fn(() => mockGetFormValue),
@@ -54,7 +53,6 @@ vi.mock('./InternationalizedArrayContext', () => ({
   })),
 }))
 
-// Mock useToast from @sanity/ui to avoid missing ToastProvider context
 vi.mock('@sanity/ui', async (importOriginal) => {
   const original = await importOriginal<typeof import('@sanity/ui')>()
   return {
@@ -373,7 +371,6 @@ describe('InternationalizedArray', () => {
 
     renderInternationalizedArray(props)
 
-    // The useEffect should detect out-of-order and call onChange(set(reordered))
     expect(onChange).toHaveBeenCalled()
     expect(onChange).toHaveBeenCalledWith({
       type: 'set',
@@ -406,7 +403,6 @@ describe('InternationalizedArray', () => {
 
     renderInternationalizedArray(props)
 
-    // Should NOT reorder because documentReadOnly is true
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -472,7 +468,6 @@ describe('InternationalizedArray', () => {
 
     renderInternationalizedArray(props)
 
-    // Should not add defaults while deleting
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -487,10 +482,9 @@ describe('InternationalizedArray', () => {
 
     renderInternationalizedArray(props)
 
-    // Give the setTimeout a chance to fire
-    await new Promise((r) => setTimeout(r, 10))
+    // Allow the scheduled setTimeout in the useEffect to fire
+    await new Promise((resolve) => setTimeout(resolve, 10))
 
-    // Should not add defaults when documentReadOnly is true
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -507,7 +501,6 @@ describe('InternationalizedArray', () => {
     expect(screen.getByTestId('add-fr')).toBeInTheDocument()
     expect(screen.getByTestId('add-es')).toBeInTheDocument()
     expect(screen.getByTestId('add-de')).toBeInTheDocument()
-    // Add buttons should still be visible (individual language buttons)
     expect(screen.queryByTestId('add-all-languages')).not.toBeInTheDocument()
   })
 
@@ -522,7 +515,25 @@ describe('InternationalizedArray', () => {
 
     renderInternationalizedArray(props)
 
-    // Add buttons should be disabled
+    expect(screen.getByTestId('add-en')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-fr')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-es')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-de')).toHaveAttribute('data-disabled', 'true')
+    expect(screen.getByTestId('add-all-languages')).toHaveAttribute('data-disabled', 'true')
+  })
+
+  test('disables add buttons when document is readOnly (props.readOnly)', () => {
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue(
+      MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+    )
+
+    const props = createMockArrayProps({
+      readOnly: true,
+      schemaType: {name: 'internationalizedArrayString', readOnly: false},
+    })
+
+    renderInternationalizedArray(props)
+
     expect(screen.getByTestId('add-en')).toHaveAttribute('data-disabled', 'true')
     expect(screen.getByTestId('add-fr')).toHaveAttribute('data-disabled', 'true')
     expect(screen.getByTestId('add-es')).toHaveAttribute('data-disabled', 'true')

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -55,7 +55,7 @@ export default function InternationalizedArray(
   const value = _value as InternationalizedArrayItem[]
   const itemsNeedingMigration = value?.filter((v) => !v[LANGUAGE_FIELD_NAME]) ?? []
   const shouldMigrateArray = itemsNeedingMigration.length > 0
-  const readOnly = typeof schemaType.readOnly === 'boolean' ? schemaType.readOnly : false
+  const readOnly = Boolean(documentReadOnly) || schemaType.readOnly === true
   const toast = useToast()
 
   const getFormValue = useGetFormValue()
@@ -76,7 +76,7 @@ export default function InternationalizedArray(
   const usingBuiltInLanguageFilter =
     typeof documentType === 'string' && builtInLanguageFilter.documentTypes.includes(documentType)
 
-  // TODO:Is this redundant? The filter plugin is already filtering the members, why do we also need to call it at this level.
+  // TODO: Is this redundant? The filter plugin already filters members at its own level.
   const filteredMembers = useMemo(
     () =>
       usingLanguageFilterPlugin || usingBuiltInLanguageFilter
@@ -94,11 +94,9 @@ export default function InternationalizedArray(
             if (!valueMember || valueMember.kind !== 'field') {
               return false
             }
-            // Yes, this is a mess but it's necessary to support both the built-in language filter and the language filter plugin.
-            // If they are using the built-in method it's better to pass the languages to the filter so we can return the fields that are
-            // not using a valid language id instead of hiding them from the users.
-            // We can't do that with the language filter plugin.
-            // Also, the built in method is better because the filter function will only run once.
+            // The built-in filter receives the full languages list so it can
+            // surface fields with invalid language IDs rather than hiding them.
+            // The language filter plugin does not support this.
             return usingBuiltInLanguageFilter
               ? internationalizedArrayLanguageFilter(
                   member.item.schemaType,
@@ -173,7 +171,7 @@ export default function InternationalizedArray(
         .filter((language) => languages.find((l) => l.id === language))
       // Account for strict mode by scheduling the update
       const timeout = setTimeout(() => {
-        if (!documentReadOnly) handleAddLanguages(languagesToAdd)
+        if (!readOnly) handleAddLanguages(languagesToAdd)
       })
       return () => clearTimeout(timeout)
     }
@@ -184,7 +182,7 @@ export default function InternationalizedArray(
     defaultLanguages,
     addedLanguages,
     languages,
-    documentReadOnly,
+    readOnly,
     shouldMigrateArray,
   ])
 
@@ -248,10 +246,10 @@ export default function InternationalizedArray(
 
   // Automatically restore order of fields
   useEffect(() => {
-    if (languagesOutOfOrder.length > 0 && allKeysAreLanguages && !documentReadOnly) {
+    if (languagesOutOfOrder.length > 0 && allKeysAreLanguages && !readOnly) {
       handleRestoreOrder()
     }
-  }, [languagesOutOfOrder, allKeysAreLanguages, handleRestoreOrder, documentReadOnly])
+  }, [languagesOutOfOrder, allKeysAreLanguages, handleRestoreOrder, readOnly])
 
   // compare value keys with possible languages
   const allLanguagesArePresent = useMemo(

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
@@ -13,6 +13,7 @@ import {internationalizedArrayFieldAction} from './index'
 
 const mockUseFormValue = vi.fn()
 const mockOnChange = vi.fn()
+let mockFormState: Record<string, unknown> | undefined
 
 vi.mock('sanity', async (importOriginal) => {
   const original = await importOriginal<typeof import('sanity')>()
@@ -25,6 +26,7 @@ vi.mock('sanity', async (importOriginal) => {
 vi.mock('sanity/structure', () => ({
   useDocumentPane: vi.fn(() => ({
     onChange: mockOnChange,
+    formState: mockFormState,
   })),
 }))
 
@@ -60,6 +62,7 @@ describe('internationalizedArrayFieldAction', () => {
   beforeEach(() => {
     mockUseFormValue.mockReturnValue(undefined)
     mockOnChange.mockClear()
+    mockFormState = undefined
     vi.mocked(useInternationalizedArrayContext).mockReturnValue(
       MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
     )
@@ -379,5 +382,38 @@ describe('internationalizedArrayFieldAction', () => {
         },
       ],
     })
+  })
+
+  test('all translate actions disabled when document is readOnly', () => {
+    mockFormState = {readOnly: true}
+    mockUseFormValue.mockReturnValue(undefined)
+
+    const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
+
+    const fieldGroup = result.current.type === 'group' ? result.current : undefined
+    if (!fieldGroup) {
+      throw new Error('Field group not found')
+    }
+
+    fieldGroup.children.filter(isActionItem).forEach((action) => {
+      expect(action.disabled).toBe(true)
+    })
+  })
+
+  test('add-missing action disabled when document is readOnly', () => {
+    mockFormState = {readOnly: true}
+    mockUseFormValue.mockReturnValue(undefined)
+
+    const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
+
+    const fieldGroup = result.current.type === 'group' ? result.current : undefined
+    if (!fieldGroup) {
+      throw new Error('Field group not found')
+    }
+    const addMissing = fieldGroup.children[fieldGroup.children.length - 1]!
+    if (!isActionItem(addMissing)) {
+      throw new Error('Add missing action is not an action item')
+    }
+    expect(addMissing.disabled).toBe(true)
   })
 })

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
@@ -27,13 +27,13 @@ const createTranslateFieldActions: (
   languages.map((language) => {
     // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
     const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
+    const {onChange, formState} = useDocumentPane()
     const disabled =
-      value && Array.isArray(value)
+      Boolean(formState?.readOnly) ||
+      (value && Array.isArray(value)
         ? Boolean(value?.find((item) => item[LANGUAGE_FIELD_NAME] === language.id))
-        : false
+        : false)
     const hidden = !filteredLanguages.some((f) => f.id === language.id)
-
-    const {onChange} = useDocumentPane()
 
     const onAction = useCallback(() => {
       const {schemaType, path} = fieldActionProps
@@ -70,10 +70,10 @@ const AddMissingTranslationsFieldAction: (
 ) => DocumentFieldActionItem = (fieldActionProps, {languages, filteredLanguages}) => {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
   const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
-  const disabled = value && value.length === filteredLanguages.length
+  const {onChange, formState} = useDocumentPane()
+  const disabled =
+    Boolean(formState?.readOnly) || (value && value.length === filteredLanguages.length)
   const hidden = checkAllLanguagesArePresent(filteredLanguages, value)
-
-  const {onChange} = useDocumentPane()
 
   const onAction = useCallback(() => {
     const {schemaType, path} = fieldActionProps


### PR DESCRIPTION
### Description

Fixes [SAPP-3353](https://linear.app/sanity/issue/SAPP-3353/internationalized-array-plugin-does-not-respect-read-only-state) - the internationalized array plugin ignored document-level read-only state, allowing users to add languages to fields that should be locked.

When a document was read-only (via `readOnly: true`, permissions, or role-based access), Sanity's core form correctly disabled text inputs, but the plugin's own buttons (add language, add missing languages, field actions) remained interactive.

Root cause: three locations derived read-only state incorrectly:
- `InternationalizedArray.tsx` only checked `schemaType.readOnly`, ignoring `props.readOnly` (the resolved document-level state)
- `DocumentAddButtons.tsx` hardcoded `readOnly={false}`
- `fieldActions/index.ts` had no read-only checks at all

### What to review

- `InternationalizedArray.tsx` - combines `props.readOnly` with `schemaType.readOnly` into a single flag used by buttons and auto-mutation effects (reorder, default languages)
- `DocumentAddButtons.tsx` - reads `formState.readOnly` from `useDocumentPane()` instead of hardcoding `false`
- `fieldActions/index.ts` - adds `formState.readOnly` to `disabled` conditions for both per-language and "add missing" actions
- New tests in all three areas

### Testing

- `pnpm build` passes (22/22 plugin packages)
- `pnpm test` passes (473/473 tests, including 5 new read-only tests)
- `pnpm lint` passes (no new errors)
- Manual verification: set `readOnly: true` on `internationalizedPost` document type in test studio, confirmed all add-language buttons and field actions are disabled
- Manual verification: removed `readOnly: true`, confirmed buttons work normally (no regression)