### PR TITLE
feat(sanity-plugin-dashboard-dad-jokes): add dad jokes dashboard widget

### DIFF
--- a/.changeset/add-dashboard-dad-jokes.md
+++ b/.changeset/add-dashboard-dad-jokes.md
@@ -1,0 +1,5 @@
+---
+'sanity-plugin-dashboard-dad-jokes': minor
+---
+
+Add the dad jokes dashboard widget to the monorepo, modernized for Sanity Studio v3+ (dashboard widget API, ESM build, React 19).

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Sessions can be compared in the DevTools UI to diff bundle changes between build
 | [`sanity-plugin-aprimo`](./plugins/sanity-plugin-aprimo)                                                 | Aprimo asset selector integration                                   |
 | [`sanity-plugin-asset-source-unsplash`](./plugins/sanity-plugin-asset-source-unsplash)                   | Use Unsplash images directly in Sanity Studio                       |
 | [`sanity-plugin-bynder-input`](./plugins/sanity-plugin-bynder-input)                                     | Bynder asset picker integration                                     |
+| [`sanity-plugin-dashboard-dad-jokes`](./plugins/sanity-plugin-dashboard-dad-jokes)                       | Dashboard widget that fetches a random dad joke                     |
 | [`sanity-plugin-dashboard-widget-document-list`](./plugins/sanity-plugin-dashboard-widget-document-list) | Dashboard widget for displaying document lists                      |
 | [`sanity-plugin-dashboard-widget-netlify`](./plugins/sanity-plugin-dashboard-widget-netlify)             | Dashboard widget for triggering Netlify builds                      |
 | [`sanity-plugin-dashboard-widget-vercel`](./plugins/sanity-plugin-dashboard-widget-vercel)               | Dashboard widget for managing Vercel deployments                    |

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -39,6 +39,7 @@
     "sanity-plugin-aprimo": "workspace:*",
     "sanity-plugin-asset-source-unsplash": "workspace:*",
     "sanity-plugin-bynder-input": "workspace:*",
+    "sanity-plugin-dashboard-dad-jokes": "workspace:*",
     "sanity-plugin-dashboard-widget-document-list": "workspace:*",
     "sanity-plugin-dashboard-widget-netlify": "workspace:*",
     "sanity-plugin-dashboard-widget-vercel": "workspace:*",

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -26,6 +26,7 @@ import {
   internationalizedArrayAsyncLanguages,
   internationalizedArrayExample,
 } from '#internationalized-array'
+import {jokesWidgetExample} from '#jokes-widget'
 import {latexInputExample} from '#latex-input'
 import {markdownExample} from '#markdown'
 import {mediaExample} from '#media'
@@ -112,6 +113,7 @@ export default defineConfig([
     plugins: [
       structureTool(),
       dashboardToolExample(),
+      jokesWidgetExample(),
       documentListWidgetExample(),
       netlifyWidgetExample(),
       vercelWidgetExample(),

--- a/dev/test-studio/src/jokes-widget/index.tsx
+++ b/dev/test-studio/src/jokes-widget/index.tsx
@@ -1,0 +1,13 @@
+import {dashboardTool} from '@sanity/dashboard'
+import {definePlugin} from 'sanity'
+import {jokesWidget} from 'sanity-plugin-dashboard-dad-jokes'
+
+export const jokesWidgetExample = definePlugin(() => ({
+  plugins: [
+    dashboardTool({
+      name: 'dad-jokes',
+      title: 'Dad Jokes',
+      widgets: [jokesWidget({layout: {width: 'medium'}})],
+    }),
+  ],
+}))

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -238,6 +238,11 @@
       ],
     },
 
+    "plugins/sanity-plugin-dashboard-dad-jokes": {
+      "entry": ["package.config.ts"],
+      "project": ["src/**/*.{ts,tsx}"],
+    },
+
     "plugins/sanity-plugin-dashboard-widget-document-list": {
       "entry": ["package.config.ts"],
       "project": ["src/**/*.{ts,tsx}"],

--- a/plugins/sanity-plugin-dashboard-dad-jokes/README.md
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/README.md
@@ -1,0 +1,52 @@
+# sanity-plugin-dashboard-dad-jokes
+
+> This is a **Sanity Studio v3+** plugin.
+
+A dashboard widget for [Sanity Content Studio](https://www.sanity.io/) that fetches a random dad joke from [icanhazdadjoke.com](https://icanhazdadjoke.com/).
+
+## Installation
+
+```sh
+npm install sanity-plugin-dashboard-dad-jokes
+```
+
+This widget is rendered by [`@sanity/dashboard`](https://github.com/sanity-io/plugins/tree/main/plugins/%40sanity/dashboard), so install that too if you haven't already:
+
+```sh
+npm install @sanity/dashboard
+```
+
+## Usage
+
+Add `dashboardTool` to your plugins and pass `jokesWidget()` as one of its widgets in `sanity.config.ts` (or `.js`):
+
+```ts
+import {defineConfig} from 'sanity'
+import {dashboardTool} from '@sanity/dashboard'
+import {jokesWidget} from 'sanity-plugin-dashboard-dad-jokes'
+
+export default defineConfig({
+  // ...
+  plugins: [
+    dashboardTool({
+      widgets: [jokesWidget()],
+    }),
+  ],
+})
+```
+
+### Configuration
+
+`jokesWidget` accepts an optional config object:
+
+| Property | Type           | Description                                                  |
+| -------- | -------------- | ------------------------------------------------------------ |
+| `layout` | `LayoutConfig` | Controls the widget's size. Defaults to `{width: 'medium'}`. |
+
+```ts
+jokesWidget({layout: {width: 'small'}})
+```
+
+## License
+
+[MIT](LICENSE) © Sachin Sancheti

--- a/plugins/sanity-plugin-dashboard-dad-jokes/package.config.ts
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/package.config.ts
@@ -1,0 +1,8 @@
+import config from '@repo/package.config'
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  ...config,
+  babel: {reactCompiler: true},
+  reactCompilerOptions: {target: '19'},
+})

--- a/plugins/sanity-plugin-dashboard-dad-jokes/package.json
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "sanity-plugin-dashboard-dad-jokes",
+  "version": "1.0.0",
+  "description": "A dashboard widget for Sanity Content Studio to obtain dad jokes",
+  "keywords": [
+    "dad-jokes",
+    "dashboard",
+    "plugin",
+    "sanity",
+    "widget"
+  ],
+  "homepage": "https://github.com/sanity-io/plugins/tree/main/plugins/sanity-plugin-dashboard-dad-jokes#readme",
+  "bugs": {
+    "url": "https://github.com/sanity-io/plugins/issues"
+  },
+  "license": "MIT",
+  "author": "Sachin Sancheti <sachin.sancheti@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/sanity-io/plugins.git",
+    "directory": "plugins/sanity-plugin-dashboard-dad-jokes"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "build": "pkg build --strict --check --clean",
+    "prepack": "turbo run build"
+  },
+  "dependencies": {
+    "@sanity/ui": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/package.config": "workspace:*",
+    "@repo/tsconfig": "workspace:*",
+    "@sanity/dashboard": "workspace:*",
+    "@sanity/pkg-utils": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "babel-plugin-react-compiler": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "sanity": "catalog:"
+  },
+  "peerDependencies": {
+    "@sanity/dashboard": "workspace:^",
+    "react": "^19.2",
+    "react-dom": "^19.2",
+    "sanity": "^5 || ^6.0.0-0"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  }
+}

--- a/plugins/sanity-plugin-dashboard-dad-jokes/src/Jokes.tsx
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/src/Jokes.tsx
@@ -1,0 +1,52 @@
+import {DashboardWidgetContainer} from '@sanity/dashboard'
+import {Button, Card, Code, Spinner, Text} from '@sanity/ui'
+import {useEffect, useState} from 'react'
+
+export default function Jokes() {
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | undefined>()
+  const [joke, setJoke] = useState<string | undefined>()
+
+  // Performs the request and only updates state from async callbacks, so it is
+  // safe to call from an effect without triggering a synchronous setState.
+  function loadJoke() {
+    return fetch('https://icanhazdadjoke.com/', {headers: {Accept: 'application/json'}})
+      .then((res) => res.json())
+      .then((data) => setJoke(data.joke))
+      .catch((e: Error) => setError(e))
+      .finally(() => setIsLoading(false))
+  }
+
+  function getJoke() {
+    setIsLoading(true)
+    setError(undefined)
+    void loadJoke()
+  }
+
+  useEffect(() => {
+    void loadJoke()
+  }, [])
+
+  return (
+    <DashboardWidgetContainer
+      header="A dad joke"
+      footer={<Button text="New joke" tone="primary" onClick={getJoke} disabled={isLoading} />}
+    >
+      {isLoading && (
+        <Card paddingX={3} paddingY={4}>
+          <Spinner />
+        </Card>
+      )}
+      {error && !isLoading && (
+        <Card paddingX={3} paddingY={4} tone="critical">
+          <Code>{JSON.stringify(error, null, 2)}</Code>
+        </Card>
+      )}
+      {joke && !isLoading && !error && (
+        <Card paddingX={3} paddingY={4} tone="positive">
+          <Text>{joke}</Text>
+        </Card>
+      )}
+    </DashboardWidgetContainer>
+  )
+}

--- a/plugins/sanity-plugin-dashboard-dad-jokes/src/index.test.ts
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/src/index.test.ts
@@ -1,0 +1,19 @@
+import {fileURLToPath} from 'node:url'
+
+import {expect, test} from 'vitest'
+import {getPackageExportsManifest} from 'vitest-package-exports'
+
+test('package exports', {timeout: 30_000}, async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: 'dist',
+    cwd: fileURLToPath(import.meta.url),
+  })
+
+  expect(manifest.exports).toMatchInlineSnapshot(`
+    {
+      ".": {
+        "jokesWidget": "function",
+      },
+    }
+  `)
+})

--- a/plugins/sanity-plugin-dashboard-dad-jokes/src/index.ts
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/src/index.ts
@@ -1,0 +1,1 @@
+export {jokesWidget, type JokesWidgetConfig} from './plugin'

--- a/plugins/sanity-plugin-dashboard-dad-jokes/src/plugin.tsx
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/src/plugin.tsx
@@ -1,0 +1,17 @@
+import type {DashboardWidget, LayoutConfig} from '@sanity/dashboard'
+
+import Jokes from './Jokes'
+
+export interface JokesWidgetConfig {
+  layout?: LayoutConfig
+}
+
+export function jokesWidget(config: JokesWidgetConfig = {}): DashboardWidget {
+  return {
+    name: 'jokes-widget',
+    component: function component() {
+      return <Jokes />
+    },
+    layout: config.layout ?? {width: 'medium'},
+  }
+}

--- a/plugins/sanity-plugin-dashboard-dad-jokes/tsconfig.build.json
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@repo/tsconfig/build.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {
+    "isolatedDeclarations": false
+  }
+}

--- a/plugins/sanity-plugin-dashboard-dad-jokes/tsconfig.json
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/tsconfig/check.json",
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/plugins/sanity-plugin-dashboard-dad-jokes/vitest.config.ts
+++ b/plugins/sanity-plugin-dashboard-dad-jokes/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        inline: ['vitest-package-exports'],
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       sanity-plugin-bynder-input:
         specifier: workspace:*
         version: link:../../plugins/sanity-plugin-bynder-input
+      sanity-plugin-dashboard-dad-jokes:
+        specifier: workspace:*
+        version: link:../../plugins/sanity-plugin-dashboard-dad-jokes
       sanity-plugin-dashboard-widget-document-list:
         specifier: workspace:*
         version: link:../../plugins/sanity-plugin-dashboard-widget-document-list
@@ -1484,6 +1487,43 @@ importers:
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
+
+  plugins/sanity-plugin-dashboard-dad-jokes:
+    dependencies:
+      '@sanity/ui':
+        specifier: 'catalog:'
+        version: 3.2.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.2)
+    devDependencies:
+      '@repo/package.config':
+        specifier: workspace:*
+        version: link:../../packages/@repo/package.config
+      '@repo/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/@repo/tsconfig
+      '@sanity/dashboard':
+        specifier: workspace:*
+        version: link:../@sanity/dashboard
+      '@sanity/pkg-utils':
+        specifier: 'catalog:'
+        version: 10.5.7(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.20.0)(typescript@5.9.3)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      babel-plugin-react-compiler:
+        specifier: 'catalog:'
+        version: 1.0.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      sanity:
+        specifier: ^6.1.0
+        version: 6.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.4)(@sanity/cli-core@2.0.1)(@types/node@24.13.2)(@types/react-dom@19.2.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.8)(jiti@2.7.0)(oxfmt@0.55.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.1.1)(styled-components@6.4.2)(terser@5.48.0)(typescript@5.9.3)
 
   plugins/sanity-plugin-dashboard-widget-document-list:
     dependencies:


### PR DESCRIPTION
Porting the dad jokes dashboard widget into the monorepo, modernized for Sanity
Studio v3+ (dashboard widget API, ESM build, React 19 / React Compiler). Wires
up a test-studio example in the Dashboard workspace and adds the knip, README,
and changeset entries.

### Description

What changes are introduced?
- Adds a new plugin: `plugins/sanity-plugin-dashboard-dad-jokes` — a Dashboard
  widget that fetches a random dad joke from icanhazdadjoke.com and renders it
  with `@sanity/ui`, with a "New joke" button to fetch another.
- Public API: `jokesWidget(config?: JokesWidgetConfig): DashboardWidget`, used
  inside `dashboardTool({ widgets: [jokesWidget()] })`. `JokesWidgetConfig`
  exposes an optional `layout`.
- Follows the existing monorepo conventions (modeled on
  `sanity-plugin-dashboard-widget-document-list`): ESM-only build via
  `@sanity/pkg-utils`, shared `@repo/package.config` + `@repo/tsconfig`,
  `catalog:`/`workspace:*` dependencies, React Compiler enabled.
- Wiring: registers the plugin as a `workspace:*` dependency of `test-studio`,
  adds a `jokesWidgetExample` to the **Dashboard** workspace in
  `dev/test-studio/sanity.config.ts`, and adds the `knip.jsonc` workspace entry,
  the README plugin-table row, and a changeset.

Why are these changes introduced?
- The dad jokes widget previously existed only as a standalone, Studio-v2-era
  example plugin. This brings it into the monorepo and modernizes it for the
  current Studio (v3+), so it builds, tests, lints, and releases like every
  other first-party plugin here.

What issue(s) does this solve? (with link, if possible)
- N/A

### What to review

What steps should the reviewer take in order to review?
- `pnpm install && pnpm build` — confirm the plugin builds (`pkg build --strict
  --check --clean`) and emits `dist/index.js` + `dist/index.d.ts`.
- `pnpm --filter sanity-plugin-dashboard-dad-jokes test` — the package-exports
  snapshot test passes (asserts the `jokesWidget` export).
- `pnpm dev` → open the **Dashboard** workspace and confirm the "A dad joke"
  widget renders, shows a joke, and the "New joke" button fetches another.
- Skim `src/Jokes.tsx`: the effect deliberately avoids synchronous `setState`
  (state starts in the loading state; updates happen only in async callbacks) to
  satisfy the React Compiler `EffectSetState` rule, and the fetch promises are
  explicitly `void`-ed.

What parts/flows of the application/packages/tooling is affected?
- New `plugins/sanity-plugin-dashboard-dad-jokes` workspace.
- `dev/test-studio` (new dependency, example file, and Dashboard workspace entry).
- `knip.jsonc`, root `README.md`, and a new changeset. No existing plugins are
  touched.

### Testing

Did you add sufficient testing for this change?
- Yes — includes the standard `src/index.test.ts` package-exports snapshot test
  (matching the other widget plugins), verifying the built `dist` exposes
  `jokesWidget` as a function. Verified locally: build ✅, vitest 1/1 ✅, oxlint
  clean ✅, oxfmt clean ✅.
- The widget's runtime behavior (network fetch + render) is exercised manually in
  the test-studio Dashboard workspace; there's no automated UI/network test, in
  keeping with the other dashboard-widget plugins in this repo.
