### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,38 @@ corepack enable
 2. Verify you have access to the project
 3. Check the browser console for specific errors
 
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service                  | Port | Purpose                                       |
+| ------------------------ | ---- | --------------------------------------------- |
+| Test Studio (`pnpm dev`) | 3333 | Local Sanity Studio for manual plugin testing |
+
+No Docker, databases, or other local services are required. CI-style verification (`pnpm lint`, `pnpm build`, `pnpm test run`) runs entirely in-process.
+
+### Starting the dev server non-interactively
+
+`pnpm dev` may block on an interactive prompt when local Sanity package versions differ from the auto-update runtime (`Do you want to upgrade local versions?`). In headless/cloud environments, start with:
+
+```bash
+CI=true pnpm dev
+```
+
+This skips the prompt and serves the studio at `http://localhost:3333`.
+
+### Sanity authentication
+
+The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` by default). Full end-to-end studio testing requires **browser-based Sanity login** and project access. Without login, the studio still loads and shows the workspace picker, but all workspaces appear as "Signed out".
+
+### Node.js version notes
+
+`dev/test-studio` declares `engines.node: "24"`; the monorepo otherwise targets latest LTS. Node 22 works for build/lint/test with engine warnings. Node 24 is preferred when available.
+
+### Lint / build / test
+
+Standard commands from the Quick Reference table apply. Run `pnpm build` before `pnpm lint` if type errors reference missing `dist/` output. `pretest` automatically builds all packages except `dev/*` before Vitest runs.
+
 ## Related Documentation
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - Human contributor guide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -416,17 +416,21 @@ The test studio dev script uses `sanity dev --no-auto-updates`, so `pnpm dev` st
 
 ### Sanity authentication
 
-The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` by default). For cloud agents, use the injected `__studio_auth_token_ppsg7ml5` secret instead of interactive login.
+The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` by default). For cloud agents, use the injected `STUDIO_AUTH_TOKEN` secret instead of interactive login.
 
-Sanity stores auth in browser `localStorage` under key `__studio_auth_token_ppsg7ml5` as JSON: `{"token":"<token>","time":"<iso-timestamp>"}`.
+Navigate to the studio with the token in the URL hash (Sanity consumes it on load and removes it from the address bar):
 
-Generate a one-liner for the browser console on `http://localhost:3333`:
-
-```bash
-node -e "const t=process.env.__studio_auth_token_ppsg7ml5; console.log(\"localStorage.setItem('__studio_auth_token_ppsg7ml5', \"+JSON.stringify(JSON.stringify({token:t,time:new Date().toISOString()}))+\"); location.href='http://localhost:3333/kitchen-sink';\")" > /tmp/studio-auth-console.js
+```
+http://localhost:3333/kitchen-sink#token=<STUDIO_AUTH_TOKEN>
 ```
 
-Paste the output into the browser DevTools console (type `allow pasting` first if Chrome blocks paste). Reload or navigate to `/kitchen-sink` to confirm authentication. Without a token, workspaces show as "Signed out".
+Build the URL from the secret:
+
+```bash
+node -e "const t=process.env.STUDIO_AUTH_TOKEN; console.log('http://localhost:3333/kitchen-sink#token=' + encodeURIComponent(t))"
+```
+
+Open that URL in the browser to authenticate and land directly in the Kitchen Sink workspace. Without a token, workspaces show as "Signed out".
 
 ### Node.js version notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,7 +422,17 @@ This skips the prompt and serves the studio at `http://localhost:3333`.
 
 ### Sanity authentication
 
-The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` by default). Full end-to-end studio testing requires **browser-based Sanity login** and project access. Without login, the studio still loads and shows the workspace picker, but all workspaces appear as "Signed out".
+The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` by default). For cloud agents, use the injected `__studio_auth_token_ppsg7ml5` secret instead of interactive login.
+
+Sanity stores auth in browser `localStorage` under key `__studio_auth_token_ppsg7ml5` as JSON: `{"token":"<token>","time":"<iso-timestamp>"}`.
+
+Generate a one-liner for the browser console on `http://localhost:3333`:
+
+```bash
+node -e "const t=process.env.__studio_auth_token_ppsg7ml5; console.log(\"localStorage.setItem('__studio_auth_token_ppsg7ml5', \"+JSON.stringify(JSON.stringify({token:t,time:new Date().toISOString()}))+\"); location.href='http://localhost:3333/kitchen-sink';\")" > /tmp/studio-auth-console.js
+```
+
+Paste the output into the browser DevTools console (type `allow pasting` first if Chrome blocks paste). Reload or navigate to `/kitchen-sink` to confirm authentication. Without a token, workspaces show as "Signed out".
 
 ### Node.js version notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,15 +410,9 @@ corepack enable
 
 No Docker, databases, or other local services are required. CI-style verification (`pnpm lint`, `pnpm build`, `pnpm test run`) runs entirely in-process.
 
-### Starting the dev server non-interactively
+### Starting the dev server
 
-`pnpm dev` may block on an interactive prompt when local Sanity package versions differ from the auto-update runtime (`Do you want to upgrade local versions?`). In headless/cloud environments, start with:
-
-```bash
-CI=true pnpm dev
-```
-
-This skips the prompt and serves the studio at `http://localhost:3333`.
+The test studio dev script uses `sanity dev --no-auto-updates`, so `pnpm dev` starts non-interactively (no version-upgrade prompt). The studio serves at `http://localhost:3333`.
 
 ### Sanity authentication
 

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "sanity build",
-    "dev": "sanity dev",
+    "dev": "sanity dev --no-auto-updates",
     "typegen": "sanity schema extract --enforce-required-fields --workspace kitchen-sink && sanity typegen generate"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md and updates the test studio dev script.

**Changes:**
- `dev/test-studio`: `sanity dev --no-auto-updates` for non-interactive `pnpm dev`
- Cloud studio auth via URL hash: `http://localhost:3333/kitchen-sink#token=<STUDIO_AUTH_TOKEN>`
- Node.js version notes for cloud agents

**Verified in cloud VM:** Hash token auth works — Sanity consumes `#token=` on load, Kitchen Sink opens authenticated, documents are editable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8d29b5b-b51b-4d38-b1a2-34174178f4b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8d29b5b-b51b-4d38-b1a2-34174178f4b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

