### PR TITLE
feat(presets): rename link.internalTypes to link.to with shorthand

### DIFF
--- a/.changeset/presets-link-to.md
+++ b/.changeset/presets-link-to.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": minor
+---
+
+Rename `link.internalTypes` to `link.to`, aligning with the Schema API's `reference.to`. The `to` option now accepts both string shorthand (`['page', 'post']`) and the object form (`[{type: 'page'}]`) used natively by `reference.to`.

--- a/dev/test-studio/src/presets/index.tsx
+++ b/dev/test-studio/src/presets/index.tsx
@@ -8,9 +8,9 @@ import {definePlugin, defineType, defineField} from 'sanity'
 // A convenient pattern is to destructure the `define<type>` functions.
 const {defineImage, definePage, defineLink, defineRichText} = createPresetsRegistry({
   link: {
-    // Presets can be globally configured. Here, `link.internalTypes` is
+    // Presets can be globally configured. Here, `link.to` is
     // configured to include the "corePresetsTest" document type in all
-    // link objects (unless the `internalTypes` is overridden when `defineLink`
+    // link objects (unless the `to` is overridden when `defineLink`
     // is called).
     //
     // Globally configuring a preset is useful, because the configuration
@@ -19,7 +19,7 @@ const {defineImage, definePage, defineLink, defineRichText} = createPresetsRegis
     // `defineRichText`, the link type it composes will automatically be
     // configured to allow internal links to the "corePresetsTest" document
     // type.
-    internalTypes: ['corePresetsTest'],
+    to: ['corePresetsTest'],
   },
 })
 

--- a/plugins/@sanity/presets/README.md
+++ b/plugins/@sanity/presets/README.md
@@ -85,8 +85,8 @@ The registry serves two purposes:
 ```ts
 const {defineLink, defineCta, definePage} = createPresetsRegistry({
   link: {
-    // Every link in this registry - standalone, inside CTAs,
-    // inside rich text - will offer these types for internal links.
+    // Every link in this registry — standalone, inside CTAs,
+    // inside rich text — will offer these types for internal links.
     to: ['marketingPage', 'blogPost'],
   },
 })

--- a/plugins/@sanity/presets/README.md
+++ b/plugins/@sanity/presets/README.md
@@ -43,7 +43,7 @@ import {createPresetsRegistry} from '@sanity/presets'
 
 const {defineLink, defineCta, defineSeo, defineImage, definePage} = createPresetsRegistry({
   link: {
-    internalTypes: ['page', 'post'],
+    to: ['page', 'post'],
   },
 })
 ```
@@ -78,16 +78,16 @@ The **presets registry** is the entry point to `@sanity/presets`. Call `createPr
 
 The registry serves two purposes:
 
-1. **Global configuration.** Presets can be configured at the registry level, providing defaults that apply everywhere a preset is used. For example, configuring `link.internalTypes` once means every link — whether standalone, inside a CTA, or inside rich text — knows which document types are available for internal links.
+1. **Global configuration.** Presets can be configured at the registry level, providing defaults that apply everywhere a preset is used. For example, configuring `link.to` once means every link — whether standalone, inside a CTA, or inside rich text — knows which document types are available for internal links.
 
 2. **Composition.** Some presets compose other presets internally. The CTA preset includes a link field; the page preset includes SEO fields. The registry ensures these composed presets share the same global configuration.
 
 ```ts
 const {defineLink, defineCta, definePage} = createPresetsRegistry({
   link: {
-    // Every link in this registry — standalone, inside CTAs,
-    // inside rich text — will offer these types for internal links.
-    internalTypes: ['marketingPage', 'blogPost'],
+    // Every link in this registry - standalone, inside CTAs,
+    // inside rich text - will offer these types for internal links.
+    to: ['marketingPage', 'blogPost'],
   },
 })
 ```
@@ -97,8 +97,8 @@ Global configuration can be overridden at the call site. If a specific link inst
 ```ts
 defineLink({
   name: 'specialLink',
-  // Overrides the registry-level internalTypes for this instance only.
-  internalTypes: ['product'],
+  // Overrides the registry-level to for this instance only.
+  to: ['product'],
 })
 ```
 
@@ -106,10 +106,10 @@ defineLink({
 
 Presets can compose other presets. This means configuring one preset can affect others that depend on it.
 
-The **link** preset is the clearest example. When you configure `link.internalTypes` at the registry level, that configuration cascades to:
+The **link** preset is the clearest example. When you configure `link.to` at the registry level, that configuration cascades to:
 
-- **CTA (call to action)** — the CTA preset includes an inline link field. The link field automatically uses the registry-level `internalTypes` configuration.
-- **Rich text** — the rich text preset includes link annotations. Those annotations also use the registry-level `internalTypes` configuration.
+- **CTA (call to action)** — the CTA preset includes an inline link field. The link field automatically uses the registry-level `to` configuration.
+- **Rich text** — the rich text preset includes link annotations. Those annotations also use the registry-level `to` configuration.
 
 This means you configure link behaviour once, and every preset that uses links inherits that configuration automatically.
 
@@ -197,8 +197,8 @@ defineLink({
   name: 'primaryLink',
   title: 'Primary Link',
   // Document types available for internal links. Falls back to
-  // the registry-level link.internalTypes if not provided here.
-  internalTypes: ['page', 'post'],
+  // the registry-level link.to if not provided here.
+  to: ['page', 'post'],
 })
 ```
 
@@ -207,15 +207,15 @@ defineLink({
 | Field          | Type        | Description                                                                                              |
 | -------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
 | `linkType`     | `string`    | "Internal" or "External". Defaults to "Internal".                                                        |
-| `reference`    | `reference` | Internal link. Hidden when link type is external. Targets configured via `internalTypes`.                |
+| `reference`    | `reference` | Internal link. Hidden when link type is external. Targets configured via `to`.                           |
 | `url`          | `url`       | External URL. Hidden when link type is internal. Validates `http`, `https`, `mailto`, and `tel` schemes. |
 | `openInNewTab` | `boolean`   | Whether to open in a new tab. Hidden for internal links.                                                 |
 
 **Options:**
 
-| Option          | Type       | Description                                                                                         |
-| --------------- | ---------- | --------------------------------------------------------------------------------------------------- |
-| `internalTypes` | `string[]` | Document types available for internal links. Falls back to the registry-level `link.internalTypes`. |
+| Option | Type                           | Description                                                                                                                                                         |
+| ------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `to`   | `(string \| {type: string})[]` | Document types available for internal links. Accepts string shorthand (`['page']`) or object form (`[{type: 'page'}]`). Falls back to the registry-level `link.to`. |
 
 ### CTA (call to action)
 
@@ -230,10 +230,10 @@ defineCta({
 
 **Fields:**
 
-| Field   | Type     | Description                                                                                |
-| ------- | -------- | ------------------------------------------------------------------------------------------ |
-| `link`  | `object` | An inline link, composed from the link preset. Inherits `internalTypes` from the registry. |
-| `level` | `number` | Semantic importance level (1, 2, or 3).                                                    |
+| Field   | Type     | Description                                                                     |
+| ------- | -------- | ------------------------------------------------------------------------------- |
+| `link`  | `object` | An inline link, composed from the link preset. Inherits `to` from the registry. |
+| `level` | `number` | Semantic importance level (1, 2, or 3).                                         |
 
 ### SEO (search engine optimization)
 
@@ -332,12 +332,12 @@ defineRichText({
 
 #### Configuring the embedded presets
 
-Configure each object's options (link `internalTypes`, image `altText`, and so on) at the registry level. Those options cascade into every rich text field:
+Configure each object's options (link `to`, image `altText`, and so on) at the registry level. Those options cascade into every rich text field:
 
 ```ts
 const {defineRichText} = createPresetsRegistry({
   link: {
-    internalTypes: ['page', 'post'],
+    to: ['page', 'post'],
   },
   image: {
     altText: true,
@@ -352,12 +352,12 @@ The `objects` option only toggles embedded objects on or off. To reshape the arr
 
 ### Configure links globally
 
-The [link preset](#link) is used by multiple other presets ([CTA](#cta-call-to-action), [rich text](#rich-text)). Configure `internalTypes` at the registry level so all links share the same set of linkable document types:
+The [link preset](#link) is used by multiple other presets ([CTA](#cta-call-to-action), [rich text](#rich-text)). Configure `to` at the registry level so all links share the same set of linkable document types:
 
 ```ts
 const {defineLink, defineCta, definePage} = createPresetsRegistry({
   link: {
-    internalTypes: ['page', 'post', 'product'],
+    to: ['page', 'post', 'product'],
   },
 })
 ```

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -2,6 +2,8 @@ import {defineField, defineType} from 'sanity'
 
 import {definePresetType} from '../../definePresetType'
 
+// Object entries are limited to {type} shorthand by design; richer reference.to
+// target props (title, options, icon) can be added later if needed.
 type LinkToEntry = string | {type: string}
 
 export interface LinkTypeConfig {

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -2,16 +2,21 @@ import {defineField, defineType} from 'sanity'
 
 import {definePresetType} from '../../definePresetType'
 
+type LinkToEntry = string | {type: string}
+
 export interface LinkTypeConfig {
-  internalTypes?: string[]
+  to?: LinkToEntry[]
+}
+
+function normalizeToTargets(entries: LinkToEntry[]): {type: string}[] {
+  return entries.map((entry) => (typeof entry === 'string' ? {type: entry} : entry))
 }
 
 export const linkType = definePresetType<LinkTypeConfig, 'object', 'preview'>({
   name: 'link',
   identifier: 'core.link',
-  schemaType: ({internalTypes, fields, ...objectConfig}) => {
-    const resolvedInternalTypes = internalTypes ?? []
-    const referenceTargets = resolvedInternalTypes.map((type) => ({type}))
+  schemaType: ({to, fields, ...objectConfig}) => {
+    const referenceTargets = normalizeToTargets(to ?? [])
 
     return defineType({
       ...objectConfig,

--- a/plugins/@sanity/presets/src/presets/link-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/index.ts
@@ -2,8 +2,6 @@ import {defineField, defineType} from 'sanity'
 
 import {definePresetType} from '../../definePresetType'
 
-// Object entries are limited to {type} shorthand by design; richer reference.to
-// target props (title, options, icon) can be added later if needed.
 type LinkToEntry = string | {type: string}
 
 export interface LinkTypeConfig {

--- a/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/link-type/link-type.test.ts
@@ -4,7 +4,7 @@ import {describe, expect} from 'vitest'
 import {getField, getFields, test} from '../../test/fixtures'
 import {linkType} from './index'
 
-const defaultConfig = {name: 'link', internalTypes: ['page']}
+const defaultConfig = {name: 'link', to: ['page']}
 
 function evaluateHidden(field: FieldDefinition, parent: Record<string, unknown>): unknown {
   if (typeof field.hidden === 'function') {
@@ -50,13 +50,29 @@ describe('linkType', () => {
     expect(fieldNames).toEqual(['linkType', 'reference', 'url', 'openInNewTab'])
   })
 
-  test('maps internalTypes to reference targets', ({stubRegistry}) => {
+  test('maps to entries to reference targets', ({stubRegistry}) => {
     const fields = getFields(
-      linkType.schemaType({name: 'link', internalTypes: ['page', 'post']}, stubRegistry),
+      linkType.schemaType({name: 'link', to: ['page', 'post']}, stubRegistry),
     )
     const referenceField = getField(fields, 'reference')
 
     expect(referenceField).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
+  })
+
+  test('accepts object-form entries in to', ({stubRegistry}) => {
+    const fields = getFields(
+      linkType.schemaType({name: 'link', to: [{type: 'page'}, {type: 'post'}]}, stubRegistry),
+    )
+
+    expect(getField(fields, 'reference')).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
+  })
+
+  test('accepts mixed string and object entries in to', ({stubRegistry}) => {
+    const fields = getFields(
+      linkType.schemaType({name: 'link', to: ['page', {type: 'post'}]}, stubRegistry),
+    )
+
+    expect(getField(fields, 'reference')).toHaveProperty('to', [{type: 'page'}, {type: 'post'}])
   })
 
   test('hidden callbacks show correct fields for internal type', ({stubRegistry}) => {

--- a/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/index.ts
@@ -14,7 +14,7 @@ export interface RichTextTypeConfig {
    * Defaults to all enabled. Pass `false` to disable every object, or an
    * object to toggle individual ones (e.g. `{link: false}`).
    *
-   * Each object's options (link `internalTypes`, image `altText`, …) are
+   * Each object's options (link `to`, image `altText`, …) are
    * configured on `createPresetsRegistry` and cascade into every rich text
    * field. Use `map.of` for per-field structural changes.
    */

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -144,10 +144,10 @@ describe('richTextType via the registry', () => {
     })
   })
 
-  describe('with registry-level internalTypes', () => {
-    test.override('registryConfig', {link: {internalTypes: ['marketingPage']}})
+  describe('with registry-level to', () => {
+    test.override('registryConfig', {link: {to: ['marketingPage']}})
 
-    test('link annotations inherit internalTypes from registry config', ({registry}) => {
+    test('link annotations inherit to from registry config', ({registry}) => {
       const result = registry.defineRichText({name: 'body'})
       const block = getBlock(result)
 

--- a/plugins/@sanity/presets/src/registry.test.tsx
+++ b/plugins/@sanity/presets/src/registry.test.tsx
@@ -44,10 +44,10 @@ describe('createPresetsRegistry', () => {
     expect(result).toHaveProperty('type', 'object')
   })
 
-  describe('with registry-level internalTypes', () => {
-    test.override('registryConfig', {link: {internalTypes: ['marketingPage']}})
+  describe('with registry-level to', () => {
+    test.override('registryConfig', {link: {to: ['marketingPage']}})
 
-    test('defineLink reflects registry-level internalTypes', ({registry}) => {
+    test('defineLink reflects registry-level to', ({registry}) => {
       const result = registry.defineLink({name: 'testLink'})
 
       expect(result).toEqual(
@@ -113,10 +113,10 @@ describe('preset composition via getPreset', () => {
     )
   })
 
-  describe('with registry-level internalTypes', () => {
-    test.override('registryConfig', {link: {internalTypes: ['article', 'page']}})
+  describe('with registry-level to', () => {
+    test.override('registryConfig', {link: {to: ['article', 'page']}})
 
-    test('defineCta link field inherits internalTypes from registry config', ({registry}) => {
+    test('defineCta link field inherits to from registry config', ({registry}) => {
       const result = registry.defineCta({name: 'testCta'})
 
       expect(result).toEqual(


### PR DESCRIPTION
## Description

The `@sanity/presets` link preset exposed its internal-link targets through a config key named `internalTypes`, which diverged from the Schema API's own `reference.to`. Consumers configuring linkable document types had to learn a preset-specific name that mapped onto a concept they already knew.

This PR renames the key to `to` across the registry, link preset, composed presets (CTA, rich text), README, and test studio, aligning it with `reference.to`. The `to` option now accepts both the string shorthand (`['page', 'post']`) and the object form (`[{type: 'page'}]`) that `reference.to` uses natively, normalising either into reference targets.
