### PR TITLE
feat: per-schemaType language filtering for document-internationalization + internationalized-array (#570)

### DIFF
--- a/.changeset/issue-570-document-internationalization-language-filter.md
+++ b/.changeset/issue-570-document-internationalization-language-filter.md
@@ -1,0 +1,5 @@
+---
+'@sanity/document-internationalization': minor
+---
+
+Add `languageFilter` plugin option to restrict the Translations menu language list per document type. Receives `{schemaType, defaultLanguages}` and returns the subset of languages to render. Only affects the menu UI - badges, templates, and validity checks continue to use the full `supportedLanguages` list. Closes #570.

--- a/.changeset/issue-570-internationalized-array-filter-languages.md
+++ b/.changeset/issue-570-internationalized-array-filter-languages.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-internationalized-array': minor
+---
+
+Add `filterLanguages` plugin option to restrict the add-language buttons (and the "add missing languages" action) per document type. Receives `{schemaType, defaultLanguages}` and returns the subset of languages to render. Composes with `@sanity/language-filter`: the static filter runs first to narrow the universe, then the user's per-session selection is applied on top. Existing array values are never removed or hidden, only the buttons. Companion to `@sanity/document-internationalization`'s `languageFilter` (issue #570).

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,38 @@
+name: Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  workflow_dispatch:
+    inputs:
+      issue_url:
+        description: GitHub issue URL to triage
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  trigger:
+    name: Trigger Miriad triage
+    if: github.event_name == 'workflow_dispatch' || github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'needs-triage')
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      ISSUE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.issue_url || github.event.issue.html_url }}
+      MIRIAD_SPACE_ID: ${{ secrets.MIRIAD_SPACE_ID }}
+      MIRIAD_TOKEN: ${{ secrets.MIRIAD_TOKEN }}
+      MIRIAD_URL: ${{ secrets.MIRIAD_URL }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Trigger issue triage
+        run: node scripts/trigger-triage/src/index.ts --verbose "$ISSUE_URL"

--- a/dev/test-studio/src/document-internationalization/index.tsx
+++ b/dev/test-studio/src/document-internationalization/index.tsx
@@ -4,6 +4,7 @@ import {
   useDuplicateWithTranslationsAction,
 } from '@sanity/document-internationalization'
 import {defineField, definePlugin, defineType} from 'sanity'
+import {internationalizedArray} from 'sanity-plugin-internationalized-array'
 
 // Define a simple lesson schema type for testing document internationalization
 const lessonType = defineType({
@@ -31,13 +32,87 @@ const lessonType = defineType({
   ],
 })
 
+// --- Per-document-type language filter demo (issue #570) -------------------
+//
+// Two document types share the same shared `supportedLanguages` /
+// `languages` lists, but they use the parallel filter options on each plugin
+// to render different language sets in the UI:
+//
+//   - `lfDemoRecipe` is restricted to en + it on BOTH the document-level
+//     Translations menu (`documentInternationalization.languageFilter`) AND
+//     the field-level "Add language" buttons on the body field
+//     (`internationalizedArray.filterLanguages`).
+//   - `lfDemoLesson` has no filter, so all six languages render in both
+//     places.
+//
+// To exercise the demo:
+//   1. Open the `kitchen-sink` workspace.
+//   2. Create a new "Recipe (#570 demo)" document. Click "Translations" in
+//      the toolbar — only English and Italian appear. The Localized title
+//      field's add-language buttons should show only EN and IT too.
+//   3. Create a new "Lesson (#570 demo)" document. The Translations menu
+//      and the add-language buttons both show all six languages.
+
+const SHARED_LANGUAGES = [
+  {id: 'en', title: 'English'},
+  {id: 'es', title: 'Spanish'},
+  {id: 'fr', title: 'French'},
+  {id: 'de', title: 'German'},
+  {id: 'it', title: 'Italian'},
+  {id: 'pt', title: 'Portuguese'},
+]
+
+const RECIPE_LANGUAGES = new Set(['en', 'it'])
+
+const lfDemoRecipe = defineType({
+  name: 'lfDemoRecipe',
+  title: 'Recipe (#570 demo)',
+  type: 'document',
+  fields: [
+    defineField({name: 'title', title: 'Title (document)', type: 'string'}),
+    defineField({
+      name: 'language',
+      title: 'Language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
+      name: 'localizedTitle',
+      title: 'Localized title (field — also restricted)',
+      type: 'internationalizedArrayString',
+    }),
+  ],
+})
+
+const lfDemoLesson = defineType({
+  name: 'lfDemoLesson',
+  title: 'Lesson (#570 demo, no filter)',
+  type: 'document',
+  fields: [
+    defineField({name: 'title', title: 'Title (document)', type: 'string'}),
+    defineField({
+      name: 'language',
+      title: 'Language',
+      type: 'string',
+      readOnly: true,
+      hidden: true,
+    }),
+    defineField({
+      name: 'localizedTitle',
+      title: 'Localized title (field — all languages)',
+      type: 'internationalizedArrayString',
+    }),
+  ],
+})
+
 export const documentInternationalizationExample = definePlugin(() => ({
   schema: {
-    types: [lessonType],
+    types: [lessonType, lfDemoRecipe, lfDemoLesson],
   },
   document: {
     actions: (prev, {schemaType}) => {
-      if (['lesson'].includes(schemaType)) {
+      if (['lesson', 'lfDemoRecipe', 'lfDemoLesson'].includes(schemaType)) {
         return [...prev, useDeleteTranslationAction, useDuplicateWithTranslationsAction]
       }
 
@@ -46,15 +121,36 @@ export const documentInternationalizationExample = definePlugin(() => ({
   },
   plugins: [
     documentInternationalization({
-      supportedLanguages: [
-        {id: 'en', title: 'English'},
-        {id: 'es', title: 'Spanish'},
-        {id: 'fr', title: 'French'},
-      ],
-      schemaTypes: ['lesson'],
+      supportedLanguages: SHARED_LANGUAGES,
+      schemaTypes: ['lesson', 'lfDemoRecipe', 'lfDemoLesson'],
       bulkPublish: true,
       metadataInternationalization: {
         languageDisplay: 'titleAndCode',
+      },
+      // Document-level menu filter (issue #570)
+      languageFilter: ({schemaType, defaultLanguages}) => {
+        if (schemaType === 'lfDemoRecipe') {
+          return defaultLanguages.filter((l) => RECIPE_LANGUAGES.has(l.id))
+        }
+        return defaultLanguages
+      },
+    }),
+    // The lessonType example above doesn't use internationalizedArray.
+    // For the #570 demo we add a separate internationalizedArray instance
+    // configured for the demo doc types and exercising filterLanguages.
+    internationalizedArray({
+      languages: SHARED_LANGUAGES,
+      fieldTypes: ['string'],
+      buttonLocations: ['field'],
+      includeForDocumentType: (documentType) =>
+        ['lfDemoRecipe', 'lfDemoLesson'].includes(documentType),
+      // Field-level button filter (issue #570 follow-up — applies to the
+      // sanity-plugin-internationalized-array half).
+      filterLanguages: ({schemaType, defaultLanguages}) => {
+        if (schemaType === 'lfDemoRecipe') {
+          return defaultLanguages.filter((l) => RECIPE_LANGUAGES.has(l.id))
+        }
+        return defaultLanguages
       },
     }),
   ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "pnpm turbo dev --filter=test-studio",
     "format": "oxfmt . --no-error-on-unmatched-pattern",
     "generate": "turbo gen",
+    "issue-triage": "node scripts/trigger-triage/src/index.ts",
     "knip": "knip",
     "lint": "pnpm run oxlint",
     "lint:fix": "pnpm lint --fix --fix-suggestions",

--- a/plugins/@sanity/document-internationalization/README.md
+++ b/plugins/@sanity/document-internationalization/README.md
@@ -250,10 +250,73 @@ export const defineConfig({
       // - An array of schema type names: `hideLanguageFilter: ['lesson']`
       // - A function for dynamic control: `hideLanguageFilter: (ctx) => ctx.schemaType === 'lesson'`
       hideLanguageFilter: true, // defaults to false
+
+      // Optional
+      // Restrict which languages appear in the Translations menu for a given
+      // document type. Receives the schemaType name and the resolved
+      // supportedLanguages list, and returns the subset to show in the menu.
+      // Only affects the menu UI - badges, templates, and the underlying data
+      // continue to use the full supportedLanguages list.
+      languageFilter: ({schemaType, defaultLanguages}) => {
+        // Example: a per-schemaType allowlist
+        const allowlist = {
+          lesson: ['en', 'es', 'fr'],
+          recipe: ['en', 'it'],
+        }
+        const allowed = allowlist[schemaType]
+        return allowed
+          ? defaultLanguages.filter((l) => allowed.includes(l.id))
+          : defaultLanguages
+      },
     })
   ]
 })
 ```
+
+### Per-document-type language filtering
+
+By default the Translations menu shows every entry in `supportedLanguages` for every document type that has the plugin enabled. The optional `languageFilter` option lets you narrow that list per schema type at render time.
+
+```ts
+documentInternationalization({
+  supportedLanguages: [
+    {id: 'en', title: 'English'},
+    {id: 'es', title: 'Spanish'},
+    {id: 'fr', title: 'French'},
+    {id: 'de', title: 'German'},
+    // ...many more
+  ],
+  schemaTypes: ['lesson', 'recipe'],
+  languageFilter: ({schemaType, defaultLanguages}) => {
+    if (schemaType === 'recipe') {
+      return defaultLanguages.filter((l) => ['en', 'it'].includes(l.id))
+    }
+    return defaultLanguages
+  },
+})
+```
+
+**Signature**
+
+```ts
+type LanguageFilterContext = {
+  schemaType: string // The document's schema type name
+  defaultLanguages: Language[] // The resolved supportedLanguages list
+}
+
+type LanguageFilter = (context: LanguageFilterContext) => Language[]
+```
+
+- The filter runs **synchronously** at menu render time, after `supportedLanguages` has been resolved (including when it is supplied as an async function).
+- Returning an empty array yields a menu with no language options. The "Manage Translations" button still renders so existing translation metadata is reachable.
+- Returning a reordered list reorders the menu.
+
+**What `languageFilter` does _not_ affect**
+
+- **Badges.** Documents in any supported language still show their language badge in lists. A document that is already translated into a language you later remove from the menu keeps its badge and remains reachable through the metadata document.
+- **Templates** generated for the New Document menu — these continue to be generated from the full `supportedLanguages` × `schemaTypes` matrix.
+- **Validity checks.** The "source language is supported" check still uses the full list, so a document whose language is valid plugin-wide will not surface a warning just because the menu filter excludes it.
+- **`translation.metadata` documents.** The shared metadata document's `translations` array is not constrained by this option. Filtering metadata languages per type is a separate concern because metadata documents can span multiple schema types.
 
 ### Language field
 

--- a/plugins/@sanity/document-internationalization/README.md
+++ b/plugins/@sanity/document-internationalization/README.md
@@ -318,6 +318,31 @@ type LanguageFilter = (context: LanguageFilterContext) => Language[]
 - **Validity checks.** The "source language is supported" check still uses the full list, so a document whose language is valid plugin-wide will not surface a warning just because the menu filter excludes it.
 - **`translation.metadata` documents.** The shared metadata document's `translations` array is not constrained by this option. Filtering metadata languages per type is a separate concern because metadata documents can span multiple schema types.
 
+### Restricting field-level languages too
+
+`languageFilter` above only narrows the **document-level Translations menu**. If you also use [`sanity-plugin-internationalized-array`](https://github.com/sanity-io/plugins/tree/main/plugins/sanity-plugin-internationalized-array) for field-level translations, that plugin has a parallel `filterLanguages` option which narrows the add-language buttons rendered on each `internationalizedArray*` field. The two options cover different UI surfaces and can be set independently, but it usually makes sense to keep them aligned:
+
+```ts
+const recipeLanguages = ['en', 'it']
+
+documentInternationalization({
+  supportedLanguages: [...],
+  schemaTypes: ['recipe', 'lesson'],
+  languageFilter: ({schemaType, defaultLanguages}) =>
+    schemaType === 'recipe'
+      ? defaultLanguages.filter((l) => recipeLanguages.includes(l.id))
+      : defaultLanguages,
+}),
+internationalizedArray({
+  languages: [...],
+  fieldTypes: ['string', 'text'],
+  filterLanguages: ({schemaType, defaultLanguages}) =>
+    schemaType === 'recipe'
+      ? defaultLanguages.filter((l) => recipeLanguages.includes(l.id))
+      : defaultLanguages,
+}),
+```
+
 ### Language field
 
 The schema types that use document internationalization must also have a `string` field type with the same name configured in the `languageField` setting. Unless you want content creators to be able to change the language of a document, you may hide or disable this field since the plugin will handle writing patches to it.

--- a/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.test.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.test.tsx
@@ -229,4 +229,140 @@ describe('DocumentInternationalizationMenu', () => {
     })
     expect(screen.getByText('pt:other:enabled')).toBeInTheDocument()
   })
+
+  describe('languageFilter', () => {
+    test('renders the full supportedLanguages list when no languageFilter is configured', async () => {
+      vi.mocked(useTranslationMetadata).mockReturnValue({
+        data: [{_id: 'meta-1', _createdAt: '2024-01-01', translations: []}],
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />,
+        {wrapper: ThemeWrapper},
+      )
+      fireEvent.click(screen.getByRole('button', {name: 'Translations'}))
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('language-option')).toHaveLength(MOCK_LANGUAGES.length)
+      })
+    })
+
+    test('restricts the menu to languages returned by languageFilter', async () => {
+      const languageFilter = vi.fn(({defaultLanguages}: {defaultLanguages: Language[]}) =>
+        defaultLanguages.filter((l) => l.id === 'en' || l.id === 'fr'),
+      )
+      vi.mocked(useDocumentInternationalizationContext).mockReturnValue({
+        ...MOCK_PLUGIN_CONFIG,
+        languageFilter,
+      })
+      vi.mocked(useTranslationMetadata).mockReturnValue({
+        data: [{_id: 'meta-1', _createdAt: '2024-01-01', translations: []}],
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />,
+        {wrapper: ThemeWrapper},
+      )
+      fireEvent.click(screen.getByRole('button', {name: 'Translations'}))
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('language-option')).toHaveLength(2)
+      })
+      const ids = screen
+        .getAllByTestId('language-option')
+        .map((node) => node.textContent?.split(':')[0])
+      expect(ids).toEqual(['en', 'fr'])
+    })
+
+    test('passes the document schemaType and resolved defaultLanguages to languageFilter', async () => {
+      const languageFilter = vi.fn(
+        ({defaultLanguages}: {defaultLanguages: Language[]}) => defaultLanguages,
+      )
+      vi.mocked(useDocumentInternationalizationContext).mockReturnValue({
+        ...MOCK_PLUGIN_CONFIG,
+        languageFilter,
+      })
+      vi.mocked(useTranslationMetadata).mockReturnValue({
+        data: [{_id: 'meta-1', _createdAt: '2024-01-01', translations: []}],
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />,
+        {wrapper: ThemeWrapper},
+      )
+      fireEvent.click(screen.getByRole('button', {name: 'Translations'}))
+
+      await waitFor(() => {
+        expect(languageFilter).toHaveBeenCalled()
+      })
+      expect(languageFilter).toHaveBeenCalledWith({
+        schemaType: 'article',
+        defaultLanguages: MOCK_LANGUAGES,
+      })
+    })
+
+    test('renders Manage Translations but no language options when languageFilter returns []', async () => {
+      const languageFilter = vi.fn(() => [] as Language[])
+      vi.mocked(useDocumentInternationalizationContext).mockReturnValue({
+        ...MOCK_PLUGIN_CONFIG,
+        languageFilter,
+      })
+      vi.mocked(useTranslationMetadata).mockReturnValue({
+        data: [{_id: 'meta-1', _createdAt: '2024-01-01', translations: []}],
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />,
+        {wrapper: ThemeWrapper},
+      )
+      fireEvent.click(screen.getByRole('button', {name: 'Translations'}))
+
+      // The Manage Translations button (mocked) still renders.
+      expect(screen.getByTestId('language-manage')).toBeInTheDocument()
+      // No language options.
+      expect(screen.queryAllByTestId('language-option')).toHaveLength(0)
+      expect(screen.queryAllByTestId('language-patch')).toHaveLength(0)
+    })
+
+    test('uses filtered count to decide whether to show the search input', async () => {
+      const manyLanguages: Language[] = [
+        ...MOCK_LANGUAGES,
+        {id: 'pt', title: 'Portuguese'},
+        {id: 'it', title: 'Italian'},
+        {id: 'nl', title: 'Dutch'},
+      ]
+      // 7 languages globally, but filter narrows to 3 so the search input
+      // should disappear (threshold is > 4).
+      vi.mocked(useDocumentInternationalizationContext).mockReturnValue({
+        ...MOCK_PLUGIN_CONFIG,
+        supportedLanguages: manyLanguages,
+        languageFilter: ({defaultLanguages}) =>
+          defaultLanguages.filter((l) => ['en', 'fr', 'es'].includes(l.id)),
+      })
+      vi.mocked(useTranslationMetadata).mockReturnValue({
+        data: [{_id: 'meta-1', _createdAt: '2024-01-01', translations: []}],
+        loading: false,
+        error: null,
+      })
+
+      render(
+        <DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />,
+        {wrapper: ThemeWrapper},
+      )
+      fireEvent.click(screen.getByRole('button', {name: 'Translations'}))
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('language-option')).toHaveLength(3)
+      })
+      expect(screen.queryByPlaceholderText('Filter languages')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.tsx
@@ -19,7 +19,8 @@ export function DocumentInternationalizationMenu(
 ): React.JSX.Element | null {
   const {documentId} = props
   const schemaType = props.schemaType
-  const {languageField, supportedLanguages} = useDocumentInternationalizationContext()
+  const {languageField, supportedLanguages, languageFilter} =
+    useDocumentInternationalizationContext()
 
   // Search filter query
   const [query, setQuery] = useState(``)
@@ -78,6 +79,19 @@ export function DocumentInternationalizationMenu(
     return valid
   }, [supportedLanguages])
 
+  // Apply per-schemaType language filter (if configured). This affects ONLY
+  // what's rendered in the menu — validity checks above still run against the
+  // full, plugin-wide supportedLanguages list. See PluginConfig.languageFilter.
+  const menuLanguages = useMemo(() => {
+    if (typeof languageFilter !== 'function') {
+      return supportedLanguages
+    }
+    return languageFilter({
+      schemaType: schemaType.name,
+      defaultLanguages: supportedLanguages,
+    })
+  }, [languageFilter, schemaType.name, supportedLanguages])
+
   const content = (
     <Box padding={1}>
       {error ? (
@@ -93,10 +107,10 @@ export function DocumentInternationalizationMenu(
             schemaType={schemaType}
             sourceLanguageId={sourceLanguageId}
           />
-          {supportedLanguages.length > 4 ? (
+          {menuLanguages.length > 4 ? (
             <TextInput onChange={handleQuery} value={query} placeholder="Filter languages" />
           ) : null}
-          {supportedLanguages.length > 0 ? (
+          {menuLanguages.length > 0 ? (
             <>
               {/* Once metadata is loaded, there may be issues */}
               {loading ? null : (
@@ -127,7 +141,7 @@ export function DocumentInternationalizationMenu(
                   ) : null}
                 </>
               )}
-              {supportedLanguages
+              {menuLanguages
                 .filter((language) => {
                   if (query) {
                     return language.title.toLowerCase().includes(query.toLowerCase())

--- a/plugins/@sanity/document-internationalization/src/constants.ts
+++ b/plugins/@sanity/document-internationalization/src/constants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONFIG: PluginConfigContext = {
   apiVersion: API_VERSION,
   allowCreateMetaDoc: false,
   callback: null,
+  languageFilter: null,
   hideLanguageFilter: false,
   addTemplates: true,
 }

--- a/plugins/@sanity/document-internationalization/src/types.ts
+++ b/plugins/@sanity/document-internationalization/src/types.ts
@@ -28,6 +28,29 @@ export type PluginCallbackArgs = {
   client: SanityClient
 }
 
+/**
+ * Context passed to `languageFilter` when the Translations menu renders.
+ * Receives the schema type name of the document the menu is being rendered
+ * against, plus the fully resolved list of supported languages (the same
+ * list `supportedLanguages` produces).
+ */
+export type LanguageFilterContext = {
+  schemaType: string
+  defaultLanguages: Language[]
+}
+
+/**
+ * Synchronous filter applied to the language list shown in the Translations
+ * menu, scoped per document type. Receives the resolved `defaultLanguages`
+ * and must return a (possibly reordered, possibly empty) subset.
+ *
+ * The filter only affects the menu UI. Templates, badges, language patches
+ * driven from `supportedLanguages` and the data layer all keep using the
+ * full, unfiltered list, so existing translated documents never lose their
+ * badges or become unrouteable.
+ */
+export type LanguageFilter = (context: LanguageFilterContext) => Language[]
+
 export type PluginConfig = {
   supportedLanguages: SupportedLanguages
   schemaTypes: string[]
@@ -38,6 +61,15 @@ export type PluginConfig = {
   apiVersion?: string
   allowCreateMetaDoc?: boolean
   callback?: ((args: PluginCallbackArgs) => Promise<void>) | null
+  /**
+   * Restrict which languages appear in the Translations menu for a given
+   * schema type. Runs at menu render time, after `supportedLanguages` has
+   * been resolved. Returning an empty array yields a menu with no language
+   * options (the Manage Translations button still renders).
+   *
+   * Only the menu is affected. See {@link LanguageFilter} for details.
+   */
+  languageFilter?: LanguageFilter | null
   hideLanguageFilter?: boolean | string[] | ((ctx: DocumentLanguageFilterContext) => boolean)
   /**
    * Allows configuring the behavior of the internationalized array for the metadata document.

--- a/plugins/sanity-plugin-internationalized-array/README.md
+++ b/plugins/sanity-plugin-internationalized-array/README.md
@@ -308,6 +308,55 @@ export default defineConfig({
 
 If you need more control, you can continue using `@sanity/language-filter` directly and pass `internationalizedArrayLanguageFilter` from this package as your `filterField`.
 
+## Restricting languages per document type
+
+If different document types should only support specific subsets of your configured `languages`, use the `filterLanguages` option to narrow the list of add-language buttons (and the "add missing languages" action) per schema type.
+
+```ts
+import {defineConfig} from 'sanity'
+import {internationalizedArray} from 'sanity-plugin-internationalized-array'
+
+export default defineConfig({
+  // ...
+  plugins: [
+    internationalizedArray({
+      languages: [
+        {id: 'en', title: 'English'},
+        {id: 'es', title: 'Spanish'},
+        {id: 'fr', title: 'French'},
+        {id: 'it', title: 'Italian'},
+        // ...many more
+      ],
+      fieldTypes: ['string', 'text'],
+      filterLanguages: ({schemaType, defaultLanguages}) => {
+        if (schemaType === 'recipe') {
+          return defaultLanguages.filter((l) => ['en', 'it'].includes(l.id))
+        }
+        return defaultLanguages
+      },
+    }),
+  ],
+})
+```
+
+**Signature**
+
+```ts
+type FilterLanguagesContext = {
+  schemaType: string // The document type currently in the form
+  defaultLanguages: Language[] // The resolved languages list
+}
+
+type FilterLanguages = (context: FilterLanguagesContext) => Language[]
+```
+
+- The filter runs **synchronously** after `languages` has been resolved (including when supplied as an async function).
+- It composes with `@sanity/language-filter`: `filterLanguages` runs first to narrow the universe of candidates, then the user's per-session toggle is applied on top.
+- It only affects which add-language buttons render. Existing values in an `internationalizedArray*` field are never removed or hidden by it, so documents that already contain a language you later filter out keep their data and continue to render normally.
+- Returning `[]` results in no add-language buttons being rendered for that document type.
+
+For the document-level Translations menu (the popover added by `@sanity/document-internationalization`), use the parallel `languageFilter` option on that plugin. The two filters cover different UI surfaces and can be set independently.
+
 ## Shape of stored data
 
 The custom input contains buttons which will add new array items with a random `_key` and the language stored in a dedicated `language` field. Data returned from this array will look like this:

--- a/plugins/sanity-plugin-internationalized-array/src/components/AddButtons.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/AddButtons.test.tsx
@@ -208,4 +208,41 @@ describe('AddButtons', () => {
     expect(getButtonByValue('es')).toHaveAttribute('data-disabled', 'true')
     expect(getButtonByValue('de')).toHaveAttribute('data-disabled', 'false')
   })
+
+  test('renders only the languages remaining after filterLanguages narrows the context', () => {
+    // Simulates what InternationalizedArrayProvider does: filterLanguages
+    // has already narrowed the list before reaching AddButtons.
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      filteredLanguages: [
+        {id: 'en', title: 'English'},
+        {id: 'it', title: 'Italian'},
+      ],
+    })
+
+    render(<AddButtons readOnly={false} languagesInUse={[]} handleClick={vi.fn()} />, {
+      wrapper: ThemeWrapper,
+    })
+
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(2)
+    expect(getButtonByValue('en')).toBeInTheDocument()
+    expect(getButtonByValue('it')).toBeInTheDocument()
+  })
+
+  test('renders no buttons when filterLanguages reduces the context to an empty list', () => {
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      filteredLanguages: [],
+    })
+
+    render(<AddButtons readOnly={false} languagesInUse={[]} handleClick={vi.fn()} />, {
+      wrapper: ThemeWrapper,
+    })
+
+    // AddButtons returns null when languages is empty, so the grid is absent
+    // and no language buttons are rendered.
+    expect(screen.queryByTestId('add-buttons-grid')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
 })

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.test.ts
@@ -1,0 +1,140 @@
+import {describe, expect, test, vi} from 'vitest'
+
+import {MOCK_LANGUAGES} from '../test/helpers'
+import type {Language} from '../types'
+import {composeFilteredLanguages} from './InternationalizedArrayContext'
+
+// Hoisted filter helpers — keeping them at module scope satisfies
+// unicorn/consistent-function-scoping (these don't capture test-local state).
+const reorderToFrEn = (): Language[] => [
+  {id: 'fr', title: 'French'},
+  {id: 'en', title: 'English'},
+]
+
+const allowEnFrEs = ({defaultLanguages}: {defaultLanguages: Language[]}): Language[] =>
+  defaultLanguages.filter((l) => ['en', 'fr', 'es'].includes(l.id))
+
+const ghostLanguage: Language = {id: 'xx', title: 'Ghost'}
+const returnGhost = (): Language[] => [ghostLanguage]
+
+const returnEmpty = (): Language[] => []
+
+describe('composeFilteredLanguages', () => {
+  test('returns the full list when no filterLanguages and language-filter not enabled', () => {
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: null,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(result).toEqual(MOCK_LANGUAGES)
+  })
+
+  test('applies filterLanguages when configured', () => {
+    const filterLanguages = vi.fn(
+      ({defaultLanguages}: {defaultLanguages: Language[]}): Language[] =>
+        defaultLanguages.filter((l) => l.id === 'en' || l.id === 'fr'),
+    )
+
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(filterLanguages).toHaveBeenCalledWith({
+      schemaType: 'article',
+      defaultLanguages: MOCK_LANGUAGES,
+    })
+    expect(result.map((l) => l.id)).toEqual(['en', 'fr'])
+  })
+
+  test('preserves filterLanguages return order', () => {
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: reorderToFrEn,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(result.map((l) => l.id)).toEqual(['fr', 'en'])
+  })
+
+  test('returns [] when filterLanguages returns []', () => {
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: returnEmpty,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(result).toEqual([])
+  })
+
+  test('composes filterLanguages with @sanity/language-filter user selection', () => {
+    // Static filter narrows to en/fr/es.
+    // User-selection filter is enabled for this document type and the user
+    // has selected en + es. Final menu should be en + es (intersection).
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: allowEnFrEs,
+      selectedLanguageIds: ['en', 'es', 'de'], // 'de' was never in static set, so irrelevant
+      languageFilterDocumentTypes: ['article'],
+    })
+
+    expect(result.map((l) => l.id)).toEqual(['en', 'es'])
+  })
+
+  test('language-filter user selection is ignored when the document type is not enabled', () => {
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: null,
+      selectedLanguageIds: ['en'],
+      languageFilterDocumentTypes: ['someOtherType'], // article not in list
+    })
+
+    expect(result).toEqual(MOCK_LANGUAGES)
+  })
+
+  test('static filter receives the document schemaType', () => {
+    const filterLanguages = vi.fn(
+      ({defaultLanguages}: {defaultLanguages: Language[]}): Language[] => defaultLanguages,
+    )
+
+    composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'recipe',
+      filterLanguages,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(filterLanguages).toHaveBeenCalledWith({
+      schemaType: 'recipe',
+      defaultLanguages: MOCK_LANGUAGES,
+    })
+  })
+
+  test('static filter ignores languages that are not in the resolved set (it operates on defaultLanguages)', () => {
+    // If a misconfigured filter returns languages that aren't in the input,
+    // they pass through (the type system already prevents this in practice,
+    // but documenting the runtime contract).
+    const result = composeFilteredLanguages({
+      languages: MOCK_LANGUAGES,
+      schemaType: 'article',
+      filterLanguages: returnGhost,
+      selectedLanguageIds: [],
+      languageFilterDocumentTypes: [],
+    })
+
+    expect(result).toEqual([ghostLanguage])
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.tsx
@@ -6,7 +6,7 @@ import {useDocumentPane} from 'sanity/structure'
 
 import {createCacheKey, createOrGetPromise, setFunctionCache} from '../cache'
 import {CONFIG_DEFAULT} from '../constants'
-import type {Language, PluginConfig} from '../types'
+import type {FilterLanguages, Language, PluginConfig} from '../types'
 import {getSelectedValue} from './getSelectedValue'
 
 // This provider makes the plugin config available to all components in the document form
@@ -15,6 +15,34 @@ import {getSelectedValue} from './getSelectedValue'
 export type InternationalizedArrayContextProps = Required<PluginConfig> & {
   languages: Language[]
   filteredLanguages: Language[]
+}
+
+/**
+ * Pure compose helper: applies the optional static `filterLanguages` from
+ * plugin config first, then the per-user runtime selection from
+ * `@sanity/language-filter`. Exported for testing — the provider below is
+ * the only production caller.
+ */
+export function composeFilteredLanguages(input: {
+  languages: Language[]
+  schemaType: string
+  filterLanguages: FilterLanguages | null
+  selectedLanguageIds: string[]
+  languageFilterDocumentTypes: string[]
+}): Language[] {
+  const {languages, schemaType, filterLanguages, selectedLanguageIds, languageFilterDocumentTypes} =
+    input
+
+  const staticallyFiltered =
+    typeof filterLanguages === 'function'
+      ? filterLanguages({schemaType, defaultLanguages: languages})
+      : languages
+
+  const languageFilterEnabled = languageFilterDocumentTypes.includes(schemaType)
+
+  return languageFilterEnabled
+    ? staticallyFiltered.filter((language) => selectedLanguageIds.includes(language.id))
+    : staticallyFiltered
 }
 
 const InternationalizedArrayContext = createContext<InternationalizedArrayContextProps>({
@@ -94,13 +122,23 @@ export function InternationalizedArrayProvider(
   // Filter out some languages if language filter is enabled
   const {selectedLanguageIds, options: languageFilterOptions} = useLanguageFilterStudioContext()
 
-  const filteredLanguages = useMemo(() => {
-    const languageFilterEnabled = languageFilterOptions.documentTypes.includes(documentType)
-
-    return languageFilterEnabled
-      ? languages.filter((language) => selectedLanguageIds.includes(language.id))
-      : languages
-  }, [documentType, languageFilterOptions, languages, selectedLanguageIds])
+  const filteredLanguages = useMemo(
+    () =>
+      composeFilteredLanguages({
+        languages,
+        schemaType: documentType,
+        filterLanguages: internationalizedArray.filterLanguages,
+        selectedLanguageIds,
+        languageFilterDocumentTypes: languageFilterOptions.documentTypes,
+      }),
+    [
+      documentType,
+      internationalizedArray.filterLanguages,
+      languageFilterOptions,
+      languages,
+      selectedLanguageIds,
+    ],
+  )
 
   const context = useMemo(
     () => ({...internationalizedArray, languages, filteredLanguages}),

--- a/plugins/sanity-plugin-internationalized-array/src/constants.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/constants.ts
@@ -44,4 +44,5 @@ export const CONFIG_DEFAULT: Required<PluginConfig> = {
   languageFilter: {
     documentTypes: [],
   },
+  filterLanguages: null,
 }

--- a/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
@@ -55,4 +55,5 @@ export const MOCK_INTERNATIONALIZED_ARRAY_CONTEXT: InternationalizedArrayContext
   languageFilter: {
     documentTypes: [],
   },
+  filterLanguages: null,
 }

--- a/plugins/sanity-plugin-internationalized-array/src/types.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/types.ts
@@ -53,6 +53,32 @@ export type LanguageCallback = (
 
 export type LanguageDisplay = 'titleOnly' | 'codeOnly' | 'titleAndCode'
 
+/**
+ * Context passed to `filterLanguages` when the plugin is computing the list
+ * of languages to render in the add-language buttons (and to use for "add
+ * missing languages"). The `schemaType` is the document type currently in
+ * the form; `defaultLanguages` is the fully-resolved list from the plugin's
+ * `languages` option (after any async function has settled and after any
+ * `@sanity/language-filter` user selection has been applied).
+ */
+export type FilterLanguagesContext = {
+  schemaType: string
+  defaultLanguages: Language[]
+}
+
+/**
+ * Synchronous, per-schemaType filter applied to the language list used by
+ * the add-language buttons and the "add missing languages" action. Receives
+ * the resolved `defaultLanguages` and returns a (possibly reordered, possibly
+ * empty) subset.
+ *
+ * The filter affects the UI surface only. Existing values in an
+ * `internationalizedArray*` field are never removed or hidden by it, so
+ * documents that already contain a language you later filter out keep their
+ * data and continue to render normally.
+ */
+export type FilterLanguages = (context: FilterLanguagesContext) => Language[]
+
 export type PluginConfig = {
   /**
    * https://www.sanity.io/docs/api-versioning
@@ -174,4 +200,28 @@ export type PluginConfig = {
     documentTypes: Required<LanguageFilterConfig>['documentTypes']
     defaultLanguages?: LanguageFilterConfig['defaultLanguages']
   }
+  /**
+   * Narrow the list of languages shown in the add-language buttons (and used
+   * by "add missing languages") per document type. Receives the document's
+   * `schemaType` name and the resolved `defaultLanguages` list, and returns
+   * the subset to render.
+   *
+   * Composes with `@sanity/language-filter` (configured via `languageFilter`
+   * above): the static filter runs first to narrow the universe of
+   * candidates, then the user's per-session language toggle is applied on
+   * top. The filter only affects which buttons render; existing values in
+   * the array are not removed or hidden.
+   *
+   * ```tsx
+   * {
+   *   filterLanguages: ({schemaType, defaultLanguages}) => {
+   *     if (schemaType === 'recipe') {
+   *       return defaultLanguages.filter((l) => ['en', 'it'].includes(l.id))
+   *     }
+   *     return defaultLanguages
+   *   }
+   * }
+   * ```
+   */
+  filterLanguages?: FilterLanguages | null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1366,6 +1366,15 @@ importers:
         specifier: 'catalog:'
         version: 5.21.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.1(@noble/hashes@2.2.0)(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(@sanity/styled-components@6.1.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@types/node@24.12.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3)
 
+  scripts/trigger-triage:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   turbo/generators:
     devDependencies:
       '@sanity/tsconfig':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - packages/@sanity/*
   - plugins/*
   - plugins/@sanity/*
+  - scripts/*
   - turbo/generators
 
 catalog:

--- a/scripts/trigger-triage/.env.example
+++ b/scripts/trigger-triage/.env.example
@@ -1,0 +1,7 @@
+# For local issue triage runs get it from miriad workspace.
+MIRIAD_URL=
+MIRIAD_SPACE_ID=
+MIRIAD_TOKEN=
+
+# Optional. Useful locally if anonymous GitHub API requests hit rate limits or if you are testing against a private repository.
+GITHUB_TOKEN=

--- a/scripts/trigger-triage/README.md
+++ b/scripts/trigger-triage/README.md
@@ -1,0 +1,147 @@
+# Issue Triage Trigger
+
+This package triggers the Miriad issue triage workflow for a GitHub issue URL.
+It is used by the `sanity-io/plugins` GitHub workflow and can also be run from
+the terminal while developing or testing.
+
+The runtime path is dependency-free: the GitHub Action runs the TypeScript file
+directly with Node, without `pnpm install` or a build step. Use Node 22.18 or
+newer locally.
+
+## How It Works
+
+Given a GitHub issue URL, the CLI:
+
+1. Parses the owner, repo, and issue number.
+2. Fetches the issue from the GitHub REST API.
+3. Ignores noise, including bot authors, dependency dashboards, and issues with
+   ignored labels.
+4. Creates or reuses a Miriad channel named after the repo and issue number.
+5. Adds the configured Miriad agents to the channel.
+6. Posts a kickoff message tagging `@triager`.
+
+The trigger does not post back to GitHub. It only starts the Miriad workflow.
+
+## GitHub Workflow
+
+The workflow that calls this package is:
+
+```text
+.github/workflows/issue-triage.yml
+```
+
+It runs when:
+
+- A new issue is opened.
+- The `needs-triage` label is added to an existing issue.
+- A developer manually runs the workflow from the GitHub Actions UI and provides
+  an `issue_url` input.
+
+For issue events, the workflow passes `github.event.issue.html_url` to the CLI.
+For manual runs, it passes the `issue_url` input instead.
+
+```bash
+node scripts/trigger-triage/src/index.ts "$ISSUE_URL"
+```
+
+To trigger it manually, open the `Issue Triage` workflow in GitHub Actions, click
+`Run workflow`, and paste a GitHub issue URL such as
+`https://github.com/sanity-io/plugins/issues/725`.
+
+## Local Usage
+
+From the repository root:
+
+```bash
+pnpm issue-triage https://github.com/sanity-io/plugins/issues/725
+```
+
+Dry-run mode fetches and filters the issue, then prints the Miriad kickoff
+message without calling Miriad:
+
+```bash
+pnpm issue-triage --dry-run https://github.com/sanity-io/plugins/issues/725
+```
+
+Verbose mode prints debug logs:
+
+```bash
+pnpm issue-triage --verbose https://github.com/sanity-io/plugins/issues/725
+```
+
+## Required GitHub Actions Secrets
+
+Add these to the target repository's GitHub Actions secrets:
+
+- `MIRIAD_URL` - Miriad REST API base URL.
+- `MIRIAD_TOKEN` - Bearer token for the Miriad REST API.
+- `MIRIAD_SPACE_ID` - Miriad space short id.
+
+The workflow sets `GITHUB_TOKEN` from GitHub's built-in token:
+
+```yaml
+GITHUB_TOKEN: ${{ github.token }}
+```
+
+Do not add a custom `GITHUB_TOKEN` repository secret for this workflow.
+
+## Local Environment
+
+For local terminal runs, `GITHUB_TOKEN` is optional. Set it only if anonymous
+GitHub API requests hit rate limits or if you are testing against a private
+repository.
+
+```bash
+GITHUB_TOKEN=ghp_example pnpm issue-triage --dry-run https://github.com/sanity-io/plugins/issues/725
+```
+
+The script also loads local `.env` files automatically without any dependencies.
+Shell-provided environment variables always win. For local Miriad runs, copy the
+example file and fill in the required values:
+
+```bash
+cp scripts/trigger-triage/.env.example scripts/trigger-triage/.env
+```
+
+The lookup order is:
+
+1. Environment variables already set in the shell or GitHub Actions.
+2. `scripts/trigger-triage/.env`.
+3. Repository root `.env`.
+
+The script-local `.env` is preferred because it keeps these secrets scoped to
+this helper. The root `.env` fallback exists for convenience in this repo.
+
+## Hardcoded Agents
+
+The Miriad agents are intentionally hardcoded in `src/index.ts`:
+
+```ts
+const AGENT_NAMES = ['triager', 'squigler'] as const
+```
+
+This keeps the GitHub workflow and repository settings small: agent assignment
+is part of the script behavior, not deployment configuration. If another repo or
+Miriad workspace uses different callsigns, update `AGENT_NAMES` before copying
+or enabling the workflow there.
+
+## Moving This To Another Repo
+
+To reuse this setup in another repository, such as the main `sanity` repo:
+
+1. Copy `scripts/trigger-triage/`.
+2. Copy `.github/workflows/issue-triage.yml`.
+3. Add the script package to that repository's package manager or workspace
+   setup.
+4. Create a new Miriad workspace. From this workspace you will get:
+   - `MIRIAD_URL`
+   - `MIRIAD_TOKEN`
+   - `MIRIAD_SPACE_ID`
+     Add these variables to the repository secrets.
+5. Review `AGENT_NAMES` in `src/index.ts` and update the callsigns if the target
+   Miriad workspace uses different agents.
+6. Confirm the workflow passes `github.event.issue.html_url` to the CLI.
+7. Confirm the manual `workflow_dispatch` input is still named `issue_url`.
+8. Run a local dry-run against a real issue URL.
+9. Smoke-test the workflow by opening a test issue or adding `needs-triage` to
+   an existing issue.

--- a/scripts/trigger-triage/package.json
+++ b/scripts/trigger-triage/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sanity/issue-trigger-triage",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLI and GitHub Actions helper that triggers the Miriad issue triage workflow for a GitHub issue URL.",
+  "bin": {
+    "trigger-triage": "./src/index.ts"
+  },
+  "type": "module",
+  "scripts": {
+    "dev": "node src/index.ts",
+    "start": "node src/index.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18"
+  }
+}

--- a/scripts/trigger-triage/src/github.ts
+++ b/scripts/trigger-triage/src/github.ts
@@ -1,0 +1,103 @@
+interface GitHubIssueUser {
+  login: string
+  type: string
+}
+
+interface GitHubIssueLabel {
+  name: string
+}
+
+export interface GitHubIssue {
+  number: number
+  title: string
+  body: string | null
+  html_url: string
+  state: 'open' | 'closed'
+  created_at: string
+  user: GitHubIssueUser
+  labels: GitHubIssueLabel[]
+  pull_request?: unknown
+}
+
+const ISSUE_URL_RE =
+  /^https:\/\/github\.com\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/issues\/(\d+)(?:[#?/].*)?$/
+
+export function parseIssueUrl(url: string): {
+  owner: string
+  repo: string
+  issueNumber: number
+} {
+  const match = url.trim().match(ISSUE_URL_RE)
+  if (!match) {
+    throw new Error(
+      `invalid GitHub issue URL: ${url}\n  expected: https://github.com/<owner>/<repo>/issues/<N>`,
+    )
+  }
+
+  const [, owner, repo, issueNumber] = match
+  return {owner, repo, issueNumber: Number.parseInt(issueNumber, 10)}
+}
+
+export interface FetchIssueOptions {
+  owner: string
+  repo: string
+  issueNumber: number
+  token?: string | undefined
+  log?: (msg: string) => void
+}
+
+export async function fetchIssue(opts: FetchIssueOptions): Promise<GitHubIssue> {
+  const {owner, repo, issueNumber, token, log} = opts
+  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`
+
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'sanity-io-trigger-triage/0.1',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+
+  log?.(`GET ${apiUrl}`)
+
+  let res: Response
+  try {
+    res = await fetch(apiUrl, {headers})
+  } catch (err) {
+    throw new Error(`network error contacting GitHub: ${errorMessage(err)}`, {cause: err})
+  }
+
+  if (res.status === 404) {
+    throw new Error(
+      `issue not found: ${owner}/${repo}#${issueNumber} (private repo? set GITHUB_TOKEN locally)`,
+    )
+  }
+
+  if (res.status === 403 || res.status === 429) {
+    const remaining = res.headers.get('x-ratelimit-remaining')
+    throw new Error(
+      `GitHub API rate-limited (status ${res.status}, x-ratelimit-remaining=${remaining ?? '?'}). Set GITHUB_TOKEN locally to raise the limit.`,
+    )
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`GitHub API returned ${res.status} ${res.statusText}: ${text.slice(0, 200)}`)
+  }
+
+  let issue: GitHubIssue
+  try {
+    issue = await res.json()
+  } catch (err) {
+    throw new Error(`failed to parse GitHub JSON response: ${errorMessage(err)}`, {cause: err})
+  }
+
+  if (issue.pull_request) {
+    throw new Error(`${owner}/${repo}#${issueNumber} is a pull request, not an issue`)
+  }
+
+  return issue
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/scripts/trigger-triage/src/index.ts
+++ b/scripts/trigger-triage/src/index.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+import {existsSync, readFileSync} from 'node:fs'
+import {dirname, resolve} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {fetchIssue, parseIssueUrl, type GitHubIssue} from './github.ts'
+import {MiriadRestClient} from './miriad-rest.ts'
+
+const AGENT_NAMES = ['triager', 'squigler'] as const
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const PACKAGE_DIR = resolve(SCRIPT_DIR, '..')
+const REPO_ROOT_DIR = resolve(PACKAGE_DIR, '../..')
+const LOCAL_ENV_FILES = [resolve(PACKAGE_DIR, '.env'), resolve(REPO_ROOT_DIR, '.env')]
+
+const isTTY = process.stdout.isTTY
+const color = (code: string, value: string): string =>
+  isTTY ? `\x1b[${code}m${value}\x1b[0m` : value
+const c = {
+  blue: (value: string) => color('34', value),
+  bold: (value: string) => color('1', value),
+  gray: (value: string) => color('90', value),
+  green: (value: string) => color('32', value),
+  red: (value: string) => color('31', value),
+  yellow: (value: string) => color('33', value),
+}
+
+interface Args {
+  url: string | null
+  dryRun: boolean
+  verbose: boolean
+  help: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {url: null, dryRun: false, verbose: false, help: false}
+
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') args.help = true
+    else if (arg === '--dry-run') args.dryRun = true
+    else if (arg === '--verbose' || arg === '-v') args.verbose = true
+    else if (arg.startsWith('-')) die(`Unknown flag: ${arg}. Run with --help for usage.`)
+    else {
+      if (args.url) die(`Unexpected extra argument: ${arg}`)
+      args.url = arg
+    }
+  }
+
+  return args
+}
+
+function printHelp(): void {
+  process.stdout.write(`trigger-triage - kick off the Miriad triage workflow for a GitHub issue
+
+Usage:
+  trigger-triage <github-issue-url>
+  trigger-triage --dry-run <github-issue-url>
+  trigger-triage --verbose <github-issue-url>
+  trigger-triage --help
+
+Environment:
+  MIRIAD_URL        Miriad REST API base URL (required, unless --dry-run)
+  MIRIAD_TOKEN      Miriad bearer token (required, unless --dry-run)
+  MIRIAD_SPACE_ID   Miriad space short id (required, unless --dry-run)
+  GITHUB_TOKEN      Optional for local runs; GitHub Actions uses github.token
+
+Agents:
+  ${AGENT_NAMES.join(', ')} (hardcoded in src/index.ts)
+
+Examples:
+  trigger-triage https://github.com/sanity-io/plugins/issues/725
+  trigger-triage --dry-run https://github.com/sanity-io/plugins/issues/725
+`)
+}
+
+function die(msg: string): never {
+  process.stderr.write(c.red(`error: ${msg}\n`))
+  process.exit(1)
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function loadLocalEnv(log: (msg: string) => void): void {
+  for (const envFile of LOCAL_ENV_FILES) {
+    if (!existsSync(envFile)) continue
+
+    log(`loading local env from ${envFile}`)
+    const contents = readFileSync(envFile, 'utf8')
+    for (const rawLine of contents.split(/\r?\n/)) {
+      const parsed = parseEnvLine(rawLine)
+      if (!parsed) continue
+
+      const {key, value} = parsed
+      if (process.env[key] === undefined) process.env[key] = value
+    }
+  }
+}
+
+function parseEnvLine(rawLine: string): {key: string; value: string} | null {
+  const line = rawLine.trim()
+  if (!line || line.startsWith('#')) return null
+
+  const normalized = line.startsWith('export ') ? line.slice('export '.length).trim() : line
+  const separator = normalized.indexOf('=')
+  if (separator <= 0) return null
+
+  const key = normalized.slice(0, separator).trim()
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null
+
+  const rawValue = normalized.slice(separator + 1).trim()
+  return {key, value: unquoteEnvValue(rawValue)}
+}
+
+function unquoteEnvValue(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+const IGNORED_LABELS = new Set(['automated', 'dependencies', 'duplicate', 'wontfix'])
+const DEPENDENCY_DASHBOARD = /^Dependency Dashboard/
+
+interface FilterResult {
+  ignore: boolean
+  reason?: string
+}
+
+function shouldIgnore(issue: GitHubIssue): FilterResult {
+  if (issue.user.type === 'Bot' || issue.user.login.endsWith('[bot]')) {
+    return {ignore: true, reason: `bot author (@${issue.user.login})`}
+  }
+
+  const hit = issue.labels.find((label) => IGNORED_LABELS.has(label.name.toLowerCase()))
+  if (hit) return {ignore: true, reason: `label "${hit.name}"`}
+
+  if (DEPENDENCY_DASHBOARD.test(issue.title)) {
+    return {ignore: true, reason: 'dependency dashboard title'}
+  }
+
+  return {ignore: false}
+}
+
+function composeKickoff(owner: string, repo: string, issue: GitHubIssue): string {
+  const labelNames = issue.labels.map((label) => label.name)
+  const labelStr = labelNames.length > 0 ? labelNames.join(', ') : 'none'
+
+  return [
+    `@triager New issue in ${owner}/${repo}:`,
+    '',
+    `**#${issue.number} - ${issue.title}**`,
+    '',
+    '|  |  |',
+    '| --- | --- |',
+    `| Author | @${issue.user.login} |`,
+    `| Labels | ${labelStr} |`,
+    `| URL | ${issue.html_url} |`,
+    '',
+    'Please read the issue and all of its comments in full before forming a verdict.',
+    'Apply the filters (bot authors, dependency dashboards, ignored labels) yourself.',
+    'Follow the workflow in your SKILL.md end to end.',
+  ].join('\n')
+}
+
+function channelNameFor(repo: string, issueNumber: number): string {
+  if (repo === 'plugins') return `plugins-issue-${issueNumber}`
+  return `${repo}-issue-${issueNumber}`
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2))
+
+  if (args.help) {
+    printHelp()
+    return
+  }
+
+  if (!args.url) {
+    printHelp()
+    die('missing <github-issue-url>')
+  }
+
+  const log = (msg: string): void => {
+    if (args.verbose) process.stderr.write(c.gray(`[debug] ${msg}\n`))
+  }
+  loadLocalEnv(log)
+
+  let parsed: {owner: string; repo: string; issueNumber: number}
+  try {
+    parsed = parseIssueUrl(args.url)
+  } catch (err) {
+    die(errorMessage(err))
+  }
+
+  const {owner, repo, issueNumber} = parsed
+  log(`parsed: owner=${owner} repo=${repo} issue=${issueNumber}`)
+
+  const channelName = channelNameFor(repo, issueNumber)
+
+  let issue: GitHubIssue
+  try {
+    issue = await fetchIssue({
+      owner,
+      repo,
+      issueNumber,
+      token: process.env.GITHUB_TOKEN,
+      log,
+    })
+  } catch (err) {
+    die(`failed to fetch issue: ${errorMessage(err)}`)
+  }
+
+  log(`fetched issue: "${issue.title}" by @${issue.user.login} (${issue.state})`)
+
+  const filter = shouldIgnore(issue)
+  if (filter.ignore) {
+    process.stdout.write(c.yellow(`ignored: ${filter.reason}\n`))
+    return
+  }
+
+  if (issue.state === 'closed') {
+    process.stderr.write(
+      c.yellow('warning: issue is closed - proceeding because needs-triage can be intentional\n'),
+    )
+  }
+
+  const kickoff = composeKickoff(owner, repo, issue)
+
+  if (args.dryRun) {
+    process.stdout.write(c.blue(c.bold('DRY RUN\n')))
+    process.stdout.write(c.gray(`channel: ${channelName}\n`))
+    process.stdout.write(c.gray('--- kickoff message ---\n'))
+    process.stdout.write(`${kickoff}\n`)
+    process.stdout.write(c.gray('--- end ---\n'))
+    process.stdout.write(c.green('dry-run complete (no Miriad REST call made)\n'))
+    return
+  }
+
+  const miriadUrl = process.env.MIRIAD_URL
+  const miriadToken = process.env.MIRIAD_TOKEN
+  const miriadSpaceId = process.env.MIRIAD_SPACE_ID
+
+  if (!miriadUrl) die('MIRIAD_URL is not set (see scripts/trigger-triage/README.md)')
+  if (!miriadToken) die('MIRIAD_TOKEN is not set (see scripts/trigger-triage/README.md)')
+  if (!miriadSpaceId) die('MIRIAD_SPACE_ID is not set (see scripts/trigger-triage/README.md)')
+
+  try {
+    const client = new MiriadRestClient({
+      url: miriadUrl,
+      token: miriadToken,
+      spaceId: miriadSpaceId,
+      log,
+    })
+    const channel = await client.ensureChannel(channelName)
+
+    await Promise.all(AGENT_NAMES.map((agentName) => client.addAgent(channel.id, agentName)))
+
+    await client.sendMessage(channel.id, kickoff)
+  } catch (err) {
+    die(`Miriad REST dispatch failed: ${errorMessage(err)}`)
+  }
+
+  process.stdout.write(
+    c.green(`Triggered triage for ${owner}/${repo}#${issue.number} - channel: ${channelName}\n`),
+  )
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err)
+  process.stderr.write(c.red(`error: ${msg}\n`))
+  process.exit(1)
+})

--- a/scripts/trigger-triage/src/miriad-rest.ts
+++ b/scripts/trigger-triage/src/miriad-rest.ts
@@ -1,0 +1,196 @@
+export interface MiriadRestClientOptions {
+  url: string
+  token: string
+  spaceId: string
+  log?: (msg: string) => void
+}
+
+export interface MiriadChannel {
+  id: string
+  name: string
+  displayName: string | null
+}
+
+export interface MiriadAgent {
+  name: string
+  status?: string
+  statusMessage?: string | null
+}
+
+type JsonObject = Record<string, unknown>
+
+export class MiriadRestClient {
+  private readonly baseUrl: string
+  private readonly token: string
+  private readonly spaceId: string
+  private readonly log: (msg: string) => void
+
+  constructor(opts: MiriadRestClientOptions) {
+    try {
+      this.baseUrl = new URL(opts.url).href.replace(/\/$/, '')
+    } catch {
+      throw new Error(`MIRIAD_URL is not a valid URL: ${opts.url}`)
+    }
+
+    this.token = opts.token
+    this.spaceId = opts.spaceId
+    this.log = opts.log ?? (() => {})
+  }
+
+  async findChannelByName(name: string): Promise<MiriadChannel | null> {
+    const body = await this.request(`/spaces/${this.spaceId}/channels`)
+    return parseChannels(body).find((channel) => channel.name === name) ?? null
+  }
+
+  async ensureChannel(name: string): Promise<MiriadChannel> {
+    const existing = await this.findChannelByName(name)
+    if (existing) {
+      this.log(`channel ${name} already exists - reusing`)
+      return existing
+    }
+
+    this.log(`creating channel ${name}`)
+    try {
+      const body = await this.request(`/spaces/${this.spaceId}/channels`, {
+        method: 'POST',
+        body: JSON.stringify({name}),
+      })
+      return parseChannel(body)
+    } catch (err) {
+      // A concurrent trigger may create the channel between list and create.
+      if (!isHttpStatusError(err, 409)) throw err
+
+      const channel = await this.findChannelByName(name)
+      if (!channel) throw err
+
+      this.log(`channel ${name} was created concurrently - reusing`)
+      return channel
+    }
+  }
+
+  async addAgent(channelId: string, name: string): Promise<MiriadAgent | null> {
+    this.log(`adding agent ${name} to channel ${channelId}`)
+    try {
+      const body = await this.request(`/channels/${channelId}/agents`, {
+        method: 'POST',
+        body: JSON.stringify({name}),
+      })
+      return parseAgent(body)
+    } catch (err) {
+      if (!isHttpStatusError(err, 409)) throw err
+
+      this.log(`agent ${name} already assigned to channel ${channelId}`)
+      return null
+    }
+  }
+
+  async sendMessage(channelId: string, content: string): Promise<void> {
+    this.log(`sending kickoff message to channel ${channelId}`)
+    await this.request(`/channels/${channelId}/messages`, {
+      method: 'POST',
+      body: JSON.stringify({content}),
+    })
+  }
+
+  private async request(path: string, options: RequestInit = {}): Promise<unknown> {
+    const method = options.method ?? 'GET'
+    this.log(`${method} ${path}`)
+    const headers = new Headers(options.headers)
+    headers.set('Authorization', `Bearer ${this.token}`)
+    if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      ...options,
+      headers,
+    })
+
+    const body = await parseBody(res)
+    if (!res.ok) {
+      throw new HttpStatusError(method, path, res.status, body)
+    }
+
+    return body
+  }
+}
+
+class HttpStatusError extends Error {
+  readonly method: string
+  readonly path: string
+  readonly status: number
+  readonly body: unknown
+
+  constructor(method: string, path: string, status: number, body: unknown) {
+    super(`${method} ${path} failed: ${status} ${formatBody(body)}`)
+    this.method = method
+    this.path = path
+    this.status = status
+    this.body = body
+  }
+}
+
+function isHttpStatusError(err: unknown, status: number): err is HttpStatusError {
+  return err instanceof HttpStatusError && err.status === status
+}
+
+async function parseBody(res: Response): Promise<unknown> {
+  const text = await res.text()
+  if (!text) return null
+
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return text
+  }
+}
+
+function formatBody(body: unknown): string {
+  if (body === null || body === undefined) return '(empty response)'
+  return typeof body === 'string' ? body : JSON.stringify(body)
+}
+
+function parseChannels(body: unknown): MiriadChannel[] {
+  const rawChannels = Array.isArray(body)
+    ? body
+    : isObject(body) && Array.isArray(body.channels)
+      ? body.channels
+      : []
+
+  return rawChannels
+    .map((channel) => toChannel(channel))
+    .filter((channel): channel is MiriadChannel => channel !== null)
+}
+
+function parseChannel(body: unknown): MiriadChannel {
+  const channel = toChannel(body)
+  if (!channel)
+    throw new Error(`Miriad channel payload did not match expected shape: ${formatBody(body)}`)
+  return channel
+}
+
+function parseAgent(body: unknown): MiriadAgent {
+  if (!isObject(body) || typeof body.name !== 'string') {
+    throw new Error(`Miriad agent payload did not match expected shape: ${formatBody(body)}`)
+  }
+
+  return {
+    name: body.name,
+    status: typeof body.status === 'string' ? body.status : undefined,
+    statusMessage: typeof body.statusMessage === 'string' ? body.statusMessage : null,
+  }
+}
+
+function toChannel(value: unknown): MiriadChannel | null {
+  if (!isObject(value) || typeof value.id !== 'string' || typeof value.name !== 'string') {
+    return null
+  }
+
+  return {
+    id: value.id,
+    name: value.name,
+    displayName: typeof value.displayName === 'string' ? value.displayName : null,
+  }
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null
+}

--- a/scripts/trigger-triage/tsconfig.json
+++ b/scripts/trigger-triage/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "declaration": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "exclude": ["dist", "node_modules"],
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Closes #570

Adds **per-schemaType language filtering** across both plugins that participate in the translations UI. The reporter has 56 languages with a per-type mapping; today every type that has the plugin enabled shows all 56.

This PR covers both surfaces:

| Surface | Plugin | Option |
|---|---|---|
| Translations menu (the document toolbar popover) | `@sanity/document-internationalization` | `languageFilter({schemaType, defaultLanguages}) => Language[]` |
| Add-language buttons on `internationalizedArray*` fields | `sanity-plugin-internationalized-array` | `filterLanguages({schemaType, defaultLanguages}) => Language[]` |

Different names because `languageFilter` is already the existing config key on `sanity-plugin-internationalized-array` for the `@sanity/language-filter` plugin integration. Reusing the name would be a breaking change there. Same signature on both, so a user who wants the two layers aligned can pass the same lambda to both.

## API

```ts
// Document-level (the Translations menu)
documentInternationalization({
  supportedLanguages: [...],
  schemaTypes: ['lesson', 'recipe'],
  languageFilter: ({schemaType, defaultLanguages}) => {
    if (schemaType === 'recipe') {
      return defaultLanguages.filter((l) => ['en', 'it'].includes(l.id))
    }
    return defaultLanguages
  },
})

// Field-level (the add-language buttons on internationalizedArray fields)
internationalizedArray({
  languages: [...],
  fieldTypes: ['string', 'text'],
  filterLanguages: ({schemaType, defaultLanguages}) => {
    if (schemaType === 'recipe') {
      return defaultLanguages.filter((l) => ['en', 'it'].includes(l.id))
    }
    return defaultLanguages
  },
})
```

Both filters are:
- **Sync.** They run after the underlying `supportedLanguages` / `languages` is resolved (including async-function language sources).
- **UI-only.** Badges, templates, validity checks, existing array values, and the `translation.metadata` document layer are all untouched. A document previously translated into a language you later filter out keeps its data and its badge, and remains reachable through the metadata document.
- **Composable.** The array plugin's `filterLanguages` runs **before** the existing `@sanity/language-filter` user-selection toggle, so the user picks among the already-narrowed set.

## Design choices

- **Sync, not async.** Both filters run at render time on an already-resolved language list, so we don't introduce extra loading states inside the menu or the field. Easy to relax later.
- **Receives `defaultLanguages` instead of being called per-language.** Lets the caller filter/reorder/dedupe in one pass.
- **Menu/buttons only.** Validity checks (`sourceLanguageIsValid`), badges, and the templates registered for the "Create new translation" command continue to operate against the full lists.
- **`translation.metadata` array left out of scope.** The metadata doc isn't pinned to one schemaType (`metadata.schemaTypes: string[]`), so a single-schemaType filter doesn't map cleanly there. Worth a separate issue if it becomes a blocker. Documented as a known limitation in both READMEs.

## Tests

**`@sanity/document-internationalization`** — `src/components/DocumentInternationalizationMenu.test.tsx`, new `languageFilter` describe block:
1. Default behaviour unchanged when no `languageFilter` is configured.
2. Filter returning a subset narrows the menu to that subset, in order.
3. Filter receives `{schemaType, defaultLanguages}` correctly.
4. Filter returning `[]` renders the Manage Translations button but no language options.
5. Search-input visibility threshold uses the filtered count.

**`sanity-plugin-internationalized-array`** — new `src/components/InternationalizedArrayContext.test.ts` covering the composition logic in isolation:
1. No filter, no user selection → full list.
2. Filter applied with the right context shape.
3. Filter return order preserved.
4. Filter returning `[]` → empty result.
5. Composition: static filter intersected with user selection.
6. User selection ignored when documentType isn't enabled in `languageFilter.documentTypes`.
7. Filter receives correct `schemaType`.
8. Runtime contract: filter return value is trusted (no second-stage filtering against `defaultLanguages`).

Plus two tests in `src/components/AddButtons.test.tsx` verifying the consumer side renders correctly when `filteredLanguages` is narrowed (or empty).

Test status:
- `@sanity/document-internationalization`: **155/155** ✅
- `sanity-plugin-internationalized-array`: **182/182** ✅
- Both plugins: `pnpm build` strict + check passes.
- `dev/test-studio` build passes with the new demo doc types.

## Live demo in test-studio

`dev/test-studio/src/document-internationalization/index.tsx` now registers two demo doc types in the `kitchen-sink` workspace:

- **Recipe (#570 demo)** — uses `languageFilter` (doc menu) **and** `filterLanguages` (field buttons), both restricted to `en + it`.
- **Lesson (#570 demo, no filter)** — same shared language list (`en, es, fr, de, it, pt`), no filter, so all six render in both surfaces.

To exercise:
1. `gh pr checkout 879` && `pnpm install` && `pnpm --filter test-studio... build` (or `pnpm --filter test-studio dev`)
2. Open the `kitchen-sink` workspace
3. Create a new **Recipe (#570 demo)** document. Click `Translations` in the toolbar — only English and Italian appear. The `Localized title` field's add-language buttons show only `EN` and `IT` too.
4. Create a new **Lesson (#570 demo, no filter)** document. Both surfaces show all six languages.

## How to review

```sh
gh pr checkout 879
pnpm install
pnpm --filter @sanity/document-internationalization test
pnpm --filter sanity-plugin-internationalized-array test
pnpm --filter test-studio... build
```

Both READMEs have new sections with full signatures and the cross-plugin pairing pattern.

## ⚠️ Bot-drafted

Drafted by `sanity-issue-bot` for issue #570 at @pedro's request, then extended at @pedro's request to cover the field-level half. Needs human review before merge.