### PR TITLE
fix(presets): tighten getPreset return type to SchemaTypeDefinition & FieldDefinition

### DIFF
--- a/.changeset/presets-tighten-get-preset-return-type.md
+++ b/.changeset/presets-tighten-get-preset-return-type.md
@@ -1,0 +1,5 @@
+---
+'@sanity/presets': patch
+---
+
+Tighten `RegistryContext.getPreset` return type to `SchemaTypeDefinition & FieldDefinition` to reflect what the registry actually returns

--- a/plugins/@sanity/presets/src/definePresetType.ts
+++ b/plugins/@sanity/presets/src/definePresetType.ts
@@ -8,7 +8,10 @@ import type {
 import type {PartialSchemaDefinition} from './types'
 
 export interface RegistryContext {
-  getPreset: (presetName: string, config?: Record<string, unknown>) => FieldDefinition
+  getPreset: (
+    presetName: string,
+    config?: Record<string, unknown>,
+  ) => SchemaTypeDefinition & FieldDefinition
 }
 
 type ProhibitedProperties = 'type'

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -1,4 +1,4 @@
-import {defineField, type FieldDefinition, type SchemaTypeDefinition} from 'sanity'
+import type {FieldDefinition, SchemaTypeDefinition} from 'sanity'
 import {describe, expect, vi} from 'vitest'
 
 import type {RegistryContext} from '../../definePresetType'
@@ -21,14 +21,11 @@ interface BlockMember extends Member {
 function makeStubRegistry(): RegistryContext & {
   getPreset: ReturnType<typeof vi.fn>
 } {
-  const getPreset = vi.fn(
-    (presetName: string, presetConfig?: Record<string, unknown>): FieldDefinition => {
-      const name = typeof presetConfig?.['name'] === 'string' ? presetConfig['name'] : presetName
-      return Object.assign(defineField({name, type: 'object', fields: []}), {
-        __preset: presetName,
-      })
-    },
-  )
+  const getPreset = vi.fn((presetName: string, presetConfig?: Record<string, unknown>) => {
+    const name = typeof presetConfig?.['name'] === 'string' ? presetConfig['name'] : presetName
+    return {name, type: 'object', fields: [], __preset: presetName} as SchemaTypeDefinition &
+      FieldDefinition
+  })
   return {getPreset}
 }
 

--- a/plugins/@sanity/presets/src/test/fixtures.ts
+++ b/plugins/@sanity/presets/src/test/fixtures.ts
@@ -1,5 +1,4 @@
 import type {FieldDefinition, SchemaTypeDefinition} from 'sanity'
-import {defineField} from 'sanity'
 import {test as baseTest} from 'vitest'
 
 import type {RegistryContext} from '../definePresetType'
@@ -14,7 +13,7 @@ export const test = baseTest
   })
   .extend('stubRegistry', (): RegistryContext => {
     return {
-      getPreset: () => defineField({name: 'stub', type: 'object', fields: []}),
+      getPreset: () => ({name: 'stub', type: 'object', fields: []}),
     }
   })
   .extend('registryConfig', (): PresetsRegistryConfig => ({}))


### PR DESCRIPTION
## Description

[SAPP-3871](https://linear.app/sanity/issue/SAPP-3871/tighten-getpreset-return-type) - `RegistryContext.getPreset` was typed as `FieldDefinition` but the registry returns `SchemaTypeDefinition & FieldDefinition` at every call site. Preset authors saw a narrower type than they actually had to work with.

This PR tightens the interface in `definePresetType.ts` to the actual return shape, and updates the two test stubs that implemented the interface to satisfy the wider type.
