### PR TITLE
Address Copilot review feedback on @sanity/plugin-kit (#979)

### DIFF
--- a/.changeset/plugin-kit-review-fixes.md
+++ b/.changeset/plugin-kit-review-fixes.md
@@ -1,0 +1,10 @@
+---
+'@sanity/plugin-kit': patch
+---
+
+Fix CLI command name in messages, plus typos and a redundant tsconfig read
+
+- Correct `binname` to `plugin-kit` so the `version`/`link-watch` help text and the missing-`sanity.json` error suggest the executable that is actually installed
+- Remove a stray apostrophe from the `verify-package --single` fail-fast hint so it can be copy-pasted as-is
+- Fix user-facing typos in CLI help and error messages ("promt" → "prompt", "exsists" → "exists", "Typescript" → "TypeScript")
+- Parse the tsconfig file once in `readTSConfig` instead of reading it twice

--- a/packages/@sanity/plugin-kit/docs/ui-workshop.md
+++ b/packages/@sanity/plugin-kit/docs/ui-workshop.md
@@ -16,9 +16,8 @@ Sets up your package with [@sanity/ui-workshop](https://github.com/sanity-io/ui-
 to make component testing a breeze.
 
 - Adds [@sanity/ui-workshop](https://github.com/sanity-io/ui-workshop) dev dependency.
-- Adds a example files for testing components using @sanity/ui-workshop
+- Adds example files for testing components using @sanity/ui-workshop
 - Adds .workshop to .gitignore
--
 
 ## Manual steps after inject
 

--- a/packages/@sanity/plugin-kit/package.json
+++ b/packages/@sanity/plugin-kit/package.json
@@ -102,5 +102,5 @@
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
   },
-  "binname": "sanity-plugin"
+  "binname": "plugin-kit"
 }

--- a/packages/@sanity/plugin-kit/src/actions/inject.ts
+++ b/packages/@sanity/plugin-kit/src/actions/inject.ts
@@ -166,7 +166,7 @@ async function writeLicense(
     return false
   }
 
-  // Prefer whatever path the user is currenly using (LICENSE.md or LICENSE)
+  // Prefer whatever path the user is currently using (LICENSE.md or LICENSE)
   const hasLicenseMdFile = await fileExists(path.join(basePath, 'LICENSE.md'))
   const licensePath = path.join(basePath, hasLicenseMdFile ? 'LICENSE.md' : 'LICENSE')
 
@@ -211,7 +211,7 @@ async function getLicenseIdentifier(
     return null
   }
 
-  // --license becomes "", --license mit beocomes "mit"
+  // --license becomes "", --license mit becomes "mit"
   if (typeof flags.license === 'string') {
     const license = licenses.find(`${flags.license}`)
     if (!license) {

--- a/packages/@sanity/plugin-kit/src/actions/verify-package.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify-package.ts
@@ -83,7 +83,7 @@ export async function verifyPackage({basePath, flags}: {basePath: string; flags:
         - Reference documentation: ${urls.refDocs}
 
         ${chalk.grey(
-          `To fail-fast on first detected issue run:\nnpx ${cliName} verify-package' --single`,
+          `To fail-fast on first detected issue run:\nnpx ${cliName} verify-package --single`,
         )}
       `.trimStart(),
     )

--- a/packages/@sanity/plugin-kit/src/actions/verify/verify-common.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify/verify-common.ts
@@ -83,7 +83,7 @@ export function createValidator(
 
 export async function runTscMaybe(verifyConfig: VerifyPackageConfig, ts?: ParsedCommandLine) {
   if (ts && verifyConfig.tsc !== false) {
-    log.info('All checks ok, running Typescript compiler.')
+    log.info('All checks ok, running TypeScript compiler.')
     const {code} = await runCommand('tsc --build')
     if (code !== 0) {
       throw new Error('Compilation failed. See output above.\n\n' + disableCheckText('tsc'))

--- a/packages/@sanity/plugin-kit/src/cmds/init.ts
+++ b/packages/@sanity/plugin-kit/src/cmds/init.ts
@@ -31,7 +31,7 @@ Options
   --author [name]         Use the provided author
   --repo [url]            Use the provided repo url
   --license [spdx]        Use the license with the given SPDX identifier
-  --force                 No promt when overwriting files
+  --force                 No prompt when overwriting files
 
   --preset [preset-name]  Adds config and files from a named preset. --preset can be supplied multiple times.
                           The following presets are available:
@@ -62,7 +62,7 @@ async function run({argv}: {argv: string[]}) {
   const {v3ConfigFile} = await findStudioV3Config(basePath)
   if (v3ConfigFile) {
     throw new Error(
-      `${v3ConfigFile} exsists - are you trying to init into a studio instead of a plugin?`,
+      `${v3ConfigFile} exists - are you trying to init into a studio instead of a plugin?`,
     )
   }
 

--- a/packages/@sanity/plugin-kit/src/cmds/inject.ts
+++ b/packages/@sanity/plugin-kit/src/cmds/inject.ts
@@ -26,7 +26,7 @@ Options
   --no-scripts            Disables scripts from being added to package.json
 
   --license [spdx]        Use the license with the given SPDX identifier
-  --force                 No promt when overwriting files
+  --force                 No prompt when overwriting files
 
   --preset [preset-name]  Adds config and files from a named preset. --preset can be supplied multiple times.
                           The following presets are available:

--- a/packages/@sanity/plugin-kit/src/dependencies/import-linter.ts
+++ b/packages/@sanity/plugin-kit/src/dependencies/import-linter.ts
@@ -65,7 +65,7 @@ export async function validateImports({basePath}: {basePath: string}): Promise<s
       const formatter = await eslint.loadFormatter('stylish')
       const resultText = await formatter.format(onlyImportErrors)
 
-      const addtionalInfo = outdent`
+      const additionalInfo = outdent`
         ESLint detected Studio V2 imports that are no longer available.
         It is recommended configure @sanity/eslint-config-no-v2-imports for ESLint.
 
@@ -80,7 +80,7 @@ export async function validateImports({basePath}: {basePath: string}): Promise<s
 
         If the plugin package does not use eslint, disable this check.
     `
-      return [resultText + addtionalInfo]
+      return [resultText + additionalInfo]
     }
   } catch (e) {
     log.error('Failed to run eslint check', e)

--- a/packages/@sanity/plugin-kit/src/presets/semver-workflow.ts
+++ b/packages/@sanity/plugin-kit/src/presets/semver-workflow.ts
@@ -122,7 +122,7 @@ async function readmeSnippets(options: InjectOptions) {
 }
 
 /**
- * Returns sections that does not exists "close enough" in readme
+ * Returns sections that do not exist "close enough" in readme
  */
 export function missingSections(readme: string, sections: string[]) {
   return sections.filter((section) => !closeEnough(section, readme))

--- a/packages/@sanity/plugin-kit/src/util/ts.ts
+++ b/packages/@sanity/plugin-kit/src/util/ts.ts
@@ -11,11 +11,9 @@ export async function readTSConfig(options: {basePath: string; filename: string}
 
   if (!exists) return undefined
 
-  return ts.readConfigFile(filePath, ts.sys.readFile).config
-    ? ts.parseJsonConfigFileContent(
-        ts.readConfigFile(filePath, ts.sys.readFile).config,
-        ts.sys,
-        basePath,
-      )
-    : undefined
+  const {config} = ts.readConfigFile(filePath, ts.sys.readFile)
+
+  if (!config) return undefined
+
+  return ts.parseJsonConfigFileContent(config, ts.sys, basePath)
 }

--- a/packages/@sanity/plugin-kit/test/__snapshots__/verify-package.test.ts.snap
+++ b/packages/@sanity/plugin-kit/test/__snapshots__/verify-package.test.ts.snap
@@ -228,7 +228,7 @@ More information is available here:
 - Reference documentation: https://beta.sanity.io/docs/reference
 
 To fail-fast on first detected issue run:
-npx @sanity/plugin-kit verify-package' --single"
+npx @sanity/plugin-kit verify-package --single"
 `;
 
 exports[`plugin-kit verify-package in package with invalid eslint config 1`] = `
@@ -274,7 +274,7 @@ More information is available here:
 - Reference documentation: https://beta.sanity.io/docs/reference
 
 To fail-fast on first detected issue run:
-npx @sanity/plugin-kit verify-package' --single"
+npx @sanity/plugin-kit verify-package --single"
 `;
 
 exports[`plugin-kit verify-studio in fresh v2 studio 1`] = `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the merged `@sanity/plugin-kit` port (#979), addressing the [Copilot review](https://github.com/sanity-io/plugins/pull/979#pullrequestreview-4506552764) comments. All changes are scoped to `packages/@sanity/plugin-kit`.

## Changes

**Behavioral fixes**

- **`binname` → `plugin-kit`** (`package.json`): the package only exposes the `plugin-kit` executable via `bin`, but `binname` was `sanity-plugin`. That value is read from the package's own `package.json` and used in the `version`/`link-watch` help text and the missing-`sanity.json` error (`manifest.ts`), so those messages were suggesting a command that does not exist for users.
- **Stray apostrophe** (`actions/verify-package.ts`): the fail-fast hint printed `npx @sanity/plugin-kit verify-package' --single`, which is invalid when copied. Now matches the `verify-studio` hint. The corresponding `verify-package` snapshot was regenerated.
- **`readTSConfig` parses once** (`util/ts.ts`): the helper read/parsed the tsconfig file twice; it now stores the `readConfigFile` result and parses it a single time (same return type/behavior).

**Typo / grammar fixes**

- `promt` → `prompt` in the `--force` help text (`cmds/init.ts`, `cmds/inject.ts`)
- `exsists` → `exists` in the init error (`cmds/init.ts`)
- `Typescript` → `TypeScript` in the verify tsc log message (`verify/verify-common.ts`)
- `addtionalInfo` → `additionalInfo` variable rename (`dependencies/import-linter.ts`)
- "does not exists" → "do not exist" in the `missingSections` doc comment (`presets/semver-workflow.ts`)
- `currenly` → `currently`, `beocomes` → `becomes` in comments (`actions/inject.ts`)
- `docs/ui-workshop.md`: removed the incorrect article in "a example files" (kept the plural since the preset adds several files) and dropped the empty bullet point

## Verification

Run under Node 24 (matching CI's `lts/*`):

- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm build` (41/41 tasks)
- ✅ `pnpm test run` (157 files, 877 tests; regenerated `verify-package` snapshot)
- ✅ Manual CLI check: built `plugin-kit` help now prints `$ plugin-kit version` / `$ plugin-kit link-watch` (previously `sanity-plugin …`)

A major changeset for `@sanity/plugin-kit` from #979 is still pending release, so this patch changeset stacks on top of it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66d58347-390f-45cd-b59e-d00b4b6fa988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66d58347-390f-45cd-b59e-d00b4b6fa988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

