### PR TITLE
feat(presets): validate link type discriminator

### DIFF
--- a/.changeset/presets-link-validation.md
+++ b/.changeset/presets-link-validation.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": minor
+---
+
+Add required validation to the link type discriminator. The `linkType` field now requires a value, and the object enforces that internal links have a reference and external links have a URL.

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -16,6 +16,21 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
     return defineType({
       ...objectConfig,
       type: 'object',
+      validation: (rule) =>
+        rule.custom((value) => {
+          if (value === null || value === undefined) return true
+          if (typeof value !== 'object') return true
+
+          const linkValue = value as {linkType?: string; reference?: unknown; url?: unknown}
+
+          if (linkValue.linkType === 'internal') {
+            return linkValue.reference ? true : 'An internal link requires a reference'
+          }
+          if (linkValue.linkType === 'external') {
+            return linkValue.url ? true : 'An external link requires a URL'
+          }
+          return 'Select a link type'
+        }),
       fields: [
         defineField({
           name: 'linkType',
@@ -29,6 +44,7 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
               {title: 'External', value: 'external'},
             ],
           },
+          validation: (rule) => rule.required(),
         }),
         defineField({
           name: 'reference',

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -19,16 +19,18 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
       validation: (rule) =>
         rule.custom((value) => {
           const isLinkObject = typeof value === 'object' && value !== null
-          if (!isLinkObject) return true
 
-          const linkValue = value as {linkType?: string; reference?: unknown; url?: unknown}
+          if (isLinkObject) {
+            const linkValue = value as {linkType?: string; reference?: unknown; url?: unknown}
 
-          if (linkValue.linkType === 'internal') {
-            return linkValue.reference ? true : 'An internal link requires a reference'
+            if (linkValue.linkType === 'internal') {
+              return linkValue.reference ? true : 'An internal link requires a reference'
+            }
+            if (linkValue.linkType === 'external') {
+              return linkValue.url ? true : 'An external link requires a URL'
+            }
           }
-          if (linkValue.linkType === 'external') {
-            return linkValue.url ? true : 'An external link requires a URL'
-          }
+
           return true
         }),
       fields: [

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -18,8 +18,8 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
       type: 'object',
       validation: (rule) =>
         rule.custom((value) => {
-          if (value === null || value === undefined) return true
-          if (typeof value !== 'object') return true
+          const isLinkObject = typeof value === 'object' && value !== null
+          if (!isLinkObject) return true
 
           const linkValue = value as {linkType?: string; reference?: unknown; url?: unknown}
 

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -18,17 +18,13 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
       type: 'object',
       validation: (rule) =>
         rule.custom((value) => {
-          const isLinkObject = typeof value === 'object' && value !== null
+          const link = value as {linkType?: string; reference?: unknown; url?: unknown} | undefined
 
-          if (isLinkObject) {
-            const linkValue = value as {linkType?: string; reference?: unknown; url?: unknown}
-
-            if (linkValue.linkType === 'internal') {
-              return linkValue.reference ? true : 'An internal link requires a reference'
-            }
-            if (linkValue.linkType === 'external') {
-              return linkValue.url ? true : 'An external link requires a URL'
-            }
+          if (link?.linkType === 'internal') {
+            return link.reference ? true : 'An internal link requires a reference'
+          }
+          if (link?.linkType === 'external') {
+            return link.url ? true : 'An external link requires a URL'
           }
 
           return true

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -6,6 +6,12 @@ export interface LinkTypeConfig {
   internalTypes?: string[]
 }
 
+type LinkValue = {
+  linkType?: string
+  reference?: unknown
+  url?: unknown
+}
+
 export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
   name: 'link',
   identifier: 'core.link',
@@ -17,14 +23,12 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
       ...objectConfig,
       type: 'object',
       validation: (rule) =>
-        rule.custom((value) => {
-          const link = value as {linkType?: string; reference?: unknown; url?: unknown} | undefined
-
-          if (link?.linkType === 'internal') {
-            return link.reference ? true : 'An internal link requires a reference'
+        rule.custom<LinkValue>((value) => {
+          if (value?.linkType === 'internal' && !value.reference) {
+            return 'An internal link requires a reference'
           }
-          if (link?.linkType === 'external') {
-            return link.url ? true : 'An external link requires a URL'
+          if (value?.linkType === 'external' && !value.url) {
+            return 'An external link requires a URL'
           }
 
           return true

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -12,7 +12,7 @@ type LinkValue = {
   url?: unknown
 }
 
-export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
+export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview' | 'validation'>({
   name: 'link',
   identifier: 'core.link',
   schemaType: ({internalTypes, fields, ...objectConfig}) => {

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -29,7 +29,7 @@ export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
           if (linkValue.linkType === 'external') {
             return linkValue.url ? true : 'An external link requires a URL'
           }
-          return 'Select a link type'
+          return true
         }),
       fields: [
         defineField({

--- a/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
@@ -261,10 +261,12 @@ describe('linkType validation', () => {
     expect(validate({linkType: 'external'})).toBe('An external link requires a URL')
   })
 
-  test('object validation returns error when linkType is not set', ({stubRegistry}) => {
+  test('object validation defers the missing link type to field-level required()', ({
+    stubRegistry,
+  }) => {
     const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
 
-    expect(validate({})).toBe('Select a link type')
+    expect(validate({})).toBe(true)
   })
 
   test('object validation does not error when external link still carries a stale reference', ({

--- a/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
@@ -1,4 +1,4 @@
-import type {FieldDefinition, PreviewValue, SchemaTypeDefinition} from 'sanity'
+import type {FieldDefinition, PreviewValue, Rule, SchemaTypeDefinition} from 'sanity'
 import {describe, expect} from 'vitest'
 
 import {getField, getFields, test} from '../../test/fixtures'
@@ -168,5 +168,116 @@ describe('linkType preview.prepare', () => {
     })
 
     expect(result).toEqual({title: 'No reference', subtitle: 'Internal link'})
+  })
+})
+
+type CustomValidator = (value: unknown) => true | string
+
+function createRequiredSpyRule(): {rule: Rule; wasRequiredCalled: () => boolean} {
+  let requiredCalled = false
+  const stub = {
+    required() {
+      requiredCalled = true
+      return stub
+    },
+  }
+  // oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub recording whether required() is called
+  return {rule: stub as unknown as Rule, wasRequiredCalled: () => requiredCalled}
+}
+
+function captureObjectValidator(schemaType: SchemaTypeDefinition): CustomValidator {
+  const {validation} = schemaType
+  if (typeof validation !== 'function') {
+    throw new Error('Expected a validation function on the object type')
+  }
+
+  let captured: CustomValidator | undefined
+  const stub = {
+    custom(validator: CustomValidator) {
+      captured = validator
+      return stub
+    },
+  }
+
+  // oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub capturing the custom validator callback
+  validation(stub as unknown as Rule)
+
+  if (!captured) {
+    throw new Error('Expected object validation to register a custom validator')
+  }
+  return captured
+}
+
+describe('linkType validation', () => {
+  test('linkType field has required validation', ({stubRegistry}) => {
+    const fields = getFields(linkType.schemaType(defaultConfig, stubRegistry))
+    const linkTypeField = getField(fields, 'linkType')
+
+    if (typeof linkTypeField.validation !== 'function') {
+      throw new Error('Expected a validation function on the linkType field')
+    }
+
+    const {rule, wasRequiredCalled} = createRequiredSpyRule()
+    linkTypeField.validation(rule)
+
+    expect(wasRequiredCalled()).toBe(true)
+  })
+
+  test('object validation returns true for null value', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate(null)).toBe(true)
+  })
+
+  test('object validation returns true for undefined value', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate(undefined)).toBe(true)
+  })
+
+  test('object validation returns true for a valid internal link', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate({linkType: 'internal', reference: {_ref: 'abc', _type: 'reference'}})).toBe(
+      true,
+    )
+  })
+
+  test('object validation returns error for internal link missing reference', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate({linkType: 'internal'})).toBe('An internal link requires a reference')
+  })
+
+  test('object validation returns true for a valid external link', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate({linkType: 'external', url: 'https://example.com'})).toBe(true)
+  })
+
+  test('object validation returns error for external link missing url', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate({linkType: 'external'})).toBe('An external link requires a URL')
+  })
+
+  test('object validation returns error when linkType is not set', ({stubRegistry}) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(validate({})).toBe('Select a link type')
+  })
+
+  test('object validation does not error when external link still carries a stale reference', ({
+    stubRegistry,
+  }) => {
+    const validate = captureObjectValidator(linkType.schemaType(defaultConfig, stubRegistry))
+
+    expect(
+      validate({
+        linkType: 'external',
+        url: 'https://example.com',
+        reference: {_ref: 'abc', _type: 'reference'},
+      }),
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
## Description

The `defineLink` preset accepted incomplete links: `linkType` could be left unset, an internal link saved without a reference, and an external link without a URL ([SAPP-3868](https://linear.app/sanity/issue/SAPP-3868/add-validation-to-definelink-discriminator)). Nothing enforced a valid discriminator state.

This PR validates the link object. The `linkType` field is required, and an object-level custom validator requires a reference for internal links and a URL for external links. An unset `linkType` defers to the field-level required check to avoid double-reporting, and stale data on the inactive branch is left unflagged. The object-level `validation` field is locked so consumer config cannot silently override the discriminator check.

## Testing

Added unit tests for the required `linkType` field and the object validator, covering null, undefined, empty, valid, and missing-field cases for both link types.
