### PR TITLE
feat: add omnisearch availablity to document Internationalization

### DIFF
--- a/.changeset/document-internationalization-omnisearch.md
+++ b/.changeset/document-internationalization-omnisearch.md
@@ -1,0 +1,5 @@
+---
+"@sanity/document-internationalization": minor
+---
+
+Add a `metadataOmnisearchVisibility` option to control whether translation metadata documents appear in Omnisearch.

--- a/plugins/@sanity/document-internationalization/README.md
+++ b/plugins/@sanity/document-internationalization/README.md
@@ -250,6 +250,10 @@ export const defineConfig({
       // - An array of schema type names: `hideLanguageFilter: ['lesson']`
       // - A function for dynamic control: `hideLanguageFilter: (ctx) => ctx.schemaType === 'lesson'`
       hideLanguageFilter: true, // defaults to false
+
+      // Optional
+      // Controls whether translation.metadata documents are visible in Omnisearch
+      metadataOmnisearchVisibility: true, // defaults to true
     })
   ]
 })

--- a/plugins/@sanity/document-internationalization/src/constants.ts
+++ b/plugins/@sanity/document-internationalization/src/constants.ts
@@ -14,5 +14,6 @@ export const DEFAULT_CONFIG: PluginConfigContext = {
   allowCreateMetaDoc: false,
   callback: null,
   hideLanguageFilter: false,
+  metadataOmnisearchVisibility: true,
   addTemplates: true,
 }

--- a/plugins/@sanity/document-internationalization/src/plugin.tsx
+++ b/plugins/@sanity/document-internationalization/src/plugin.tsx
@@ -22,6 +22,7 @@ export const documentInternationalization = definePlugin<PluginConfig>((config) 
     bulkPublish,
     metadataFields,
     hideLanguageFilter,
+    metadataOmnisearchVisibility,
     metadataInternationalization,
     addTemplates,
   } = pluginConfig
@@ -125,7 +126,7 @@ export const documentInternationalization = definePlugin<PluginConfig>((config) 
     // - The `Translations metadata` document type to the schema
     schema: {
       // Create the metadata document type
-      types: [metadata(schemaTypes, metadataFields)],
+      types: [metadata(schemaTypes, metadataFields, metadataOmnisearchVisibility)],
 
       // For every schema type this plugin is enabled on
       // Create an initial value template to set the language

--- a/plugins/@sanity/document-internationalization/src/schema/translation/metadata.test.ts
+++ b/plugins/@sanity/document-internationalization/src/schema/translation/metadata.test.ts
@@ -6,6 +6,10 @@ import {describe, expect, test} from 'vitest'
 import {METADATA_SCHEMA_NAME, TRANSLATIONS_ARRAY_NAME} from '../../constants'
 import createMetadataSchema from './metadata'
 
+type MetadataSchema = ReturnType<typeof createMetadataSchema> & {
+  __experimental_omnisearch_visibility?: boolean
+}
+
 describe('metadata schema', () => {
   const schemaTypes = ['article', 'page']
 
@@ -93,6 +97,18 @@ describe('metadata schema', () => {
     const schema = createMetadataSchema(schemaTypes, [])
 
     expect(schema.liveEdit).toBe(true)
+  })
+
+  test('sets Omnisearch visibility to false by default', () => {
+    const schema = createMetadataSchema(schemaTypes, []) as MetadataSchema
+
+    expect(schema.__experimental_omnisearch_visibility).toBe(false)
+  })
+
+  test('configures Omnisearch visibility when provided', () => {
+    const schema = createMetadataSchema(schemaTypes, [], true) as MetadataSchema
+
+    expect(schema.__experimental_omnisearch_visibility).toBe(true)
   })
 
   test('uses TranslateIcon', () => {

--- a/plugins/@sanity/document-internationalization/src/schema/translation/metadata.test.ts
+++ b/plugins/@sanity/document-internationalization/src/schema/translation/metadata.test.ts
@@ -99,16 +99,22 @@ describe('metadata schema', () => {
     expect(schema.liveEdit).toBe(true)
   })
 
-  test('sets Omnisearch visibility to false by default', () => {
+  test('sets Omnisearch visibility to true by default', () => {
     const schema = createMetadataSchema(schemaTypes, []) as MetadataSchema
 
-    expect(schema.__experimental_omnisearch_visibility).toBe(false)
+    expect(schema.__experimental_omnisearch_visibility).toBe(true)
   })
 
   test('configures Omnisearch visibility when provided', () => {
     const schema = createMetadataSchema(schemaTypes, [], true) as MetadataSchema
 
     expect(schema.__experimental_omnisearch_visibility).toBe(true)
+  })
+
+  test('configures Omnisearch visibility when provided false', () => {
+    const schema = createMetadataSchema(schemaTypes, [], false) as MetadataSchema
+
+    expect(schema.__experimental_omnisearch_visibility).toBe(false)
   })
 
   test('uses TranslateIcon', () => {

--- a/plugins/@sanity/document-internationalization/src/schema/translation/metadata.ts
+++ b/plugins/@sanity/document-internationalization/src/schema/translation/metadata.ts
@@ -12,13 +12,14 @@ import type {TranslationReference} from '../../types'
  * metadata fields provided by the plugin consumer. The document uses `liveEdit`
  * so changes are published immediately without drafts.
  */
-export default (schemaTypes: string[], metadataFields: FieldDefinition[]): DocumentDefinition =>
+export default (schemaTypes: string[], metadataFields: FieldDefinition[], omnisearchVisibility = false): DocumentDefinition =>
   defineType({
     type: 'document',
     name: METADATA_SCHEMA_NAME,
     title: 'Translation metadata',
     icon: TranslateIcon,
     liveEdit: true,
+    __experimental_omnisearch_visibility: omnisearchVisibility,
     fields: [
       defineField({
         name: TRANSLATIONS_ARRAY_NAME,

--- a/plugins/@sanity/document-internationalization/src/schema/translation/metadata.ts
+++ b/plugins/@sanity/document-internationalization/src/schema/translation/metadata.ts
@@ -12,7 +12,7 @@ import type {TranslationReference} from '../../types'
  * metadata fields provided by the plugin consumer. The document uses `liveEdit`
  * so changes are published immediately without drafts.
  */
-export default (schemaTypes: string[], metadataFields: FieldDefinition[], omnisearchVisibility = false): DocumentDefinition =>
+export default (schemaTypes: string[], metadataFields: FieldDefinition[], omnisearchVisibility = true): DocumentDefinition =>
   defineType({
     type: 'document',
     name: METADATA_SCHEMA_NAME,

--- a/plugins/@sanity/document-internationalization/src/types.ts
+++ b/plugins/@sanity/document-internationalization/src/types.ts
@@ -40,6 +40,12 @@ export type PluginConfig = {
   callback?: ((args: PluginCallbackArgs) => Promise<void>) | null
   hideLanguageFilter?: boolean | string[] | ((ctx: DocumentLanguageFilterContext) => boolean)
   /**
+   * Controls whether the translation metadata document type appears in Omnisearch.
+   *
+   * Set to false to hide `translation.metadata` documents from Omnisearch.
+   */
+  metadataOmnisearchVisibility?: boolean
+  /**
    * Allows configuring the behavior of the internationalized array for the metadata document.
    */
   metadataInternationalization?: Pick<


### PR DESCRIPTION
### Description

Added Omnisearch visibility support for the `translation.metadata` document schema via the `metadataOmnisearchVisibility` plugin option.

This defaults to `true`, so metadata documents are still visible from global search unless users explicitly sets with `metadataOmnisearchVisibility: false`.

This lets users decide whether internal translation metadata documents should appear in Omnisearch.

### What to review

Review the new `metadataOmnisearchVisibility` config option, its default value, and how it is passed into the metadata schema as `__experimental_omnisearch_visibility`.

Affected areas:

- plugin configuration types
- default plugin config
- `translation.metadata` schema generation
- README docs
- metadata schema tests

### Testing

Added schema tests covering:

- default Omnisearch visibility is `true`
- configured Omnisearch visibility can be set to `false`