### PR TITLE
fix(repo): `import/no-commonjs` Oxlint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -87,7 +87,7 @@
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-type-arguments": "error",
     "typescript/prefer-ts-expect-error": "error",
-    "import/no-commonjs ": "error",
+    "import/no-commonjs": "error",
     "import/no-unassigned-import": ["error", {"allow": ["**/*.css"]}],
     "no-restricted-globals": [
       "error",


### PR DESCRIPTION
### Description

The `import/no-commonjs` rule name incorrectly contained an empty character before the end of the string, causing the following error when running Oxlint:

```
 Rule 'no-commonjs ' not found in plugin 'import'
```

[Example](https://github.com/sanity-io/plugins/actions/runs/24334125791/job/71046632760?pr=805#step:4:19).

### What to review

Oxlint config.

### Testing

Oxlint runs successfully.