### PR TITLE
feat(presets): rich text preset with configuration for other preset embedding

### DIFF
--- a/.changeset/presets-rich-text.md
+++ b/.changeset/presets-rich-text.md
@@ -2,4 +2,4 @@
 '@sanity/presets': minor
 ---
 
-Add `defineRichText` for Portable Text fields with composable link annotations, image blocks, and inline CTA objects. Embeds are on by default and can be disabled via `embeds: false` or toggled individually (e.g. `embeds: {cta: false}`). Embedded presets inherit registry-level configuration.
+Add `defineRichText` for Portable Text fields with composable link annotations, image blocks, and inline CTA objects. Embedded objects are on by default and can be disabled via `objects: false` or toggled individually (e.g. `objects: {cta: false}`). Embedded presets inherit registry-level configuration.

--- a/.changeset/presets-rich-text.md
+++ b/.changeset/presets-rich-text.md
@@ -1,0 +1,5 @@
+---
+'@sanity/presets': minor
+---
+
+Add `defineRichText` for Portable Text fields with composable link annotations, image blocks, and inline CTA objects. Embeds are on by default and can be disabled via `embeds: false` or toggled individually (e.g. `embeds: {cta: false}`). Embedded presets inherit registry-level configuration.

--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -137,7 +137,7 @@ export const presetsWorkspace = definePlugin(() => ({
           ],
         },
       }),
-      // Defaults enable all three embeds: link, image, and cta.
+      // Defaults enable all three embedded objects: link, image, and cta.
       defineRichText({
         name: 'richTextDefaults',
         title: 'Rich text (defaults)',
@@ -145,7 +145,7 @@ export const presetsWorkspace = definePlugin(() => ({
       defineRichText({
         name: 'richTextMinimal',
         title: 'Rich text (minimal)',
-        embeds: false,
+        objects: false,
       }),
       // Presets aren't intend to replace all content modelling. You'll likely
       // still need to use `defineDocument` and `defineType` to add custom

--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -6,7 +6,7 @@ import {definePlugin, defineType, defineField} from 'sanity'
 // functions (such as `definePage`) that produce schema types.
 //
 // A convenient pattern is to destructure the `define<type>` functions.
-const {defineImage, definePage, defineLink} = createPresetsRegistry({
+const {defineImage, definePage, defineLink, defineRichText} = createPresetsRegistry({
   link: {
     // Presets can be globally configured. Here, `link.internalTypes` is
     // configured to include the "corePresetsTest" document type in all
@@ -84,6 +84,12 @@ export const presetsWorkspace = definePlugin(() => ({
             // created by the preset itself.
             group: 'metadata',
           }),
+          defineField({
+            name: 'body',
+            title: 'Body',
+            type: 'richTextDefaults',
+            group: 'main',
+          }),
         ],
         map: {
           // Map hooks serve as an escape hatch, allowing developers to override
@@ -130,6 +136,16 @@ export const presetsWorkspace = definePlugin(() => ({
             ...fields,
           ],
         },
+      }),
+      // Defaults enable all three embeds: link, image, and cta.
+      defineRichText({
+        name: 'richTextDefaults',
+        title: 'Rich text (defaults)',
+      }),
+      defineRichText({
+        name: 'richTextMinimal',
+        title: 'Rich text (minimal)',
+        embeds: false,
       }),
       // Presets aren't intend to replace all content modelling. You'll likely
       // still need to use `defineDocument` and `defineType` to add custom

--- a/plugins/@sanity/presets/README.md
+++ b/plugins/@sanity/presets/README.md
@@ -28,7 +28,7 @@ Check back later, or watch the repository for updates.
 - `defineCta` — call-to-action with an inline link and semantic importance level
 - `defineSeo` — search engine metadata (title, description, Open Graph image)
 - `defineImage` — image with optional alt text, caption, and hotspot
-- `defineRichText` — Portable Text with link annotations, image blocks, and CTA inline objects; embeds default on, opt out with `embeds: false` or `embeds: {link: false}`
+- `defineRichText` — Portable Text with link annotations, image blocks, and CTA inline objects; embedded objects default on, opt out with `objects: false` or `objects: {link: false}`
 
 **When to use presets:**
 
@@ -303,7 +303,7 @@ defineImage({
 
 ### Rich text
 
-The rich text preset produces a Portable Text array type with link annotations, image blocks, and inline call-to-action (CTA) objects. All three embeds are on by default.
+The rich text preset produces a Portable Text array type with link annotations, image blocks, and inline call-to-action (CTA) objects. All three embedded objects are on by default.
 
 ```ts
 defineRichText({
@@ -312,9 +312,9 @@ defineRichText({
 })
 ```
 
-**Embeds:**
+**Embedded objects:**
 
-| Embed   | Type                     | Description                                                 |
+| Object  | Type                     | Description                                                 |
 | ------- | ------------------------ | ----------------------------------------------------------- |
 | `link`  | Portable Text annotation | Adds the link preset as an inline annotation on blocks.     |
 | `image` | Array member             | Adds the image preset as a block-level member of the array. |
@@ -322,31 +322,31 @@ defineRichText({
 
 **Options:**
 
-| Option   | Type                                                          | Default | Description                                                                    |
-| -------- | ------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
-| `embeds` | `boolean \| {link?: boolean, image?: boolean, cta?: boolean}` | `true`  | Toggles embeds on or off. Pass `false` to disable all, or an object per embed. |
+| Option    | Type                                                          | Default | Description                                                                              |
+| --------- | ------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `objects` | `boolean \| {link?: boolean, image?: boolean, cta?: boolean}` | `true`  | Toggles embedded objects on or off. Pass `false` to disable all, or an object per entry. |
 
-To disable all embeds for a plain Portable Text field:
+To disable all embedded objects for a plain Portable Text field:
 
 ```ts
 defineRichText({
   name: 'plainBody',
-  embeds: false,
+  objects: false,
 })
 ```
 
-To disable individual embeds:
+To disable individual embedded objects:
 
 ```ts
 defineRichText({
   name: 'body',
-  embeds: {cta: false},
+  objects: {cta: false},
 })
 ```
 
 #### Configuring the embedded presets
 
-Configure each embed's options (link `internalTypes`, image `altText`, and so on) at the registry level. Those options cascade into every rich text field:
+Configure each object's options (link `internalTypes`, image `altText`, and so on) at the registry level. Those options cascade into every rich text field:
 
 ```ts
 const {defineRichText} = createPresetsRegistry({
@@ -360,7 +360,7 @@ const {defineRichText} = createPresetsRegistry({
 })
 ```
 
-The `embeds` option only toggles embeds on or off. To reshape the array members on a specific rich text field, use the [map hooks escape hatch](#reserve-map-hooks-for-when-you-need-full-control).
+The `objects` option only toggles embedded objects on or off. To reshape the array members on a specific rich text field, use the [map hooks escape hatch](#reserve-map-hooks-for-when-you-need-full-control).
 
 ## Recommended patterns
 

--- a/plugins/@sanity/presets/README.md
+++ b/plugins/@sanity/presets/README.md
@@ -28,7 +28,7 @@ Check back later, or watch the repository for updates.
 - `defineCta` — call-to-action with an inline link and semantic importance level
 - `defineSeo` — search engine metadata (title, description, Open Graph image)
 - `defineImage` — image with optional alt text, caption, and hotspot
-- `defineRichText` — Portable Text with configurable annotations and blocks _(coming soon)_
+- `defineRichText` — Portable Text with link annotations, image blocks, and CTA inline objects; embeds default on, opt out with `embeds: false` or `embeds: {link: false}`
 
 **When to use presets:**
 
@@ -303,9 +303,64 @@ defineImage({
 
 ### Rich text
 
-> The rich text preset is under development on a separate branch and is not yet available. This section will be updated when it ships.
+The rich text preset produces a Portable Text array type with link annotations, image blocks, and inline call-to-action (CTA) objects. All three embeds are on by default.
 
-The rich text preset will produce a Portable Text array type with configurable block styles, decorators, annotations (including links composed from the link preset), and inline/block-level objects.
+```ts
+defineRichText({
+  name: 'body',
+  title: 'Body',
+})
+```
+
+**Embeds:**
+
+| Embed   | Type                     | Description                                                 |
+| ------- | ------------------------ | ----------------------------------------------------------- |
+| `link`  | Portable Text annotation | Adds the link preset as an inline annotation on blocks.     |
+| `image` | Array member             | Adds the image preset as a block-level member of the array. |
+| `cta`   | Inline object            | Adds the CTA preset as an inline object within blocks.      |
+
+**Options:**
+
+| Option   | Type                                                          | Default | Description                                                                    |
+| -------- | ------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `embeds` | `boolean \| {link?: boolean, image?: boolean, cta?: boolean}` | `true`  | Toggles embeds on or off. Pass `false` to disable all, or an object per embed. |
+
+To disable all embeds for a plain Portable Text field:
+
+```ts
+defineRichText({
+  name: 'plainBody',
+  embeds: false,
+})
+```
+
+To disable individual embeds:
+
+```ts
+defineRichText({
+  name: 'body',
+  embeds: {cta: false},
+})
+```
+
+#### Configuring the embedded presets
+
+Configure each embed's options (link `internalTypes`, image `altText`, and so on) at the registry level. Those options cascade into every rich text field:
+
+```ts
+const {defineRichText} = createPresetsRegistry({
+  link: {
+    internalTypes: ['page', 'post'],
+  },
+  image: {
+    altText: true,
+    caption: false,
+  },
+})
+```
+
+The `embeds` option only toggles embeds on or off. To reshape the array members on a specific rich text field, use the [map hooks escape hatch](#reserve-map-hooks-for-when-you-need-full-control).
 
 ## Recommended patterns
 

--- a/plugins/@sanity/presets/src/presets/cta-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/cta-type/index.ts
@@ -2,7 +2,7 @@ import {defineField, defineType} from 'sanity'
 
 import {definePresetType} from '../../definePresetType'
 
-export const ctaType = definePresetType<{}, 'object'>({
+export const ctaType = definePresetType<{}, 'object', 'preview'>({
   name: 'cta',
   identifier: 'core.cta',
   schemaType: (config, registry) => {
@@ -25,6 +25,19 @@ export const ctaType = definePresetType<{}, 'object'>({
         }),
         ...(fields ?? []),
       ],
+      preview: {
+        select: {
+          linkType: 'link.linkType',
+          url: 'link.url',
+          referenceTitle: 'link.reference.title',
+          referenceName: 'link.reference.name',
+        },
+        prepare({linkType, url, referenceTitle, referenceName}) {
+          const referenceLabel = referenceTitle || referenceName || 'No reference'
+          const title = linkType === 'external' ? url || 'No URL' : referenceLabel
+          return {title, subtitle: 'Button'}
+        },
+      },
     })
   },
 })

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -62,9 +62,11 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           linkType: 'linkType',
           url: 'url',
           referenceTitle: 'reference.title',
+          referenceName: 'reference.name',
         },
-        prepare({linkType, url, referenceTitle}) {
-          const title = linkType === 'external' ? url || 'No URL' : referenceTitle || 'No reference'
+        prepare({linkType, url, referenceTitle, referenceName}) {
+          const referenceLabel = referenceTitle || referenceName || 'No reference'
+          const title = linkType === 'external' ? url || 'No URL' : referenceLabel
 
           return {
             title,

--- a/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
@@ -96,6 +96,7 @@ describe('linkType preview.select', () => {
       linkType: 'linkType',
       url: 'url',
       referenceTitle: 'reference.title',
+      referenceName: 'reference.name',
     })
   })
 })
@@ -112,11 +113,24 @@ describe('linkType preview.prepare', () => {
     expect(result).toEqual({title: 'About Us', subtitle: 'Internal link'})
   })
 
-  test('internal link without reference title shows fallback', ({stubRegistry}) => {
+  test('internal link falls back to reference name when title is missing', ({stubRegistry}) => {
     const schemaType = linkType.schemaType(defaultConfig, stubRegistry)
     const result = callPrepare(schemaType, {
       linkType: 'internal',
       referenceTitle: undefined,
+      referenceName: 'about-us',
+      url: undefined,
+    })
+
+    expect(result).toEqual({title: 'about-us', subtitle: 'Internal link'})
+  })
+
+  test('internal link without reference title or name shows fallback', ({stubRegistry}) => {
+    const schemaType = linkType.schemaType(defaultConfig, stubRegistry)
+    const result = callPrepare(schemaType, {
+      linkType: 'internal',
+      referenceTitle: undefined,
+      referenceName: undefined,
       url: undefined,
     })
 

--- a/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
@@ -2,7 +2,7 @@ import {defineArrayMember, defineType} from 'sanity'
 
 import {definePresetType} from '../../definePresetType'
 
-export interface RichTextEmbedsConfig {
+export interface RichTextObjectsConfig {
   link?: boolean
   image?: boolean
   cta?: boolean
@@ -10,20 +10,21 @@ export interface RichTextEmbedsConfig {
 
 export interface RichTextTypeConfig {
   /**
-   * Toggle embeds. Defaults to all enabled. Pass `false` to disable every
-   * embed, or an object to toggle individual ones (e.g. `{link: false}`).
+   * Toggle the embedded objects (link annotations, image blocks, inline CTAs).
+   * Defaults to all enabled. Pass `false` to disable every object, or an
+   * object to toggle individual ones (e.g. `{link: false}`).
    *
-   * Each embed's options (link `internalTypes`, image `altText`, …) are
+   * Each object's options (link `internalTypes`, image `altText`, …) are
    * configured on `createPresetsRegistry` and cascade into every rich text
    * field. Use `map.of` for per-field structural changes.
    */
-  embeds?: boolean | RichTextEmbedsConfig
+  objects?: boolean | RichTextObjectsConfig
 }
 
-function resolveEmbeds(embeds: RichTextTypeConfig['embeds']): Required<RichTextEmbedsConfig> {
-  if (embeds === false) return {link: false, image: false, cta: false}
-  if (embeds === true || embeds === undefined) return {link: true, image: true, cta: true}
-  const {link = true, image = true, cta = true} = embeds
+function resolveObjects(objects: RichTextTypeConfig['objects']): Required<RichTextObjectsConfig> {
+  if (objects === false) return {link: false, image: false, cta: false}
+  if (objects === true || objects === undefined) return {link: true, image: true, cta: true}
+  const {link = true, image = true, cta = true} = objects
   return {link, image, cta}
 }
 
@@ -31,17 +32,15 @@ export const richTextType = definePresetType<RichTextTypeConfig, 'array', 'of'>(
   name: 'richText',
   identifier: 'core.richText',
   schemaType: (config, registry) => {
-    const {embeds, ...arrayConfig} = config
-    const {link: embedLink, image: embedImage, cta: embedCta} = resolveEmbeds(embeds)
+    const {objects, ...arrayConfig} = config
+    const {link, image, cta} = resolveObjects(objects)
 
     // The annotation name must be 'link' — Portable Text Editor's built-in link UI keys off this name.
-    const linkAnnotation = embedLink
+    const linkAnnotation = link
       ? registry.getPreset('link', {name: 'link', title: 'Link'})
       : undefined
-    const ctaInline = embedCta
-      ? registry.getPreset('cta', {name: 'richTextCta', title: 'Button'})
-      : undefined
-    const imageMember = embedImage
+    const ctaInline = cta ? registry.getPreset('cta', {name: 'cta', title: 'CTA'}) : undefined
+    const imageMember = image
       ? registry.getPreset('image', {name: 'richTextImage', title: 'Image'})
       : undefined
 

--- a/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
@@ -1,0 +1,61 @@
+import {defineArrayMember, defineType} from 'sanity'
+
+import {definePresetType} from '../../definePresetType'
+
+export interface RichTextEmbedsConfig {
+  link?: boolean
+  image?: boolean
+  cta?: boolean
+}
+
+export interface RichTextTypeConfig {
+  /**
+   * Toggle embeds. Defaults to all enabled. Pass `false` to disable every
+   * embed, or an object to toggle individual ones (e.g. `{link: false}`).
+   *
+   * Each embed's options (link `internalTypes`, image `altText`, …) are
+   * configured on `createPresetsRegistry` and cascade into every rich text
+   * field. Use `map.of` for per-field structural changes.
+   */
+  embeds?: boolean | RichTextEmbedsConfig
+}
+
+function resolveEmbeds(embeds: RichTextTypeConfig['embeds']): Required<RichTextEmbedsConfig> {
+  if (embeds === false) return {link: false, image: false, cta: false}
+  if (embeds === true || embeds === undefined) return {link: true, image: true, cta: true}
+  const {link = true, image = true, cta = true} = embeds
+  return {link, image, cta}
+}
+
+export const richTextType = definePresetType<RichTextTypeConfig, 'array', 'of'>({
+  name: 'richText',
+  identifier: 'core.richText',
+  schemaType: (config, registry) => {
+    const {embeds, ...arrayConfig} = config
+    const {link: embedLink, image: embedImage, cta: embedCta} = resolveEmbeds(embeds)
+
+    // The annotation name must be 'link' — Portable Text Editor's built-in link UI keys off this name.
+    const linkAnnotation = embedLink
+      ? registry.getPreset('link', {name: 'link', title: 'Link'})
+      : undefined
+    const ctaInline = embedCta
+      ? registry.getPreset('cta', {name: 'richTextCta', title: 'Button'})
+      : undefined
+    const imageMember = embedImage
+      ? registry.getPreset('image', {name: 'richTextImage', title: 'Image'})
+      : undefined
+
+    const blockMember = defineArrayMember({
+      type: 'block',
+      marks: {annotations: linkAnnotation ? [linkAnnotation] : []},
+      ...(ctaInline && {of: [ctaInline]}),
+    })
+
+    return defineType({
+      title: 'Rich text',
+      ...arrayConfig,
+      type: 'array',
+      of: imageMember ? [blockMember, imageMember] : [blockMember],
+    })
+  },
+})

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -1,0 +1,177 @@
+import {defineField, type FieldDefinition, type SchemaTypeDefinition} from 'sanity'
+import {describe, expect, vi} from 'vitest'
+
+import type {RegistryContext} from '../../definePresetType'
+import {test} from '../../test/fixtures'
+import {richTextType} from './index'
+
+type Member = Record<string, unknown>
+
+interface BlockMember extends Member {
+  marks?: {
+    annotations?: Member[]
+  }
+  of?: Member[]
+}
+
+/**
+ * Stub `RegistryContext` whose `getPreset` tags the returned field with
+ * `__preset` so tests can assert which preset resolved.
+ */
+function makeStubRegistry(): RegistryContext & {
+  getPreset: ReturnType<typeof vi.fn>
+} {
+  const getPreset = vi.fn(
+    (presetName: string, presetConfig?: Record<string, unknown>): FieldDefinition => {
+      const name = typeof presetConfig?.['name'] === 'string' ? presetConfig['name'] : presetName
+      return Object.assign(defineField({name, type: 'object', fields: []}), {
+        __preset: presetName,
+      })
+    },
+  )
+  return {getPreset}
+}
+
+function getOf(typeDef: SchemaTypeDefinition): Member[] {
+  if (!('of' in typeDef) || !typeDef.of) {
+    throw new Error('Expected an array type definition with an of array')
+  }
+  // oxlint-disable-next-line no-unsafe-type-assertion -- test helper narrows to stub shape
+  return typeDef.of as unknown as Member[]
+}
+
+function getBlock(typeDef: SchemaTypeDefinition): BlockMember {
+  const block = getOf(typeDef).find((member) => member['type'] === 'block')
+  if (!block) {
+    throw new Error('Expected a block member in the array')
+  }
+  // oxlint-disable-next-line no-unsafe-type-assertion -- test helper narrows to stub shape
+  return block as unknown as BlockMember
+}
+
+describe('richTextType', () => {
+  test('has the expected name and identifier', () => {
+    expect(richTextType.name).toBe('richText')
+    expect(richTextType.identifier).toBe('core.richText')
+  })
+
+  test('returns an array schema type named richText', () => {
+    const result = richTextType.schemaType({name: 'richText'}, makeStubRegistry())
+
+    expect(result.name).toBe('richText')
+    expect(result.type).toBe('array')
+  })
+
+  test('defaults to embedding link as annotation, image as block, and cta as inline object', () => {
+    const typeDef = richTextType.schemaType({name: 'richText'}, makeStubRegistry())
+    const block = getBlock(typeDef)
+    const ofMembers = getOf(typeDef)
+
+    expect(block.marks?.annotations?.[0]).toMatchObject({__preset: 'link', name: 'link'})
+    expect(block.of?.[0]).toMatchObject({__preset: 'cta', name: 'richTextCta'})
+    expect(ofMembers).toHaveLength(2)
+    expect(ofMembers[0]).toHaveProperty('type', 'block')
+    expect(ofMembers[1]).toMatchObject({__preset: 'image', name: 'richTextImage'})
+  })
+
+  test('embeds: {image: false, cta: false} disables image and inline cta but keeps link', () => {
+    const typeDef = richTextType.schemaType(
+      {name: 'richText', embeds: {image: false, cta: false}},
+      makeStubRegistry(),
+    )
+    const block = getBlock(typeDef)
+    const ofMembers = getOf(typeDef)
+
+    expect(block.of).toBeUndefined()
+    expect(ofMembers).toHaveLength(1)
+    expect(ofMembers[0]).toHaveProperty('type', 'block')
+    expect(block.marks?.annotations?.[0]).toMatchObject({__preset: 'link'})
+  })
+
+  test('embeds: false disables every embed', () => {
+    const typeDef = richTextType.schemaType({name: 'richText', embeds: false}, makeStubRegistry())
+    const block = getBlock(typeDef)
+    const ofMembers = getOf(typeDef)
+
+    expect(block.marks?.annotations).toEqual([])
+    expect(block.of).toBeUndefined()
+    expect(ofMembers).toHaveLength(1)
+  })
+
+  test('embeds: {link: false} disables only the link annotation', () => {
+    const typeDef = richTextType.schemaType(
+      {name: 'richText', embeds: {link: false}},
+      makeStubRegistry(),
+    )
+    const block = getBlock(typeDef)
+    const ofMembers = getOf(typeDef)
+
+    expect(block.marks?.annotations).toEqual([])
+    expect(block.of?.[0]).toMatchObject({__preset: 'cta'})
+    expect(ofMembers[1]).toMatchObject({__preset: 'image'})
+  })
+
+  test('name and title override defaults', () => {
+    const typeDef = richTextType.schemaType({name: 'body', title: 'Body'}, makeStubRegistry())
+
+    expect(typeDef.name).toBe('body')
+    expect(typeDef).toHaveProperty('title', 'Body')
+  })
+})
+
+describe('richTextType via the registry', () => {
+  test('defineRichText resolves link, image, and cta fields from the registry', ({registry}) => {
+    const result = registry.defineRichText({name: 'body'})
+    const ofMembers = getOf(result)
+    const block = getBlock(result)
+
+    expect(ofMembers).toHaveLength(2)
+    expect(ofMembers[0]).toHaveProperty('type', 'block')
+    expect(ofMembers[1]).toMatchObject({
+      name: 'richTextImage',
+      fields: expect.arrayContaining([
+        expect.objectContaining({name: 'image'}),
+        expect.objectContaining({name: 'altText'}),
+      ]),
+    })
+    expect(block.marks?.annotations?.[0]).toMatchObject({
+      name: 'link',
+      fields: expect.arrayContaining([expect.objectContaining({name: 'linkType'})]),
+    })
+    expect(block.of?.[0]).toMatchObject({
+      name: 'richTextCta',
+      fields: expect.arrayContaining([expect.objectContaining({name: 'link'})]),
+    })
+  })
+
+  describe('with registry-level internalTypes', () => {
+    test.override('registryConfig', {link: {internalTypes: ['marketingPage']}})
+
+    test('link annotations inherit internalTypes from registry config', ({registry}) => {
+      const result = registry.defineRichText({name: 'body'})
+      const block = getBlock(result)
+
+      expect(block.marks?.annotations?.[0]).toMatchObject({
+        name: 'link',
+        fields: expect.arrayContaining([
+          expect.objectContaining({name: 'reference', to: [{type: 'marketingPage'}]}),
+        ]),
+      })
+    })
+  })
+})
+
+describe('richTextType map hooks', () => {
+  test('map.of transforms the final of array', ({registry}) => {
+    const result = registry.defineRichText({
+      name: 'body',
+      map: {
+        of: (members = []) => members.filter((member) => member.type === 'block'),
+      },
+    })
+    const ofMembers = getOf(result)
+
+    expect(ofMembers).toHaveLength(1)
+    expect(ofMembers[0]).toHaveProperty('type', 'block')
+  })
+})

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -68,15 +68,15 @@ describe('richTextType', () => {
     const ofMembers = getOf(typeDef)
 
     expect(block.marks?.annotations?.[0]).toMatchObject({__preset: 'link', name: 'link'})
-    expect(block.of?.[0]).toMatchObject({__preset: 'cta', name: 'richTextCta'})
+    expect(block.of?.[0]).toMatchObject({__preset: 'cta', name: 'cta'})
     expect(ofMembers).toHaveLength(2)
     expect(ofMembers[0]).toHaveProperty('type', 'block')
     expect(ofMembers[1]).toMatchObject({__preset: 'image', name: 'richTextImage'})
   })
 
-  test('embeds: {image: false, cta: false} disables image and inline cta but keeps link', () => {
+  test('objects: {image: false, cta: false} disables image and inline cta but keeps link', () => {
     const typeDef = richTextType.schemaType(
-      {name: 'richText', embeds: {image: false, cta: false}},
+      {name: 'richText', objects: {image: false, cta: false}},
       makeStubRegistry(),
     )
     const block = getBlock(typeDef)
@@ -88,8 +88,8 @@ describe('richTextType', () => {
     expect(block.marks?.annotations?.[0]).toMatchObject({__preset: 'link'})
   })
 
-  test('embeds: false disables every embed', () => {
-    const typeDef = richTextType.schemaType({name: 'richText', embeds: false}, makeStubRegistry())
+  test('objects: false disables every embedded object', () => {
+    const typeDef = richTextType.schemaType({name: 'richText', objects: false}, makeStubRegistry())
     const block = getBlock(typeDef)
     const ofMembers = getOf(typeDef)
 
@@ -98,9 +98,9 @@ describe('richTextType', () => {
     expect(ofMembers).toHaveLength(1)
   })
 
-  test('embeds: {link: false} disables only the link annotation', () => {
+  test('objects: {link: false} disables only the link annotation', () => {
     const typeDef = richTextType.schemaType(
-      {name: 'richText', embeds: {link: false}},
+      {name: 'richText', objects: {link: false}},
       makeStubRegistry(),
     )
     const block = getBlock(typeDef)
@@ -139,7 +139,7 @@ describe('richTextType via the registry', () => {
       fields: expect.arrayContaining([expect.objectContaining({name: 'linkType'})]),
     })
     expect(block.of?.[0]).toMatchObject({
-      name: 'richTextCta',
+      name: 'cta',
       fields: expect.arrayContaining([expect.objectContaining({name: 'link'})]),
     })
   })

--- a/plugins/@sanity/presets/src/registry.tsx
+++ b/plugins/@sanity/presets/src/registry.tsx
@@ -11,10 +11,11 @@ import {ctaType} from './presets/cta-type'
 import {imageType, type ImageTypeConfig} from './presets/image-type'
 import {linkType, type LinkTypeConfig} from './presets/link-type'
 import {pageType, type PageTypeConfig} from './presets/page-type'
+import {richTextType} from './presets/rich-text-type'
 import {seoType} from './presets/seo-type'
 import {recordPresetUsage, registerRegistry} from './telemetry'
 
-const systemPresets = [linkType, ctaType, seoType, imageType, pageType] as const
+const systemPresets = [linkType, ctaType, seoType, imageType, pageType, richTextType] as const
 
 export interface PresetsRegistryConfig {
   link?: LinkTypeConfig
@@ -35,6 +36,7 @@ export interface PresetsRegistry {
   defineSeo: DefineFunction<typeof seoType>
   defineImage: DefineFunction<typeof imageType>
   definePage: DefineFunction<typeof pageType>
+  defineRichText: DefineFunction<typeof richTextType>
 }
 
 export function createPresetsRegistry(config: PresetsRegistryConfig = {}): PresetsRegistry {


### PR DESCRIPTION
### Description

Adds `defineRichText` to `@sanity/presets` - a preset for Portable Text fields with link annotations, image blocks, and CTA inline objects. All three embeds are on by default; pass `embeds: false` or `embeds: {link: false}` to opt out, either globally on `createPresetsRegistry` or per call.

Two supporting fixes so the embeds render cleanly in the PT editor:

- CTA gains a `preview` config - without it, inline CTAs render as raw JSON.
- Link's preview falls back to `reference.name` so references to `definePage` documents (which use `name`, not `title`) preview correctly.

Test-studio gets a `body` field on the existing demo page plus two standalone richText examples. README's bullet for `defineRichText` updated too.

### Design choices and limitations

The `embeds` config intentionally accepts **booleans only** - `embeds: false` or `embeds: {link: false, image: false, cta: false}`. It does not accept per-embed configuration objects (e.g. `embeds: {link: {internalTypes: [...]}}`).

The reasoning:

- Configuration of the composed presets (link, image, cta) belongs at the registry level. `createPresetsRegistry({link: {internalTypes: [...]}})` already cascades into every rich text field's link annotation. Adding a second seam inside `defineRichText` would create two ways to configure the same thing, with non-trivial merge semantics between them.
- For the narrow case where a specific rich text field needs structurally different embeds, `map.of` is the escape hatch.

Known constraints that follow from this:

- You cannot vary embed config per rich text field via `embeds` - all rich text fields in a registry share the same link/image/cta configuration.
- Inline embed names (`richTextCta`, `richTextImage`) and the link annotation name (`link`) are fixed. The link name specifically is load-bearing for the Portable Text Editor's built-in link UI.
- Block-level customisation (decorators, lists, styles) is not exposed as config. Use `map.of` if you need it.

### What to review

- `plugins/@sanity/presets/src/presets/rich-text-type/` - the new preset and tests
- `plugins/@sanity/presets/src/presets/cta-type/index.ts` and `link-type/index.ts` - the preview tweaks
- `dev/test-studio/src/presets/index.tsx` - the demo, additive on top of origin's content

### Testing

New unit testing for rich text. Can also be verified in the test-studio for presets