### PR TITLE
fix(internationalized-array): prevent defaultLanguages auto-add from recreating deleted documents

### DIFF
--- a/.changeset/i18n-array-no-resurrect-deleted-documents.md
+++ b/.changeset/i18n-array-no-resurrect-deleted-documents.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-internationalized-array': patch
+---
+
+Fix deleted documents being recreated as empty drafts when `defaultLanguages` is configured. The auto-add effect now only patches documents that exist in the dataset (have a `_rev`) and skips documents the pane reports as deleted. This also means new documents no longer get a draft created just by opening the form — default languages are added after the user's first edit.

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -66,6 +66,7 @@ vi.mock('./Feedback', () => ({
 }))
 
 import {useLanguageFilterStudioContext} from '@sanity/language-filter'
+import {useFormValue} from 'sanity'
 import {useDocumentPane} from 'sanity/structure'
 
 import {ThemeWrapper} from '../test/component-helpers'
@@ -467,6 +468,52 @@ describe('InternationalizedArray', () => {
     const props = createMockArrayProps({onChange})
 
     renderInternationalizedArray(props)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages when document has been deleted', async () => {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleted: true,
+      isDeleting: false,
+    } as ReturnType<typeof useDocumentPane>)
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    // Allow the scheduled setTimeout in the useEffect to fire
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages when the document does not exist yet (no _rev)', async () => {
+    // _type resolves as usual, but the document has no revision: it is either
+    // brand new (unsaved) or was just deleted while the pane is still open
+    vi.mocked(useFormValue).mockImplementation((path) =>
+      Array.isArray(path) && path[0] === '_rev' ? undefined : 'article',
+    )
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    // Allow the scheduled setTimeout in the useEffect to fire
+    await new Promise((resolve) => setTimeout(resolve, 10))
 
     expect(onChange).not.toHaveBeenCalled()
   })

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -38,8 +38,10 @@ import {MigrationBanner} from './MigrationBanner'
  *   missing languages" button (controlled by `buttonAddAll` and
  *   `buttonLocations` config). Dispatches `setIfMissing` + `insert` patches.
  * - **Default languages**: Automatically adds entries for languages listed in
- *   `defaultLanguages` when a document is first created or when those entries
- *   are missing.
+ *   `defaultLanguages` when those entries are missing. Only runs once the
+ *   document exists in the dataset (it has a `_rev`), so the effect never
+ *   recreates a just-deleted document or creates a draft before the user's
+ *   first edit.
  * - **Ordering**: Detects when value items are out of order relative to the
  *   master `languages` list and automatically re-sorts them.
  * - **Validation**: Shows a `<Feedback>` component if the languages
@@ -144,7 +146,14 @@ export default function InternationalizedArray(
     [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path],
   )
 
-  const {isDeleting} = useDocumentPane()
+  const {isDeleted, isDeleting} = useDocumentPane()
+
+  // The document only has a revision once it exists in the dataset. Patching
+  // a nonexistent document would create it: auto-adding default languages to
+  // a just-deleted document resurrects it as an empty draft (and the deleted
+  // pane can outrace `isDeleted`), and auto-adding to an unsaved new document
+  // creates a draft before the user has made any edits.
+  const documentExists = Boolean(useFormValue(['_rev']))
 
   // Create a stable dependency string that only changes when language keys change
   const languageKeysFromValue = value
@@ -165,7 +174,13 @@ export default function InternationalizedArray(
       .filter((language) => languages.find((l) => l.id === language))
       .every((language) => addedLanguages.includes(language))
 
-    if (!isDeleting && !hasAddedDefaultLanguages && !shouldMigrateArray) {
+    if (
+      documentExists &&
+      !isDeleting &&
+      !isDeleted &&
+      !hasAddedDefaultLanguages &&
+      !shouldMigrateArray
+    ) {
       const languagesToAdd = defaultLanguages
         .filter((language) => !addedLanguages.includes(language))
         .filter((language) => languages.find((l) => l.id === language))
@@ -177,6 +192,8 @@ export default function InternationalizedArray(
     }
     return undefined
   }, [
+    documentExists,
+    isDeleted,
     isDeleting,
     handleAddLanguages,
     defaultLanguages,


### PR DESCRIPTION
## Problem

With `defaultLanguages` configured, deleting a document while its pane is open puts it in an endless delete/recreate loop. The document is resurrected as an empty draft containing only the scaffolded language entries:

```json
{
  "_id": "drafts.person-editor-in-chief",
  "_type": "person",
  "title": [{"_type": "internationalizedArrayStringValue", "_key": "...", "language": "en-US"}],
  "biography": [{"_type": "internationalizedArrayTextValue", "_key": "...", "language": "en-US"}]
}
```

### Root cause

The auto-add effect in `InternationalizedArray` patches the document whenever default language entries are missing, guarded only by `useDocumentPane().isDeleting`. That guard is race-prone:

1. Delete completes → `isDeleting` flips back to `false` while the form is still mounted
2. The form value is now empty → `hasAddedDefaultLanguages` is `false`
3. The effect fires and patches the now-nonexistent document
4. The document store materializes a fresh empty draft → the document is reborn

Confirmed via HAR traces: `sanity.action.document.version.discard` is immediately followed by `sanity.action.document.create` + `setIfMissing`/`insert` patches for each internationalized field.

## Fix

Gate the auto-add effect on:

- `documentExists` — the form value has a `_rev`, i.e. the document actually exists in the dataset. This check is synchronous with the same form-state snapshot the effect reads, so it cannot lose the race the way the async pane flags can.
- `isDeleted` — belt-and-braces for the pane's deleted state.

### Behavior change

Opening a new (unsaved) document form no longer creates a draft on its own — default languages are scaffolded right after the user's first edit instead of on pane-open. This also stops empty ghost drafts from being created by editors merely opening and abandoning a new-document form.

## Test plan

- [x] Existing suite passes (174 tests across 19 files)
- [x] New test: no auto-add when pane reports `isDeleted: true`
- [x] New test: no auto-add when the document has no `_rev` (unsaved or just deleted)
- [x] Manually verified in a studio with `defaultLanguages: ['en-US']`: delete with the pane open stays deleted; first edit on a new document still scaffolds default languages

Made with [Cursor](https://cursor.com)