### PR TITLE
Address Copilot review on #977 (dashboard plugins)

### DIFF
--- a/.changeset/dashboard-copilot-review.md
+++ b/.changeset/dashboard-copilot-review.md
@@ -1,0 +1,5 @@
+---
+'@sanity/dashboard': patch
+---
+
+Give `projectUsersWidget` a unique `name` (`project-users`) so it no longer collides with `projectInfoWidget`, and fix the widget config example in the README.

--- a/.changeset/dashboard-widget-netlify-copilot-review.md
+++ b/.changeset/dashboard-widget-netlify-copilot-review.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-dashboard-widget-netlify': patch
+---
+
+Add `rel="noopener noreferrer"` to the "Manage sites at Netlify" link that opens in a new tab.

--- a/.changeset/dashboard-widget-vercel-copilot-review.md
+++ b/.changeset/dashboard-widget-vercel-copilot-review.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-dashboard-widget-vercel': patch
+---
+
+Fix the deployments table layout (correct "Creator" column width and table body display), surface JSON parsing errors from the Vercel API, and remove an invalid `htmlFor` attribute from a non-label description.

--- a/plugins/@sanity/dashboard/README.md
+++ b/plugins/@sanity/dashboard/README.md
@@ -58,7 +58,7 @@ dashboardTool({
 Widgets can be configured by passing widget-specific config:
 
 ```ts
-projectUsersWidget({layout: 'medium'})
+projectUsersWidget({layout: {width: 'medium'}})
 ```
 
 You can change the name, title and icon of the dashboard tool should you want to - which also allows you to configure multiple dashboards with different configurations:

--- a/plugins/@sanity/dashboard/src/widgets/projectUsers/index.ts
+++ b/plugins/@sanity/dashboard/src/widgets/projectUsers/index.ts
@@ -3,7 +3,7 @@ import {ProjectUsers} from './ProjectUsers'
 
 export function projectUsersWidget(config?: {layout?: LayoutConfig}): DashboardWidget {
   return {
-    name: 'project-info',
+    name: 'project-users',
     component: ProjectUsers,
     layout: config?.layout,
   }

--- a/plugins/sanity-plugin-dashboard-widget-netlify/src/components/NetlifyWidget.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-netlify/src/components/NetlifyWidget.tsx
@@ -26,6 +26,7 @@ export default function NetlifyWidget(props: NetlifyWidgetProps) {
         text="Manage sites at Netlify"
         loading={isLoading}
         target="_blank"
+        rel="noopener noreferrer"
       />
     </Flex>
   )

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployments/index.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployments/index.tsx
@@ -129,13 +129,13 @@ const Deployments = (props: Props) => {
                 </TableCell>
 
                 {/* Creator */}
-                <TableCell header variant="age">
+                <TableCell header variant="creator">
                   Creator
                 </TableCell>
               </tr>
             </Box>
 
-            <Box as="tbody" style={{display: 'table-header-group'}}>
+            <Box as="tbody" style={{display: 'table-row-group'}}>
               {/* Placeholders */}
               {!deployments &&
                 Array.from({length: deploymentTarget.deployLimit}, (_, index) => (

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/components/FormFieldInputLabel/index.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/components/FormFieldInputLabel/index.tsx
@@ -49,7 +49,7 @@ const FormFieldInputLabel: FC<Props> = (props: Props) => {
       {/* Description */}
       {description && (
         <Box marginY={3}>
-          <Text htmlFor={name} muted size={1}>
+          <Text as="p" muted size={1}>
             {description}
           </Text>
         </Box>

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/components/TableCell/index.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/components/TableCell/index.tsx
@@ -43,7 +43,7 @@ const TableCell = (props: Props) => {
       <Box
         as="th"
         colSpan={colSpan}
-        // @ts-expect-error -- `colSpan` is not part of @sanity/ui Box props, but is forwarded to the `th` element
+        // @ts-expect-error -- local `display` allows 'table-cell', which is not part of @sanity/ui's `BoxDisplay` union
         display={display}
         paddingX={3}
         paddingY={2}
@@ -62,7 +62,7 @@ const TableCell = (props: Props) => {
     <Box
       as="td"
       colSpan={colSpan}
-      // @ts-expect-error -- `colSpan` is not part of @sanity/ui Box props, but is forwarded to the `td` element
+      // @ts-expect-error -- local `display` allows 'table-cell', which is not part of @sanity/ui's `BoxDisplay` union
       display={display}
       paddingX={3}
       paddingY={[2, 2, 3]}

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/utils/fetcher.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/utils/fetcher.ts
@@ -28,7 +28,7 @@ const fetcher =
     }
 
     try {
-      return response.json()
+      return await response.json()
     } catch (err) {
       throw new Error('Unable to parse response as JSON', {cause: err})
     }

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/utils/sanitizeFormData.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/utils/sanitizeFormData.ts
@@ -1,6 +1,6 @@
 // Recursively sanitize form data:
 // - convert empty strings, undefined values and empty arrays to null (to correctly unset / delete fields)
-// - trim whitespace on string fleids
+// - trim whitespace on string fields
 
 type FormData = Record<string, any>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the merged migration PR #977, addressing the [Copilot code review](https://github.com/sanity-io/plugins/pull/977#pullrequestreview-4498008286).

Of the 13 inline comments, 3 were already resolved on `main` after the merge (vercel README broken `sanity-io/anity-…` link, netlify README "Sanity Studio v3" claim, and the document-list `package.json` `"> **NOTE**"` description). This PR fixes the remaining 10.

## `@sanity/dashboard`
- `projectUsersWidget` returned the same `name` (`project-info`) as `projectInfoWidget`; it now returns `project-users`.
- README configured `layout` as a string (`'medium'`); corrected to a `LayoutConfig` object (`{width: 'medium'}`).

## `sanity-plugin-dashboard-widget-vercel`
- `fetcher.ts`: `await response.json()` so the `try/catch` actually wraps JSON parse rejections.
- `Deployments`: the "Creator" header used `variant="age"` (now `variant="creator"`), and the table body used `display: 'table-header-group'` (now `'table-row-group'`).
- `FormFieldInputLabel`: removed an invalid `htmlFor` on the non-label description `Text` (now `as="p"`).
- `TableCell`: the `@ts-expect-error` directives stay above `display` (the line that actually errors — local `display` allows `'table-cell'`, which is not in `@sanity/ui`'s `BoxDisplay`); their misleading "colSpan" comments are rewritten to describe the real cause. `colSpan` is accepted by `Box` via `AllHTMLAttributes`, so Copilot's literal "move above colSpan" suggestion would have broken the build (verified with `tsc`: it yields `TS2578` on `colSpan` + `TS2322` on `display`).
- `sanitizeFormData.ts`: comment typo "fleids" → "fields".

## `sanity-plugin-dashboard-widget-netlify`
- Added `rel="noopener noreferrer"` to the `target="_blank"` "Manage sites at Netlify" button.

Patch changesets added for the three affected plugins.

## Testing

- `pnpm format` (no changes), `pnpm lint` (clean, `--deny-warnings`), `pnpm build` (36/36), `pnpm test run` (700 passed).
- `tsc` experiment confirmed the `TableCell` `@ts-expect-error` belongs above `display`, not `colSpan`.
- Manually verified in the test-studio `dashboard-example` workspace: the Project Info and Project Users widgets both render, and the Vercel widget's "Create deployment target" dialog renders field labels with their description helper text.

[dashboard_widgets_and_vercel_dialog_clean_demo.mp4](https://cursor.com/agents/bc-42d463b5-01a5-4e3f-9ea4-ee2931a282ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_widgets_and_vercel_dialog_clean_demo.mp4)

[Dashboard Project info and Project users widgets](https://cursor.com/agents/bc-42d463b5-01a5-4e3f-9ea4-ee2931a282ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_dashboard_project_info_and_users.webp)
[Vercel Create deployment target dialog with field labels and descriptions](https://cursor.com/agents/bc-42d463b5-01a5-4e3f-9ea4-ee2931a282ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_vercel_create_target_dialog.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d463b5-01a5-4e3f-9ea4-ee2931a282ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d463b5-01a5-4e3f-9ea4-ee2931a282ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

