### PR TITLE
feat(presets): add field descriptions across presets

### DIFF
--- a/.changeset/presets-field-descriptions.md
+++ b/.changeset/presets-field-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": patch
+---
+
+Add author-facing descriptions to preset fields to improve in-Studio guidance

--- a/plugins/@sanity/presets/src/presets/cta-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/cta-type/index.ts
@@ -17,7 +17,7 @@ export const ctaType = definePresetType<{}, 'object', 'preview'>({
           name: 'level',
           title: 'Level',
           description:
-            'Visual prominence: 1 is the primary (most prominent) button style, 3 is the least prominent.',
+            'The importance of the action relative to its siblings: level 1 being the primary action, 2 the secondary action, and so on.',
           type: 'number',
           options: {
             layout: 'radio',

--- a/plugins/@sanity/presets/src/presets/cta-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/cta-type/index.ts
@@ -16,6 +16,8 @@ export const ctaType = definePresetType<{}, 'object', 'preview'>({
         defineField({
           name: 'level',
           title: 'Level',
+          description:
+            'Visual prominence: 1 is the primary (most prominent) button style, 3 is the least prominent.',
           type: 'number',
           options: {
             layout: 'radio',

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -31,6 +31,8 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
               defineField({
                 name: 'altText',
                 title: 'Alt text',
+                description:
+                  'Describes the image for screen readers and search engines. Required for accessibility.',
                 type: 'string',
                 validation: (rule) => rule.warning('Alt text improves accessibility.'),
               }),
@@ -41,6 +43,7 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
               defineField({
                 name: 'caption',
                 title: 'Caption',
+                description: 'Visible caption displayed below the image in the rendered layout.',
                 type: 'text',
               }),
             ]

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -32,7 +32,7 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
                 name: 'altText',
                 title: 'Alt text',
                 description:
-                  'Describes the image for screen readers and search engines. Required for accessibility.',
+                  'Describes the image for screen readers and search engines. Important for accessibility.',
                 type: 'string',
                 validation: (rule) => rule.warning('Alt text improves accessibility.'),
               }),

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -43,7 +43,6 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
               defineField({
                 name: 'caption',
                 title: 'Caption',
-                description: 'Visible caption displayed below the image in the rendered layout.',
                 type: 'text',
               }),
             ]

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -21,6 +21,8 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'linkType',
           type: 'string',
           title: 'Link Type',
+          description:
+            'Internal links point to a page in this project. External links point to a full URL.',
           initialValue: 'internal',
           options: {
             layout: 'radio',
@@ -34,6 +36,7 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'reference',
           type: 'reference',
           title: 'Internal Link',
+          description: 'The page this link points to.',
           to: referenceTargets,
           hidden: ({parent}) => parent?.linkType === 'external',
         }),
@@ -41,6 +44,8 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'url',
           type: 'url',
           title: 'URL',
+          description:
+            'Full URL including protocol, e.g. https://example.com. Supports http, https, mailto, and tel.',
           hidden: ({parent}) => parent?.linkType === 'internal',
           validation: (rule) =>
             rule.uri({
@@ -51,6 +56,8 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'openInNewTab',
           type: 'boolean',
           title: 'Open in New Tab',
+          description:
+            'Opens the link in a new browser tab. Recommended for links that take users away from the current site.',
           initialValue: false,
           hidden: ({parent}) => parent?.linkType === 'internal',
         }),

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -36,7 +36,6 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'reference',
           type: 'reference',
           title: 'Internal Link',
-          description: 'The page this link points to.',
           to: referenceTargets,
           hidden: ({parent}) => parent?.linkType === 'external',
         }),
@@ -56,8 +55,6 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           name: 'openInNewTab',
           type: 'boolean',
           title: 'Open in New Tab',
-          description:
-            'Opens the link in a new browser tab. Recommended for links that take users away from the current site.',
           initialValue: false,
           hidden: ({parent}) => parent?.linkType === 'internal',
         }),

--- a/plugins/@sanity/presets/src/presets/page-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/page-type/index.ts
@@ -59,7 +59,7 @@ function defineLazyContentField(
     name: 'content',
     title: 'Content',
     description:
-      'Page sections rendered in order. Add, remove, or reorder blocks to build the layout.',
+      'Page sections rendered in order. Add, remove, or reorder blocks to build the page.',
     group: 'main',
     type: 'array',
     get of() {
@@ -113,8 +113,6 @@ export function createPageType({lookupArrayPreset}: {lookupArrayPreset: LookupAr
           defineField({
             name: 'slug',
             title: 'Slug',
-            description:
-              'The URL path for this page. Generated from the name - regenerate after renaming.',
             type: 'slug',
             group: 'main',
             options: {

--- a/plugins/@sanity/presets/src/presets/page-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/page-type/index.ts
@@ -58,6 +58,8 @@ function defineLazyContentField(
   return defineField({
     name: 'content',
     title: 'Content',
+    description:
+      'Page sections rendered in order. Add, remove, or reorder blocks to build the layout.',
     group: 'main',
     type: 'array',
     get of() {
@@ -103,6 +105,7 @@ export function createPageType({lookupArrayPreset}: {lookupArrayPreset: LookupAr
           defineField({
             name: 'name',
             title: 'Name',
+            description: 'Used as the page title and as the source for the auto-generated slug.',
             type: 'string',
             group: 'main',
             validation: (rule) => rule.required(),
@@ -110,6 +113,8 @@ export function createPageType({lookupArrayPreset}: {lookupArrayPreset: LookupAr
           defineField({
             name: 'slug',
             title: 'Slug',
+            description:
+              'The URL path for this page. Generated from the name - regenerate after renaming.',
             type: 'slug',
             group: 'main',
             options: {


### PR DESCRIPTION
## Description

Most preset-generated fields shipped with only a `title`, leaving Studio editors - and agents reading the schema - without guidance on non-obvious fields like the slug's source, the link type discriminator, or the opaque numeric `cta.level` ([SAPP-3867](https://linear.app/sanity/issue/SAPP-3867/add-field-descriptions-across-all-presets)).

This PR adds author-facing `description` copy to the fields where it adds real information: page `name`, `slug`, and `content`; the link `linkType` and `url`; `cta.level`; and image `altText`. Self-evident fields (`link.reference`, `openInNewTab`, `image.caption`) are intentionally left undescribed so a description never just restates its label.

## What to review

- Wording for the non-obvious fields: `slug` (regenerate-after-rename), `cta.level` (1 = most prominent, 3 = least), and `linkType` (internal vs external).
- The editorial call on which fields stay undescribed - confirm the three omitted ones read as self-evident to you.
- Changeset is `patch`: additive field metadata, no API or behaviour change.
