### PR TITLE
Feat/bynder plugin raw fields option

### DIFF
--- a/.changeset/bynder-persist-raw-fields.md
+++ b/.changeset/bynder-persist-raw-fields.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-bynder-input': minor
+---
+
+Add `persistRawFields` option to opt out of persisting the full raw Bynder asset payload. Available both on `bynderInputPlugin({...})` as a Studio-wide default and on a `bynder.asset` field's `options` as a per-field override. Defaults to `true` so existing documents and behavior are unchanged.

--- a/plugins/sanity-plugin-bynder-input/README.md
+++ b/plugins/sanity-plugin-bynder-input/README.md
@@ -121,6 +121,61 @@ type BynderAssetFilterJson = {
 }
 ```
 
+## Limiting persisted fields
+
+By default the plugin spreads the full raw Bynder asset payload onto the persisted document, alongside the canonical fields declared on the `bynder.asset` schema. Set `persistRawFields: false` to skip the spread and persist only the canonical subset (`id`, `name`, `databaseId`, `type`, `description`, `previewUrl`, `previewImg`, `datUrl`, `videoUrl`, `aspectRatio`, `selectedUrl`, `width`, `height`).
+
+This is useful if you want to avoid storing tags, metaproperties, derivatives, timestamps, and other Bynder-side metadata in your Sanity documents.
+
+### Studio-wide default
+
+Set `persistRawFields` when configuring the plugin to change the default for every `bynder.asset` field in the Studio.
+
+```ts
+import {defineConfig} from 'sanity'
+import {bynderInputPlugin} from 'sanity-plugin-bynder-input'
+
+export default defineConfig({
+  // ...other config
+  plugins: [
+    bynderInputPlugin({
+      portalConfig: {url: 'https://wave-trial.getbynder.com/'},
+      compactViewOptions: {language: 'en_US'},
+      // Default for all bynder.asset fields — can be overridden per field
+      persistRawFields: false,
+    }),
+  ],
+})
+```
+
+### Per-field override
+
+Set `persistRawFields` on a field's `options` to override the Studio-wide default for that field.
+
+```javascript
+import {defineType, defineField} from 'sanity'
+
+export const myDocumentSchema = defineType({
+  type: 'document',
+  name: 'article',
+  fields: [
+    defineField({
+      type: 'bynder.asset',
+      name: 'image',
+      options: {
+        // Persist only the fields declared on the bynder.asset schema,
+        // regardless of the Studio-wide default
+        persistRawFields: false,
+      },
+    }),
+  ],
+})
+```
+
+Resolution order is field-level → plugin-level → `true` (the back-compatible default).
+
+Documents written before this option was set retain any extra fields they were saved with — the option only affects new writes.
+
 ## License
 
 [MIT](LICENSE) © Sanity.io

--- a/plugins/sanity-plugin-bynder-input/src/components/BynderInput.tsx
+++ b/plugins/sanity-plugin-bynder-input/src/components/BynderInput.tsx
@@ -11,6 +11,13 @@ const BynderModalLayout = lazy(() => import('./BynderModalLayout'))
 export interface BynderConfig {
   portalConfig: PortalConfig
   compactViewOptions: Omit<CompactViewProps, 'onSuccess'>
+  /**
+   * Studio-wide default for whether the full raw Bynder asset payload is
+   * persisted onto documents (in addition to the canonical schema fields).
+   * Field-level `persistRawFields` in `BynderAssetOptions` overrides this.
+   * Defaults to `true` to preserve existing behavior.
+   */
+  persistRawFields?: boolean
 }
 
 export interface BynderInputProps extends ObjectInputProps<BynderAssetValue> {
@@ -92,17 +99,23 @@ export function BynderInput(props: BynderInputProps): React.JSX.Element {
         })
       : undefined
 
-    // Spread all raw Bynder asset fields first, then override with
-    // computed/mapped fields for backward compatibility
-    const mediaData = {
-      // 1. Spread ALL raw Bynder fields at top level
-      ...asset,
+    const persistRawFields = fieldOptions?.persistRawFields ?? pluginConfig.persistRawFields ?? true
 
-      // 2. Required Sanity fields (override any conflicts)
+    const mediaData = {
+      // When `persistRawFields` is true (the default), spread the full raw Bynder
+      // asset payload first; explicit fields below then override with the
+      // canonical, computed, or mapped values declared in the schema.
+      ...(persistRawFields ? asset : {}),
+
       _key: value?._key,
       _type: schemaType.name,
 
-      // 3. Backward-compatible computed fields (override raw values)
+      id: asset['id'],
+      name: asset['name'],
+      databaseId: asset['databaseId'],
+      type: asset['type'],
+      description: asset['description'],
+
       previewUrl: getPreviewUrl(asset, addInfo),
       previewImg: webImage?.url,
       datUrl: asset['files']?.['transformBaseUrl']?.url,

--- a/plugins/sanity-plugin-bynder-input/src/plugin.tsx
+++ b/plugins/sanity-plugin-bynder-input/src/plugin.tsx
@@ -14,6 +14,7 @@ export const bynderInputPlugin: Plugin<Partial<BynderConfig>> = definePlugin(
         language: 'en_US',
         ...config?.compactViewOptions,
       },
+      persistRawFields: config?.persistRawFields,
     }
 
     return {

--- a/plugins/sanity-plugin-bynder-input/src/schema/bynder.asset.ts
+++ b/plugins/sanity-plugin-bynder-input/src/schema/bynder.asset.ts
@@ -19,6 +19,13 @@ type BynderAssetFilterJson = {
 export interface BynderAssetOptions extends ObjectOptions {
   assetTypes?: ('image' | 'video' | 'audio' | (string & {}))[]
   assetFilter?: BynderAssetFilterJson
+  /**
+   * When `true` (the default) the full raw Bynder asset payload is spread onto
+   * the persisted document alongside the canonical fields declared in the
+   * `bynder.asset` schema. Set to `false` to persist only the canonical subset
+   * (the fields enumerated in `BynderAssetValue` / the schema definition).
+   */
+  persistRawFields?: boolean
 }
 
 /**


### PR DESCRIPTION
### Description

Adds a `persistRawFields` option to `sanity-plugin-bynder-input` so consumers can opt out of persisting the full raw Bynder asset payload on their Sanity documents. Since [PR #182 / v3.0.3](https://github.com/sanity-io/plugins/pull/182), `BynderInput`'s `onSuccess` spreads the entire Bynder asset response (`...asset`) into the document, which writes tags, metaproperties, derivatives, timestamps, and other Bynder-side metadata that isn't part of the `bynder.asset` schema. That behavior is preserved as the default, but consumers who don't want it can now turn it off — Studio-wide on the plugin config, or per-field on the schema's `options`. When disabled, only the canonical schema fields are persisted.

### What to review

- `src/components/BynderInput.tsx` — `BynderConfig` gains `persistRawFields?: boolean`. `onSuccess` resolves the effective value as `fieldOptions?.persistRawFields ?? pluginConfig.persistRawFields ?? true` and conditionally spreads `...asset`. Explicit `id` / `name` / `databaseId` / `type` / `description` assignments were added after the conditional spread so the canonical subset is still persisted when the spread is skipped (these were previously coming through `...asset` only).
- `src/schema/bynder.asset.ts` — `BynderAssetOptions` gains `persistRawFields?: boolean` for the field-level override.
- `src/plugin.tsx` — `reqConfig` forwards `persistRawFields` from the user-provided plugin config.
- `README.md` — new "Limiting persisted fields" section documenting both layers and the resolution order.
- `.changeset/bynder-persist-raw-fields.md` — `minor` bump, additive change with current behavior preserved as default.

Default behavior is unchanged. Documents written before the option is set keep any extra fields they were saved with; the option only affects new writes.

### Testing

No new automated tests. The plugin's existing test suite is a single package-exports snapshot, and the new option is a thin conditional in `onSuccess` without unit-test scaffolding for the input component. Verified via:

- `pnpm --filter sanity-plugin-bynder-input build` — passes, dts output includes the new option on both types.
- `pnpm lint` / `pnpm format` — clean.
- `pnpm vitest run --project sanity-plugin-bynder-input` — existing test passes.

**End-to-end verification in the test studio was attempted but blocked by a separate bug.** When testing in the `kitchen-sink` workspace of the local test studio, the Bynder Compact View modal opens but renders at `height: 0` — its host container (`[data-test-id="CompactViewContainer"]`) has no enforced dimensions, so the inner `[data-testid="root"]` element with `height: 100%` collapses. The login form is in the DOM (confirmed via Elements inspector and shadow root traversal) but the modal is visually empty and clicking through it freezes the Studio. This is unrelated to the change in this PR — it reproduces on `main` and appears to be a Studio v5 / `@bynder/compact-view` integration regression.

I added the `trigger:preview` and tested the preview package against a Demo studio that had the Bynder plugin installed.  I confirmed that the dialogs work as normal and that assets stored with the field-level and plugin-level `persistRawFields: false` options work as expected.  I also provided the preview package to a customer who tested and confirmed it was working on their Studio as well. 