### PR TITLE
fix(presets): soften OG image dimension validation to a warning

### DIFF
--- a/.changeset/presets-og-image-warning.md
+++ b/.changeset/presets-og-image-warning.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": patch
+---
+
+Demote OG image dimension validation from error to warning so non-1200×630 images (e.g. square product images for JSON-LD) no longer block document publishing

--- a/plugins/@sanity/presets/src/presets/seo-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/seo-type/index.ts
@@ -49,11 +49,11 @@ export const seoType = definePresetType<{}, 'object'>({
               const {height, width} = getImageDimensions(value.asset?._ref)
 
               if (height !== 630 || width !== 1200) {
-                return 'Open Graph image must be 1200x630'
+                return 'Open Graph images are recommended to be 1200x630 (1.91:1) for optimal social sharing previews.'
               }
 
               return true
-            }),
+            }).warning(),
         }),
         ...(fields ?? []),
       ],

--- a/plugins/@sanity/presets/src/presets/seo-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/seo-type/index.ts
@@ -49,7 +49,7 @@ export const seoType = definePresetType<{}, 'object'>({
               const {height, width} = getImageDimensions(value.asset?._ref)
 
               if (height !== 630 || width !== 1200) {
-                return 'Open Graph images are recommended to be 1200x630 (1.91:1) for optimal social sharing previews.'
+                return 'Open Graph images are recommended to be exactly 1200x630 (1.91:1) for the best social sharing previews.'
               }
 
               return true

--- a/plugins/@sanity/presets/src/presets/seo-type/seo-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/seo-type/seo-type.test.ts
@@ -1,0 +1,120 @@
+import {getImageDimensions} from '@sanity/asset-utils'
+import type {ImageValue, Rule} from 'sanity'
+import {beforeEach, describe, expect, vi} from 'vitest'
+
+import {getField, getFields, test} from '../../test/fixtures'
+import {seoType} from './index'
+
+vi.mock('@sanity/asset-utils', () => ({
+  getImageDimensions: vi.fn(),
+}))
+
+const getImageDimensionsMock = vi.mocked(getImageDimensions)
+
+const stubRegistry = {
+  getPreset: vi.fn(),
+}
+
+type OgImageValidator = (value: ImageValue | undefined) => unknown
+
+interface RuleMock {
+  custom: (validator: OgImageValidator) => RuleMock
+  warning: () => RuleMock
+}
+
+interface ResolvedValidator {
+  validate: OgImageValidator
+  isWarning: boolean
+}
+
+function resolveOgImageValidator(): ResolvedValidator {
+  const ogImageField = getField(
+    getFields(seoType.schemaType({name: 'seo'}, stubRegistry)),
+    'ogImage',
+  )
+
+  const validationBuilder = ogImageField.validation
+
+  if (typeof validationBuilder !== 'function') {
+    throw new Error('ogImage field is missing a validation builder')
+  }
+
+  let capturedValidator: OgImageValidator | undefined
+  let isWarning = false
+
+  const ruleMock: RuleMock = {
+    custom(validator) {
+      capturedValidator = validator
+      return ruleMock
+    },
+    warning() {
+      isWarning = true
+      return ruleMock
+    },
+  }
+
+  // The ogImage validation builder expects a full Sanity Rule; the test only needs
+  // the custom and warning methods, so a minimal mock stands in for it.
+  // oxlint-disable-next-line no-unsafe-type-assertion
+  validationBuilder(ruleMock as unknown as Rule)
+
+  if (!capturedValidator) {
+    throw new Error('ogImage validation did not register a custom validator')
+  }
+
+  return {validate: capturedValidator, isWarning}
+}
+
+function buildImageValue(assetRef: string | undefined): ImageValue {
+  if (assetRef === undefined) {
+    return {_type: 'image'}
+  }
+
+  return {_type: 'image', asset: {_type: 'reference', _ref: assetRef}}
+}
+
+describe('seoType ogImage validation', () => {
+  beforeEach(() => {
+    getImageDimensionsMock.mockReset()
+  })
+
+  test('registers the dimension check at warning level rather than error level', () => {
+    const {isWarning} = resolveOgImageValidator()
+
+    expect(isWarning).toBe(true)
+  })
+
+  test('returns true when no asset reference is present', () => {
+    const {validate} = resolveOgImageValidator()
+
+    expect(validate(buildImageValue(undefined))).toBe(true)
+    expect(getImageDimensionsMock).not.toHaveBeenCalled()
+  })
+
+  test('returns true when the image is exactly 1200x630', () => {
+    getImageDimensionsMock.mockReturnValue({width: 1200, height: 630, aspectRatio: 1200 / 630})
+
+    const {validate} = resolveOgImageValidator()
+
+    expect(validate(buildImageValue('image-abc-1200x630-png'))).toBe(true)
+  })
+
+  test('returns a warning message string (never an error object) for non-conformant dimensions', () => {
+    getImageDimensionsMock.mockReturnValue({width: 1200, height: 1200, aspectRatio: 1})
+
+    const {validate} = resolveOgImageValidator()
+    const result = validate(buildImageValue('image-abc-1200x1200-png'))
+
+    expect(typeof result).toBe('string')
+  })
+
+  test('includes the recommended dimensions and ratio in the warning message', () => {
+    getImageDimensionsMock.mockReturnValue({width: 800, height: 600, aspectRatio: 800 / 600})
+
+    const {validate} = resolveOgImageValidator()
+    const result = validate(buildImageValue('image-abc-800x600-png'))
+
+    expect(result).toContain('1200x630')
+    expect(result).toContain('1.91:1')
+  })
+})


### PR DESCRIPTION
## Description

The SEO preset validated the Open Graph image as exactly 1200x630 with a hard error, which blocked publishing images that AEO and structured-data use cases legitimately rely on - for example a square 1200x1200 product image for JSON-LD ([SAPP-3870](https://linear.app/sanity/issue/SAPP-3870/soften-og-image-dimension-validation-to-warning)).

This PR demotes that check from an error to a warning, so off-spec images publish while editors still see the 1200x630 (1.91:1) recommendation as advisory guidance. The exact-pixel check is unchanged - only its severity and message wording change.

## What to review

- `seo-type/index.ts`: the `.warning()` on the custom rule is the load-bearing change. `{message, level: 'warning'}` is not a valid `CustomValidatorResult` in the installed `@sanity/types@5.21`, so the rule-builder `.warning()` returning a string is the correct idiom.
- `seo-type.test.ts`: new tests mock `getImageDimensions` and assert a warning-level result (not an error) for off-spec dimensions, plus `true` for an exact 1200x630 and for a missing asset.
- Changeset is `patch`: relaxing a validation constraint, non-breaking.
