### PR TITLE
fix(workflow): correct drag-and-drop item positioning

### DIFF
--- a/.changeset/mighty-mirrors-flow.md
+++ b/.changeset/mighty-mirrors-flow.md
@@ -1,0 +1,12 @@
+---
+"sanity-plugin-workflow": patch
+---
+
+Fix drag-and-drop item positioning issue in workflow columns
+
+Workflow items would drop one position off from where they were visually placed when dragging within the same column. This was caused by the dragged item remaining in the destination items array during rank calculation.
+
+**Changes:**
+
+- Filter out the dragged item when reordering within the same column, aligning with dnd library expectations
+- Fix boundary check for end-of-list drops to correctly identify when dropping at or past the last position

--- a/plugins/sanity-plugin-workflow/src/components/WorkflowTool.tsx
+++ b/plugins/sanity-plugin-workflow/src/components/WorkflowTool.tsx
@@ -119,7 +119,15 @@ export default function WorkflowTool(props: WorkflowToolProps) {
       }
 
       // Find all items in current state
-      const destinationStateItems = [...filterItemsAndSort(data, destination.droppableId, [], null)]
+      let destinationStateItems = [...filterItemsAndSort(data, destination.droppableId, [], null)]
+
+      // Filter out the dragged item when reordering within the same column
+      if (source.droppableId === destination.droppableId) {
+        destinationStateItems = destinationStateItems.filter(
+          (item) => item._metadata?.documentId !== draggableId,
+        )
+      }
+
       const destinationStateIndex = states.findIndex((s) => s.id === destination.droppableId)
       const globalStateMinimumRank = data?.[0]?._metadata.orderRank
       const globalStateMaximumRank = data?.[data?.length - 1]?._metadata.orderRank
@@ -149,7 +157,7 @@ export default function WorkflowTool(props: WorkflowToolProps) {
           // Otherwise create the next rank between min and the globally minimum rank
           newOrder = LexoRank.parse(globalStateMinimumRank!).between(LexoRank.min()).toString()
         }
-      } else if (destination.index + 1 === destinationStateItems.length) {
+      } else if (destination.index >= destinationStateItems.length) {
         // Now last item in order
         const lastItemOrderRank = [...destinationStateItems].pop()?._metadata?.orderRank
 


### PR DESCRIPTION
### Description

Dragging a workflow item within the same column would drop it one position off from where it was visually placed. This was caused when reordering inside a single workflow column, `destinationStateItems` would still contain the dragged item, so the LexoRank calculation picked neighbours that were off by one. The boundary check for end-of-list drops (`destination.index + 1 === destinationStateItems.length`) also didn't account for the filtered array being one item shorter.

This PR filters the dragged item out of `destinationStateItems` when source and destination columns match, and relaxes the end-of-list boundary to `>=` so dropping at or past the last position is handled correctly.

### What to review

`WorkflowTool.tsx`: the `destinationStateItems` filter block (same-column guard) and the updated boundary condition on line 160.

### Testing

Manually tested in `dev/test-studio`, by dragging items within a single workflow column — items now land exactly where they are visually dropped. Cross-column drags unaffected.