### PR TITLE
docs(cloudinary): fix typos in asset source example comments

### DIFF
--- a/.changeset/cloudinary-readme-typo.md
+++ b/.changeset/cloudinary-readme-typo.md
@@ -1,5 +1,5 @@
 ---
-'sanity-plugin-cloudinary': patch
+"sanity-plugin-cloudinary": patch
 ---
 
 author: @antonio-lopez

--- a/.changeset/cloudinary-readme-typo.md
+++ b/.changeset/cloudinary-readme-typo.md
@@ -1,0 +1,7 @@
+---
+'sanity-plugin-cloudinary': patch
+---
+
+author: @antonio-lopez
+
+Fix typos in README asset source example comments

--- a/plugins/sanity-plugin-cloudinary/README.md
+++ b/plugins/sanity-plugin-cloudinary/README.md
@@ -60,7 +60,7 @@ export default defineConfg({
           // only use cloudinary as an asset source
           return [cloudinaryImageSource]
         }
-        // don't add cloudinary as an asset sources
+        // don't add cloudinary as an asset source
         return previousAssetSources
       },
     },

--- a/plugins/sanity-plugin-cloudinary/README.md
+++ b/plugins/sanity-plugin-cloudinary/README.md
@@ -57,10 +57,10 @@ export default defineConfg({
           return [...previousAssetSources, cloudinaryImageSource]
         }
         if (context.currentUser?.roles.includes('onlyCloudinaryAccess')) {
-          // only use clooudinary as an asset source
+          // only use cloudinary as an asset source
           return [cloudinaryImageSource]
         }
-        // dont add cloudnary as an asset sources
+        // don't add cloudinary as an asset sources
         return previousAssetSources
       },
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports [sanity-io/sanity-plugin-cloudinary#66](https://github.com/sanity-io/sanity-plugin-cloudinary/pull/66) by @antonio-lopez into the monorepo.

## What changed

Fixes three typos in the "Fine tune image sources" example comments in `plugins/sanity-plugin-cloudinary/README.md`:

- `clooudinary` → `cloudinary`
- `dont` → `don't`
- `cloudnary` → `cloudinary`

The diff matches the original PR exactly (2 additions, 2 deletions in code-comment text).

## Attribution

- The commit is authored as **Antonio Lopez** (`@antonio-lopez`), the original PR author.
- The changeset includes an `author: @antonio-lopez` directive so the release notes credit them.

## Changeset

A `patch` changeset is included for `sanity-plugin-cloudinary` (the README ships with the published npm package).

## Verification

- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm changeset status --since=main` (bumps `sanity-plugin-cloudinary` at patch)
- ✅ `pnpm turbo build --filter=sanity-plugin-cloudinary`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd3a2063-ccd3-4fc6-a78c-3507c8d576b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd3a2063-ccd3-4fc6-a78c-3507c8d576b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

