### PR TITLE
chore: widen sanity peerDependency to support Studio v6

### DIFF
--- a/.changeset/aprimo-sanity-v6-peer.md
+++ b/.changeset/aprimo-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-aprimo': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/asset-source-unsplash-sanity-v6-peer.md
+++ b/.changeset/asset-source-unsplash-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-asset-source-unsplash': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/assist-sanity-v6-peer.md
+++ b/.changeset/assist-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/assist': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/bynder-input-sanity-v6-peer.md
+++ b/.changeset/bynder-input-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-bynder-input': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/code-input-sanity-v6-peer.md
+++ b/.changeset/code-input-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/code-input': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/color-input-sanity-v6-peer.md
+++ b/.changeset/color-input-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/color-input': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/debug-live-sync-tags-sanity-v6-peer.md
+++ b/.changeset/debug-live-sync-tags-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/debug-live-sync-tags': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/debug-preview-url-secret-sanity-v6-peer.md
+++ b/.changeset/debug-preview-url-secret-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/debug-preview-url-secret-plugin': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/document-internationalization-sanity-v6-peer.md
+++ b/.changeset/document-internationalization-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/document-internationalization': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/graph-view-sanity-v6-peer.md
+++ b/.changeset/graph-view-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-graph-view': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/iframe-pane-sanity-v6-peer.md
+++ b/.changeset/iframe-pane-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-iframe-pane': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/internationalized-array-sanity-v6-peer.md
+++ b/.changeset/internationalized-array-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-internationalized-array': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/language-filter-sanity-v6-peer.md
+++ b/.changeset/language-filter-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/language-filter': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/markdown-sanity-v6-peer.md
+++ b/.changeset/markdown-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-markdown': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/presets-sanity-v6-peer.md
+++ b/.changeset/presets-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/presets': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/rich-date-input-sanity-v6-peer.md
+++ b/.changeset/rich-date-input-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/rich-date-input': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/sfcc-sanity-v6-peer.md
+++ b/.changeset/sfcc-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/sfcc': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/studio-secrets-sanity-v6-peer.md
+++ b/.changeset/studio-secrets-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/studio-secrets': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/vercel-protection-bypass-sanity-v6-peer.md
+++ b/.changeset/vercel-protection-bypass-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'@sanity/vercel-protection-bypass': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/workflow-sanity-v6-peer.md
+++ b/.changeset/workflow-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-workflow': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/.changeset/workspace-home-sanity-v6-peer.md
+++ b/.changeset/workspace-home-sanity-v6-peer.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-workspace-home': patch
+---
+
+Widen `sanity` peer-dependency range to `^5 || ^6.0.0-0` to support Sanity Studio v6 (including v6 pre-releases).

--- a/plugins/@sanity/assist/package.json
+++ b/plugins/@sanity/assist/package.json
@@ -70,10 +70,10 @@
     "styled-components": "catalog:"
   },
   "peerDependencies": {
-    "@sanity/mutator": "^5",
+    "@sanity/mutator": "^5 || ^6.0.0-0",
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/@sanity/code-input/package.json
+++ b/plugins/@sanity/code-input/package.json
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/@sanity/color-input/package.json
+++ b/plugins/@sanity/color-input/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/@sanity/debug-live-sync-tags/package.json
+++ b/plugins/@sanity/debug-live-sync-tags/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/@sanity/debug-preview-url-secret-plugin/package.json
+++ b/plugins/@sanity/debug-preview-url-secret-plugin/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/document-internationalization/package.json
+++ b/plugins/@sanity/document-internationalization/package.json
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "sanity-plugin-internationalized-array": "^5.0.0"
   },
   "engines": {

--- a/plugins/@sanity/language-filter/package.json
+++ b/plugins/@sanity/language-filter/package.json
@@ -65,7 +65,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/presets/package.json
+++ b/plugins/@sanity/presets/package.json
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/rich-date-input/package.json
+++ b/plugins/@sanity/rich-date-input/package.json
@@ -68,7 +68,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/sfcc/package.json
+++ b/plugins/@sanity/sfcc/package.json
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "sanity-plugin-internationalized-array": "^4.0.0 || ^5.0.0"
   },
   "engines": {

--- a/plugins/@sanity/studio-secrets/package.json
+++ b/plugins/@sanity/studio-secrets/package.json
@@ -64,7 +64,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/vercel-protection-bypass/package.json
+++ b/plugins/@sanity/vercel-protection-bypass/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/sanity-plugin-aprimo/package.json
+++ b/plugins/sanity-plugin-aprimo/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/sanity-plugin-asset-source-unsplash/package.json
+++ b/plugins/sanity-plugin-asset-source-unsplash/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/sanity-plugin-bynder-input/package.json
+++ b/plugins/sanity-plugin-bynder-input/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/sanity-plugin-graph-view/package.json
+++ b/plugins/sanity-plugin-graph-view/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/sanity-plugin-iframe-pane/package.json
+++ b/plugins/sanity-plugin-iframe-pane/package.json
@@ -64,7 +64,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/sanity-plugin-internationalized-array/package.json
+++ b/plugins/sanity-plugin-internationalized-array/package.json
@@ -75,7 +75,7 @@
     "@sanity/language-filter": "^5.0.0",
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"
+    "sanity": "^5 || ^6.0.0-0"
   },
   "peerDependenciesMeta": {
     "@sanity/assist": {

--- a/plugins/sanity-plugin-markdown/package.json
+++ b/plugins/sanity-plugin-markdown/package.json
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "easymde": "^2.18",
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/sanity-plugin-workflow/package.json
+++ b/plugins/sanity-plugin-workflow/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/plugins/sanity-plugin-workspace-home/package.json
+++ b/plugins/sanity-plugin-workspace-home/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "sanity": "^5",
+    "sanity": "^5 || ^6.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
         specifier: ^3.7.4
         version: 3.7.4(react@19.2.5)
       '@sanity/mutator':
-        specifier: ^5
+        specifier: ^5 || ^6.0.0-0
         version: 5.21.0(@types/react@19.2.14)
       '@sanity/ui':
         specifier: 'catalog:'

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -63,7 +63,7 @@
   "peerDependencies": {
     "react": "^19.2",
     "react-dom": "^19.2",
-    "sanity": "^5"{{#if hasStyledComponents}},
+    "sanity": "^5 || ^6.0.0-0"{{#if hasStyledComponents}},
     "styled-components": "^6.1"{{/if}}
   },
   "engines": {


### PR DESCRIPTION
### Description

Widen the `sanity` peer-dependency range on all 21 published plugins from `^5` to `^5 || ^6.0.0-0`. The `-0` lower bound lets v6 pre-release tags (e.g. `6.0.0-next.0`) satisfy the range — plain `^6` excludes pre-releases by semver rules, which would block plugins from installing against `sanity@next-major`. Also widen `@sanity/mutator` peerDep in `@sanity/assist` to the same range, and update the plugin generator template so newly scaffolded plugins inherit the wider range.

No source changes: an audit of `useClient` `.catch` sites found ~17 explicit handlers across @sanity/assist, sanity-plugin-workflow, and @sanity/document-internationalization, but the v6 global error handler will ship as opt-in (not opt-out), so existing plugin code continues to work unchanged. No `auth.providers` usage and no blatant strict-mode violations were found.

### What to review

### Testing
Existing tests should be enough