### PR TITLE
fix(@sanity/presets): allow title inference based on user-provided `name`

### DIFF
--- a/.changeset/public-crabs-leave.md
+++ b/.changeset/public-crabs-leave.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": patch
+---
+
+Preset schema type titles are now correctly inferred based on the user-provided `name`.

--- a/plugins/@sanity/presets/src/presets/cta-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/cta-type/index.ts
@@ -9,7 +9,6 @@ export const ctaType = definePresetType<{}, 'object', 'preview'>({
     const {fields, ...objectConfig} = config
 
     return defineType({
-      title: 'Call to action',
       ...objectConfig,
       type: 'object',
       fields: [

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -15,7 +15,6 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
     const {altText = true, caption = true, hotspot = true, fields, ...objectConfig} = config
 
     return defineType({
-      title: 'Image',
       ...objectConfig,
       type: 'object',
       fields: [

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -14,7 +14,6 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
     const referenceTargets = resolvedInternalTypes.map((type) => ({type}))
 
     return defineType({
-      title: 'Link',
       ...objectConfig,
       type: 'object',
       fields: [

--- a/plugins/@sanity/presets/src/presets/page-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/page-type/index.ts
@@ -22,7 +22,6 @@ export const pageType = definePresetType<PageTypeConfig, 'document'>({
     const {pageBuilderBlocks, groups, fields, ...documentConfig} = config
 
     return defineType({
-      title: 'Page',
       ...documentConfig,
       type: 'document',
       groups: [

--- a/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
@@ -51,7 +51,6 @@ export const richTextType = definePresetType<RichTextTypeConfig, 'array', 'of'>(
     })
 
     return defineType({
-      title: 'Rich text',
       ...arrayConfig,
       type: 'array',
       of: imageMember ? [blockMember, imageMember] : [blockMember],

--- a/plugins/@sanity/presets/src/presets/seo-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/seo-type/index.ts
@@ -10,7 +10,6 @@ export const seoType = definePresetType<{}, 'object'>({
     const {fields, ...objectConfig} = config
 
     return defineType({
-      title: 'Web page metadata (SEO)',
       ...objectConfig,
       type: 'object',
       fields: [


### PR DESCRIPTION
### Description

All presets require the `name` property. However, presets were providing their own `title` attribute, breaking the user's expectation that their provided `name` value would be used to infer the title.

We have fixed this by removing the default `title` property from each preset type. Now, the `name` provided by the user is correctly used to infer the title (and can be set explicitly by setting the `title` property).

For example:

```ts
definePage({
  name: 'myPage',
})
```

The title should be inferred as "My Page", not "Page".

However, `title` should take precedence if provided:

```ts
definePage({
  name: 'myPage',
  title: 'Awesome Page',
})
```

The title should be "Awesome Page", not "My Page" or "Page".

### What to review

Removal of default preset default titles.

### Testing

Haven't added tests; the actual inference occurs in Studio core. Tests to assert the presets doesn't set a default `title` seem redundant. We may want to consider adding some tests that verify how the plugin integrates with Studio in the future.