### PR TITLE
feat(presets): flatten defineImage to a native image type

### DIFF
--- a/.changeset/image-type-flatten.md
+++ b/.changeset/image-type-flatten.md
@@ -1,0 +1,21 @@
+---
+"@sanity/presets": minor
+---
+
+`defineImage` now returns a native Sanity `image` type instead of an `object` wrapper. `altText` and `caption` are added via the image type's `fields` array; `hotspot` is controlled via the top-level `options`.
+
+**Migration note - data path changes**
+
+If you have content saved with an earlier pre-release of this package, the asset, hotspot, and crop paths have moved:
+
+| Property | Before | After |
+|---|---|---|
+| Asset | `<field>.image.asset` | `<field>.asset` |
+| Hotspot | `<field>.image.hotspot` | `<field>.hotspot` |
+| Crop | `<field>.image.crop` | `<field>.crop` |
+
+`altText` and `caption` remain at `<field>.altText` and `<field>.caption` - their paths are unchanged.
+
+**Schema type change**
+
+The `map` hook for `defineImage` now targets `ImageDefinition` keys (e.g. `fields`, `options`) rather than `ObjectDefinition` keys.

--- a/plugins/@sanity/presets/src/presets/image-type/image-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/image-type.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect} from 'vitest'
 
-import {getField, getFields, test} from '../../test/fixtures'
+import {getFields, test} from '../../test/fixtures'
 import {imageType} from './index'
 
 describe('imageType', () => {
@@ -15,56 +15,54 @@ describe('imageType', () => {
     expect(result.name).toBe('image')
   })
 
-  test('default config includes image, altText, and caption fields', ({stubRegistry}) => {
+  test('default config includes altText and caption fields', ({stubRegistry}) => {
     const fields = getFields(imageType.schemaType({name: 'image'}, stubRegistry))
 
-    expect(fields).toHaveLength(3)
+    expect(fields).toHaveLength(2)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['image', 'altText', 'caption'])
+    expect(fieldNames).toEqual(['altText', 'caption'])
   })
 
   test('altText: false excludes the altText field', ({stubRegistry}) => {
     const fields = getFields(imageType.schemaType({name: 'image', altText: false}, stubRegistry))
 
-    expect(fields).toHaveLength(2)
+    expect(fields).toHaveLength(1)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['image', 'caption'])
+    expect(fieldNames).toEqual(['caption'])
   })
 
   test('caption: false excludes the caption field', ({stubRegistry}) => {
     const fields = getFields(imageType.schemaType({name: 'image', caption: false}, stubRegistry))
 
-    expect(fields).toHaveLength(2)
+    expect(fields).toHaveLength(1)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['image', 'altText'])
+    expect(fieldNames).toEqual(['altText'])
   })
 
-  test('both altText and caption disabled leaves only the image field', ({stubRegistry}) => {
+  test('both altText and caption disabled leaves no fields', ({stubRegistry}) => {
     const fields = getFields(
       imageType.schemaType({name: 'image', altText: false, caption: false}, stubRegistry),
     )
 
-    expect(fields).toHaveLength(1)
+    expect(fields).toHaveLength(0)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['image'])
+    expect(fieldNames).toEqual([])
   })
 
   test('hotspot is enabled by default', ({stubRegistry}) => {
-    const fields = getFields(imageType.schemaType({name: 'image'}, stubRegistry))
-    const imageField = getField(fields, 'image')
+    const typeDef = imageType.schemaType({name: 'image'}, stubRegistry)
 
-    expect(imageField).toHaveProperty('options.hotspot', true)
+    expect(typeDef).toHaveProperty('options.hotspot', true)
   })
 
-  test('hotspot: false disables hotspot on the image field', ({stubRegistry}) => {
-    const fields = getFields(imageType.schemaType({name: 'image', hotspot: false}, stubRegistry))
-    const imageField = getField(fields, 'image')
+  test('hotspot: false disables hotspot on the image type', ({stubRegistry}) => {
+    const typeDef = imageType.schemaType({name: 'image', hotspot: false}, stubRegistry)
 
-    expect(imageField).toHaveProperty('options.hotspot', false)
+    expect(typeDef).toHaveProperty('options.hotspot', false)
   })
 
   test('user-provided fields are appended', ({stubRegistry}) => {
@@ -77,10 +75,10 @@ describe('imageType', () => {
     )
     const fields = getFields(result)
 
-    expect(fields).toHaveLength(4)
+    expect(fields).toHaveLength(3)
 
     const fieldNames = fields.map((field) => field.name)
-    expect(fieldNames).toEqual(['image', 'altText', 'caption', 'credit'])
+    expect(fieldNames).toEqual(['altText', 'caption', 'credit'])
   })
 })
 
@@ -91,7 +89,6 @@ describe('imageType preview.select', () => {
 
     expect(select).toEqual({
       title: 'altText',
-      media: 'image',
     })
   })
 
@@ -101,7 +98,6 @@ describe('imageType preview.select', () => {
 
     expect(select).toEqual({
       title: 'caption',
-      media: 'image',
     })
   })
 
@@ -113,8 +109,7 @@ describe('imageType preview.select', () => {
     const select = 'preview' in typeDef ? typeDef.preview?.select : undefined
 
     expect(select).toEqual({
-      title: 'image.asset.originalFilename',
-      media: 'image',
+      title: 'asset.originalFilename',
     })
   })
 })

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -17,6 +17,7 @@ export const imageType = definePresetType<ImageTypeConfig, 'image', 'preview'>({
     return defineType({
       ...imageConfig,
       type: 'image',
+      // hotspot is the curated default; callers override other image options (accept, sources, storeOriginalFilename) via the map.options hook
       options: {
         hotspot,
       },

--- a/plugins/@sanity/presets/src/presets/image-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/image-type/index.ts
@@ -8,24 +8,19 @@ export interface ImageTypeConfig {
   hotspot?: boolean
 }
 
-export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>({
+export const imageType = definePresetType<ImageTypeConfig, 'image', 'preview'>({
   name: 'image',
   identifier: 'core.image',
   schemaType: (config) => {
-    const {altText = true, caption = true, hotspot = true, fields, ...objectConfig} = config
+    const {altText = true, caption = true, hotspot = true, fields, ...imageConfig} = config
 
     return defineType({
-      ...objectConfig,
-      type: 'object',
+      ...imageConfig,
+      type: 'image',
+      options: {
+        hotspot,
+      },
       fields: [
-        defineField({
-          name: 'image',
-          title: 'Image',
-          type: 'image',
-          options: {
-            hotspot,
-          },
-        }),
         ...(altText
           ? [
               defineField({
@@ -49,8 +44,7 @@ export const imageType = definePresetType<ImageTypeConfig, 'object', 'preview'>(
       ],
       preview: {
         select: {
-          title: altText ? 'altText' : caption ? 'caption' : 'image.asset.originalFilename',
-          media: 'image',
+          title: altText ? 'altText' : caption ? 'caption' : 'asset.originalFilename',
         },
       },
     })

--- a/plugins/@sanity/presets/src/presets/page-type/page-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/page-type/page-type.test.ts
@@ -109,14 +109,12 @@ describe('pageType', () => {
     expect(inlineMember).toEqual(
       expect.objectContaining({
         name: 'heroImage',
-        type: 'object',
+        type: 'image',
       }),
     )
+    expect(inlineMember).toHaveProperty('options.hotspot', true)
     expect(inlineMember).toHaveProperty('fields')
-    expect(inlineMember.fields).toEqual(
-      expect.arrayContaining([expect.objectContaining({name: 'image', type: 'image'})]),
-    )
-    expect(inlineMember.fields).toHaveLength(1)
+    expect(inlineMember.fields).toHaveLength(0)
   })
 })
 

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -129,10 +129,8 @@ describe('richTextType via the registry', () => {
     expect(ofMembers[0]).toHaveProperty('type', 'block')
     expect(ofMembers[1]).toMatchObject({
       name: 'richTextImage',
-      fields: expect.arrayContaining([
-        expect.objectContaining({name: 'image'}),
-        expect.objectContaining({name: 'altText'}),
-      ]),
+      type: 'image',
+      fields: expect.arrayContaining([expect.objectContaining({name: 'altText'})]),
     })
     expect(block.marks?.annotations?.[0]).toMatchObject({
       name: 'link',

--- a/plugins/@sanity/presets/src/registry.test.tsx
+++ b/plugins/@sanity/presets/src/registry.test.tsx
@@ -81,7 +81,7 @@ describe('createPresetsRegistry', () => {
     const result = registry.defineImage({name: 'testImage'})
 
     expect(result).toHaveProperty('name', 'testImage')
-    expect(result).toHaveProperty('type', 'object')
+    expect(result).toHaveProperty('type', 'image')
   })
 
   test('definePage returns a schema type definition', ({registry}) => {


### PR DESCRIPTION
## Description

`defineImage` previously returned an `object` schema type that wrapped a nested `image` field, so saved assets landed at `<field>.image.asset` and hotspot/crop sat under `<field>.image`. That extra nesting was non-idiomatic and made the stored shape awkward to query.

This PR flattens `defineImage` to return a native Sanity `image` type directly ([SAPP-3869](https://linear.app/sanity/issue/SAPP-3869/flatten-defineimage-to-return-image-type-directly)). `altText` and `caption` are now fields on the image type itself, `hotspot` moves to the type's top-level `options`, and the type signature shifts from `'object'` to `'image'`. The internal consumers that pull this preset by name (`richTextType`, `pageType`) inherit the new shape without source changes.

## Data shape

| Property | Before | After |
|---|---|---|
| Asset | `<field>.image.asset` | `<field>.asset` |
| Hotspot | `<field>.image.hotspot` | `<field>.hotspot` |
| Crop | `<field>.image.crop` | `<field>.crop` |

`altText` and `caption` stay at `<field>.altText` and `<field>.caption`. The package is unreleased, so this aligns the stored shape before any consumer depends on it; the changeset records the path move for anyone on a pre-release.

## What to review

- `image-type/index.ts` - the `image` type now carries `options.hotspot` and the `altText`/`caption` fields directly; `preview.select` drops `media` and reads the title from `asset.originalFilename` when both are off.
- Tests across `image-type`, `page-type`, `rich-text-type`, and `registry` assert the flattened shape and the `'object'` -> `'image'` change.
