### PR TITLE
feat(@sanity/presets): add React runtime and restore telemetry

### DIFF
--- a/plugins/@sanity/presets/package.json
+++ b/plugins/@sanity/presets/package.json
@@ -61,6 +61,8 @@
     "styled-components": "catalog:"
   },
   "peerDependencies": {
+    "react": "^19.2",
+    "react-dom": "^19.2",
     "sanity": "^5"
   },
   "engines": {

--- a/plugins/@sanity/presets/src/components/PresetsTelemetryCollector.tsx
+++ b/plugins/@sanity/presets/src/components/PresetsTelemetryCollector.tsx
@@ -1,0 +1,37 @@
+import {useTelemetry} from '@sanity/telemetry/react'
+import {useEffect, type ComponentType} from 'react'
+import type {InputProps} from 'sanity'
+
+import {collectPresetsRegistryTelemetry} from '../telemetry'
+
+type Props = InputProps & {
+  registryId: string
+  userInput?: ComponentType<InputProps>
+}
+
+/**
+ * A transparent input component wrapper that triggers telemetry collection
+ * for the presets registry. Renders the user-provided input component if
+ * supplied, otherwise the default input component unchanged.
+ *
+ * Attached to every schema type produced by a define<Type> function via
+ * components.input. The first instance to render for a given registry id
+ * submits the PresetsAdded telemetry event; subsequent renders are no-ops.
+ */
+export const PresetsTelemetryCollector: ComponentType<Props> = ({
+  registryId,
+  userInput: UserInput,
+  ...props
+}) => {
+  const telemetry = useTelemetry()
+
+  useEffect(() => {
+    collectPresetsRegistryTelemetry(registryId, telemetry)
+  }, [registryId, telemetry])
+
+  if (UserInput) {
+    return <UserInput {...props} />
+  }
+
+  return props.renderDefault(props)
+}

--- a/plugins/@sanity/presets/src/registry.test.tsx
+++ b/plugins/@sanity/presets/src/registry.test.tsx
@@ -168,7 +168,7 @@ describe('preset composition via getPreset', () => {
   })
 })
 
-describe.skip('createPresetsRegistry components.input wrapping', () => {
+describe('createPresetsRegistry components.input wrapping', () => {
   test('user-provided components.input is rendered inside the telemetry wrapper', ({registry}) => {
     const userInput = vi.fn(() => <div data-testid="user-input">User input</div>)
 

--- a/plugins/@sanity/presets/src/registry.tsx
+++ b/plugins/@sanity/presets/src/registry.tsx
@@ -1,7 +1,8 @@
 import {uuid} from '@sanity/uuid'
-import type {FieldDefinition, InputProps, SchemaTypeDefinition} from 'sanity'
 import {type ComponentType} from 'react'
+import type {FieldDefinition, InputProps, SchemaTypeDefinition} from 'sanity'
 
+import {PresetsTelemetryCollector} from './components/PresetsTelemetryCollector'
 import type {
   AnyPresetDefinition,
   PresetDefinition,
@@ -14,7 +15,6 @@ import {linkType, type LinkTypeConfig} from './presets/link-type'
 import {pageType, type PageTypeConfig} from './presets/page-type'
 import {seoType} from './presets/seo-type'
 import {recordPresetUsage, registerRegistry} from './telemetry'
-import { PresetsTelemetryCollector } from './components/PresetsTelemetryCollector'
 
 const systemPresets = [linkType, ctaType, seoType, imageType, pageType] as const
 
@@ -104,44 +104,53 @@ function createDefiner({registryId, preset, config, registry}: CreateDefinerOpti
       registryContext,
     )
 
-    applyMapHooks(schemaType, map)
-    addTelemetryComponent(schemaType, registryId)
-
     // oxlint-disable-next-line no-unsafe-type-assertion -- runtime value is a valid field definition
-    return schemaType as SchemaTypeDefinition & FieldDefinition
+    return applyMapHooks(
+      addTelemetryComponent(schemaType, registryId),
+      map,
+    ) as SchemaTypeDefinition & FieldDefinition
   }
 }
 
-function applyMapHooks(schemaType: SchemaTypeDefinition, map: unknown): void {
-  if (!map || typeof map !== 'object') return
+function applyMapHooks(schemaType: SchemaTypeDefinition, map: unknown): SchemaTypeDefinition {
+  if (!map || typeof map !== 'object') return schemaType
+
+  const mappedSchemaType: Record<string, unknown> = {}
 
   for (const [configName, configValue] of Object.entries(map)) {
     if (typeof configValue !== 'function') {
       continue
     }
 
-    // oxlint-disable-next-line no-unsafe-type-assertion -- map hooks operate on arbitrary schema type properties
-    schemaType[configName as keyof typeof schemaType] = configValue(
-      // oxlint-disable-next-line no-unsafe-type-assertion
+    mappedSchemaType[configName] = configValue(
+      // oxlint-disable-next-line no-unsafe-type-assertion -- map hooks operate on arbitrary schema type properties
       schemaType[configName as keyof typeof schemaType],
     )
   }
+
+  return {...schemaType, ...mappedSchemaType}
 }
 
-function addTelemetryComponent(schemaType: SchemaTypeDefinition, registryId: string): void {
+function addTelemetryComponent(
+  schemaType: SchemaTypeDefinition,
+  registryId: string,
+): SchemaTypeDefinition {
   const existing = 'components' in schemaType ? schemaType.components : undefined
   const existingInput =
     existing && 'input' in existing && typeof existing.input === 'function'
       ? // oxlint-disable-next-line no-unsafe-type-assertion -- presets only produce object/document schema types, whose input components are assignable to ComponentType<InputProps>
         (existing.input as ComponentType<InputProps>)
       : undefined
-  Object.assign(schemaType, {
-    components: Object.assign({}, existing, {
+  // oxlint-disable-next-line no-unsafe-type-assertion -- spreading a discriminated union loses the discriminant; the runtime shape is still a valid SchemaTypeDefinition
+  return {
+    ...schemaType,
+    components: {
+      ...existing,
       input: (props: InputProps) => (
         <PresetsTelemetryCollector {...props} registryId={registryId} userInput={existingInput} />
       ),
-    }),
-  })
+    },
+  } as SchemaTypeDefinition
 }
 
 // Re-export for consumers that previously used these types.

--- a/plugins/@sanity/presets/src/registry.tsx
+++ b/plugins/@sanity/presets/src/registry.tsx
@@ -1,5 +1,6 @@
 import {uuid} from '@sanity/uuid'
-import type {FieldDefinition, SchemaTypeDefinition} from 'sanity'
+import type {FieldDefinition, InputProps, SchemaTypeDefinition} from 'sanity'
+import {type ComponentType} from 'react'
 
 import type {
   AnyPresetDefinition,
@@ -13,6 +14,7 @@ import {linkType, type LinkTypeConfig} from './presets/link-type'
 import {pageType, type PageTypeConfig} from './presets/page-type'
 import {seoType} from './presets/seo-type'
 import {recordPresetUsage, registerRegistry} from './telemetry'
+import { PresetsTelemetryCollector } from './components/PresetsTelemetryCollector'
 
 const systemPresets = [linkType, ctaType, seoType, imageType, pageType] as const
 
@@ -103,6 +105,7 @@ function createDefiner({registryId, preset, config, registry}: CreateDefinerOpti
     )
 
     applyMapHooks(schemaType, map)
+    addTelemetryComponent(schemaType, registryId)
 
     // oxlint-disable-next-line no-unsafe-type-assertion -- runtime value is a valid field definition
     return schemaType as SchemaTypeDefinition & FieldDefinition
@@ -123,6 +126,22 @@ function applyMapHooks(schemaType: SchemaTypeDefinition, map: unknown): void {
       schemaType[configName as keyof typeof schemaType],
     )
   }
+}
+
+function addTelemetryComponent(schemaType: SchemaTypeDefinition, registryId: string): void {
+  const existing = 'components' in schemaType ? schemaType.components : undefined
+  const existingInput =
+    existing && 'input' in existing && typeof existing.input === 'function'
+      ? // oxlint-disable-next-line no-unsafe-type-assertion -- presets only produce object/document schema types, whose input components are assignable to ComponentType<InputProps>
+        (existing.input as ComponentType<InputProps>)
+      : undefined
+  Object.assign(schemaType, {
+    components: Object.assign({}, existing, {
+      input: (props: InputProps) => (
+        <PresetsTelemetryCollector {...props} registryId={registryId} userInput={existingInput} />
+      ),
+    }),
+  })
 }
 
 // Re-export for consumers that previously used these types.


### PR DESCRIPTION
### Description

This branch adds React and React DOM as peer dependencies. The absence of the React runtime broke usage of React hooks, and the code produced by React Compiler. Adding React runtime peer dependencies resolves this.

Telemetry has been restored now this issue is fixed.

This branch also includes a small refactor to avoid mutation in the registry.

### What to review

The presets workspace in a Test Studio production build: document editor should render with no errors.

### Testing

Restored telemetry tests.
