### PR TITLE
feat(documents-pane): show document count in view pane

### DIFF
--- a/.changeset/documents-pane-count.md
+++ b/.changeset/documents-pane-count.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-documents-pane": minor
+---
+
+Show document count in the documents pane view

--- a/plugins/sanity-plugin-documents-pane/src/Documents.tsx
+++ b/plugins/sanity-plugin-documents-pane/src/Documents.tsx
@@ -1,5 +1,5 @@
 import {WarningOutlineIcon} from '@sanity/icons'
-import {Box, Button, Card, Flex, Spinner, Stack} from '@sanity/ui'
+import {Box, Button, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
 import {fromString as pathFromString} from '@sanity/util/paths'
 import {useCallback} from 'react'
 import {
@@ -81,7 +81,8 @@ export default function Documents(props: DocumentsProps) {
     return (
       <>
         <NewDocument initialValueTemplates={initialValueTemplates} />
-        <Stack gap={5} padding={4}>
+        <Stack gap={4} padding={4}>
+          <DocumentsCount count={0} />
           <Feedback>No Documents found</Feedback>
           {debug ? <Debug params={params} query={query} /> : null}
         </Stack>
@@ -92,6 +93,11 @@ export default function Documents(props: DocumentsProps) {
   return (
     <>
       <NewDocument initialValueTemplates={initialValueTemplates} />
+      <Box paddingX={3} paddingTop={3} paddingBottom={1}>
+        <Box paddingLeft={1}>
+          <DocumentsCount count={data.length} />
+        </Box>
+      </Box>
       <Stack gap={1} padding={2}>
         {data.map((doc) => {
           const schemaType = schema.get(doc._type)
@@ -128,5 +134,15 @@ export default function Documents(props: DocumentsProps) {
         })}
       </Stack>
     </>
+  )
+}
+
+function DocumentsCount({count}: {count: number}) {
+  const label = count === 1 ? 'document' : 'documents'
+
+  return (
+    <Text muted size={1}>
+      {count} {label}
+    </Text>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #945

Shows how many documents match the pane's GROQ query using muted `Text` at size 1, displayed above the document list in the Incoming References view.

## Changes

- Add a `DocumentsCount` label in `Documents.tsx` for both empty and populated states
- Use singular/plural copy (`1 document` / `N documents`)

## Preview

<img width="539" height="507" alt="Screenshot 2026-06-09 at 09 02 29" src="https://github.com/user-attachments/assets/86ddc4e0-ec0f-4df7-8df1-769097a8da8c" />

[Incoming References pane showing document count](https://cursor.com/agents/bc-bad09306-f253-4ed5-a73d-fc11f9dceab6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocuments-pane-count.png)

## Test plan

- [x] Opened Documents Pane Example workspace in test studio
- [x] Verified count shows as muted text above the list (`1 document`)
- [x] Plugin package tests pass

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bad09306-f253-4ed5-a73d-fc11f9dceab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bad09306-f253-4ed5-a73d-fc11f9dceab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

