### PR TITLE
feat(test-studio): improve naive HTML serializer preview UI

### DIFF
--- a/dev/test-studio/src/sanity-naive-html-serializer/formatHtml.ts
+++ b/dev/test-studio/src/sanity-naive-html-serializer/formatHtml.ts
@@ -1,0 +1,38 @@
+const VOID_ELEMENTS = /^(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)$/i
+
+/**
+ * Pretty-print serialized HTML for display in the studio preview.
+ * The serializer returns `outerHTML`, which is typically minified on one line.
+ */
+export function formatHtml(html: string): string {
+  const indentUnit = '  '
+  const lines = html.replace(/>\s+</g, '><').replace(/></g, '>\n<').trim().split('\n')
+
+  let indent = 0
+  const formatted: string[] = []
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+
+    const tagMatch = line.match(/^<\/?([a-zA-Z0-9-]+)/)
+    const tagName = tagMatch?.[1]
+    const isClosingTag = line.startsWith('</')
+    const isSelfClosing =
+      line.endsWith('/>') || (tagName !== undefined && VOID_ELEMENTS.test(tagName))
+    const opensAndClosesOnSameLine =
+      !isClosingTag && !isSelfClosing && /<\/[^>]+>$/.test(line) && line.indexOf('</') > 0
+
+    if (isClosingTag) {
+      indent = Math.max(0, indent - 1)
+    }
+
+    formatted.push(`${indentUnit.repeat(indent)}${line}`)
+
+    if (!isClosingTag && !isSelfClosing && !opensAndClosesOnSameLine && tagName) {
+      indent += 1
+    }
+  }
+
+  return formatted.join('\n')
+}

--- a/dev/test-studio/src/sanity-naive-html-serializer/index.tsx
+++ b/dev/test-studio/src/sanity-naive-html-serializer/index.tsx
@@ -1,6 +1,6 @@
-import {DocumentTextIcon} from '@sanity/icons'
-import {Box, Card, Code, Stack, Text} from '@sanity/ui'
-import {useMemo} from 'react'
+import {CopyIcon, DocumentTextIcon} from '@sanity/icons'
+import {Box, Button, Card, Code, Flex, Stack, Text, Tooltip, useToast} from '@sanity/ui'
+import {useCallback, useMemo} from 'react'
 import type {SanityDocument} from 'sanity'
 import {definePlugin, defineType, useSchema} from 'sanity'
 import {
@@ -9,6 +9,7 @@ import {
   type UserViewComponent,
 } from 'sanity/structure'
 
+import {formatHtml} from './formatHtml'
 import {serializeDocumentToHtml} from './serializeDocumentToHtml'
 
 const naiveHtmlSerializerArticle = defineType({
@@ -39,6 +40,7 @@ const naiveHtmlSerializerArticle = defineType({
 const HtmlSerializeView: UserViewComponent = ({document}) => {
   const schema = useSchema()
   const doc = document.displayed
+  const {push: pushToast} = useToast()
 
   const serialized = useMemo(() => {
     if (!doc?._id || !doc._type) return null
@@ -46,7 +48,33 @@ const HtmlSerializeView: UserViewComponent = ({document}) => {
     return serializeDocumentToHtml(schema, doc as SanityDocument)
   }, [schema, doc])
 
-  if (!serialized) {
+  const rawHtml = serialized?.content
+
+  const formattedHtml = useMemo(() => {
+    if (!rawHtml) return null
+    return formatHtml(rawHtml)
+  }, [rawHtml])
+
+  const handleCopy = useCallback(async () => {
+    if (!rawHtml) return
+
+    try {
+      await navigator.clipboard.writeText(rawHtml)
+      pushToast({
+        closable: true,
+        status: 'success',
+        title: 'HTML copied to clipboard',
+      })
+    } catch {
+      pushToast({
+        closable: true,
+        status: 'error',
+        title: 'Failed to copy HTML to clipboard',
+      })
+    }
+  }, [pushToast, rawHtml])
+
+  if (!serialized || !formattedHtml) {
     return (
       <Card padding={4}>
         <Text>Save the document to preview serialized HTML.</Text>
@@ -55,14 +83,48 @@ const HtmlSerializeView: UserViewComponent = ({document}) => {
   }
 
   return (
-    <Box padding={4}>
-      <Stack gap={4}>
-        <Text size={1} weight="semibold">
-          Serialized HTML
-        </Text>
-        <Card padding={3} border tone="transparent">
-          <Code language="html" size={1}>
-            {serialized.content}
+    <Box padding={4} height="fill">
+      <Stack gap={4} height="fill">
+        <Flex align="center" gap={3} justify="space-between">
+          <Text size={1} weight="semibold">
+            Serialized HTML
+          </Text>
+          <Tooltip
+            content={
+              <Text size={1} style={{whiteSpace: 'nowrap'}}>
+                Copy raw HTML
+              </Text>
+            }
+            padding={2}
+            placement="left"
+          >
+            <Button
+              aria-label="Copy HTML"
+              icon={CopyIcon}
+              mode="ghost"
+              onClick={() => void handleCopy()}
+              text="Copy"
+            />
+          </Tooltip>
+        </Flex>
+        <Card
+          border
+          padding={3}
+          radius={2}
+          style={{flex: 1, minHeight: 0, overflow: 'auto'}}
+          tone="transparent"
+        >
+          <Code
+            language="html"
+            size={1}
+            style={{
+              margin: 0,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+              overflowWrap: 'anywhere',
+            }}
+          >
+            {formattedHtml}
           </Code>
         </Card>
       </Stack>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the **HTML Preview** tab in the naive HTML serializer test studio example:

- Adds a **Copy** button that copies the raw serialized HTML to the clipboard (with toast feedback)
- Pretty-prints HTML with indentation and line breaks so markup is readable inside the panel
- Constrains the preview to a scrollable card with word wrapping—no more single-line horizontal scrolling

Built on top of #931.

## Before / After

### Before

Single-line minified HTML with horizontal scrolling and no copy action:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/df827dfe-2ca7-4f9e-bb7a-eab2865bedf0" />

### After

Formatted HTML with a Copy button and content that fits inside the panel:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/6e20c69e-f637-4037-97eb-7b4954d5cf84" />

## Test plan

- [x] `pnpm lint`
- [x] Manual verification in test studio HTML Preview tab (copy button + formatted output)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c15db31-da36-4066-8943-fdc7c9e1cb58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c15db31-da36-4066-8943-fdc7c9e1cb58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

