### PR TITLE
feat(@sanity/presets): require `name` in types

### DIFF
--- a/plugins/@sanity/presets/src/types.ts
+++ b/plugins/@sanity/presets/src/types.ts
@@ -2,4 +2,5 @@ import type {DefineSchemaBase, IntrinsicTypeName, PreviewConfig} from 'sanity'
 
 export type PartialSchemaDefinition<TypeName extends IntrinsicTypeName> = Partial<
   DefineSchemaBase<TypeName, TypeName> & {preview: PreviewConfig}
->
+> &
+  Pick<DefineSchemaBase<TypeName, TypeName>, 'name'>


### PR DESCRIPTION
### Description

Building on #859, this branch updates types to enforces the `name` property is provided.