### PR TITLE
fix(form-toolkit): address post-migration review feedback

### DIFF
--- a/.changeset/form-toolkit-review-fixes.md
+++ b/.changeset/form-toolkit-review-fixes.md
@@ -1,0 +1,10 @@
+---
+'@sanity/form-toolkit': patch
+---
+
+Address post-migration review feedback:
+
+- `FormRenderer` now renders interactive (uncontrolled) inputs when no `getFieldState` is provided, so the documented native HTML form usage works out of the box
+- `FormRenderer` falls back to `field.name` for the React key when a field has no `_key`
+- The shared HubSpot/Mailchimp request handler defaults to the Next.js-compatible handler instead of throwing when no framework environment variable is detected, and short-circuits CORS preflight (`OPTIONS`) requests
+- Corrected the `formSchema`, `formiumInput`, and `mailchimpInput` usage examples (import paths and required options), README typos, and example/dev-workflow references

--- a/.changeset/form-toolkit-review-fixes.md
+++ b/.changeset/form-toolkit-review-fixes.md
@@ -5,7 +5,7 @@
 Address post-migration review feedback:
 
 - `FormRenderer` now renders interactive (uncontrolled) inputs when no `getFieldState` is provided, so the documented native HTML form usage works out of the box
-- Uncontrolled text and textarea fields honor `options.defaultValue`
+- Uncontrolled text and textarea fields honor `options.defaultValue` (controlled fields keep form-library state only, so UI and submit values stay in sync)
 - `FormRenderer` falls back to `field.name` for the React key when a field has no `_key`
 - The shared HubSpot/Mailchimp request handler defaults to the Next.js-compatible handler instead of throwing when no framework environment variable is detected, and short-circuits CORS preflight (`OPTIONS`) requests
 - Corrected the `formSchema`, `formiumInput`, and `mailchimpInput` usage examples (import paths and required options), README typos, and example/dev-workflow references

--- a/.changeset/form-toolkit-review-fixes.md
+++ b/.changeset/form-toolkit-review-fixes.md
@@ -1,10 +1,11 @@
 ---
-'@sanity/form-toolkit': patch
+"@sanity/form-toolkit": patch
 ---
 
 Address post-migration review feedback:
 
 - `FormRenderer` now renders interactive (uncontrolled) inputs when no `getFieldState` is provided, so the documented native HTML form usage works out of the box
+- Uncontrolled text and textarea fields honor `options.defaultValue`
 - `FormRenderer` falls back to `field.name` for the React key when a field has no `_key`
 - The shared HubSpot/Mailchimp request handler defaults to the Next.js-compatible handler instead of throwing when no framework environment variable is detected, and short-circuits CORS preflight (`OPTIONS`) requests
 - Corrected the `formSchema`, `formiumInput`, and `mailchimpInput` usage examples (import paths and required options), README typos, and example/dev-workflow references

--- a/plugins/@sanity/form-toolkit/README.md
+++ b/plugins/@sanity/form-toolkit/README.md
@@ -1,5 +1,3 @@
-## Usage
-
 # @sanity/form-toolkit
 
 Plugin for integrating 3rd party form services or building your own forms with Sanity.
@@ -73,7 +71,7 @@ export default defineType({
   title: 'Post',
   type: 'document',
   fields: [
-    //...rest of schma
+    //...rest of schema
     defineField({
       name: 'hubSpot',
       type: 'hubSpotForm',
@@ -147,7 +145,7 @@ export default defineType({
   title: 'Post',
   type: 'document',
   fields: [
-    //...rest of schma
+    //...rest of schema
     defineField({
       name: 'mailchimp',
       type: 'mailchimpForm',
@@ -158,7 +156,7 @@ export default defineType({
 
 ## formSchema and FormRenderer
 
-The `formSchema` plugin and `FormRenderer` React component are designed to be used together to build and render forms in Sanity. `formSchema` provides a Sanity schema for creating `form` documents made up of various `formFields`, then `FormRenderer` takes those `form` documents and renders them as React components. The `formSchema` plugin can be used by itself with your own logic for rendering the form. The `/examples` directory of this repository shows `FormRenderer` being used with popular form libraries.
+The `formSchema` plugin and `FormRenderer` React component are designed to be used together to build and render forms in Sanity. `formSchema` provides a Sanity schema for creating `form` documents made up of various `formFields`, then `FormRenderer` takes those `form` documents and renders them as React components. The `formSchema` plugin can be used by itself with your own logic for rendering the form. The [`examples/form-schema`](examples/form-schema) directory shows `FormRenderer` being used with popular form libraries.
 
 First add `formSchema` it as a plugin in `sanity.config.ts` (or .js):
 
@@ -234,7 +232,7 @@ export const NativeFormExample: FC<NativeFormExampleProps> = ({
 
 ### FormRenderer
 
-The `FormRenderer` component takes documents created with the `formSchema` plugin and renders a form for your front-end. The `formSchema` plugin can be used by itself with your own logic for rendering the form. The `/examples` directory of this repository shows `FormRenderer` being used with popular form libraries. `FormRenderer` takes the following props
+The `FormRenderer` component takes documents created with the `formSchema` plugin and renders a form for your front-end. The `formSchema` plugin can be used by itself with your own logic for rendering the form. The [`examples/form-schema`](examples/form-schema) directory shows `FormRenderer` being used with popular form libraries. `FormRenderer` takes the following props
 
 #### All props for native `form` element
 
@@ -259,27 +257,12 @@ const fieldComponents = {
 
 #### getFieldState
 
-Function for managing each field as a piece of state (see `react-hook-form.tsx` and `tanstack-form.tsx` in the `/examples` directory)
+Function for managing each field as a piece of state (see [`react-hook-form.tsx`](examples/form-schema/react-hook-form.tsx) and [`tanstack-form.tsx`](examples/form-schema/tanstack-form.tsx) in the [`examples/form-schema`](examples/form-schema) directory)
 
 #### getFieldError
 
-Similar to `getFieldState`, a function for managing each field's errors as a piece of state (see `react-hook-form.tsx` and `tanstack-form.tsx` in the `/examples` directory)
+Similar to `getFieldState`, a function for managing each field's errors as a piece of state (see [`react-hook-form.tsx`](examples/form-schema/react-hook-form.tsx) and [`tanstack-form.tsx`](examples/form-schema/tanstack-form.tsx) in the [`examples/form-schema`](examples/form-schema) directory)
 
 ## License
 
 [MIT](LICENSE) © Chris LaRocque
-
-## Develop & test
-
-This plugin uses [@sanity/plugin-kit](https://github.com/sanity-io/plugin-kit)
-with default configuration for build & watch scripts.
-
-See [Testing a plugin in Sanity Studio](https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio)
-on how to run this plugin with hotreload in the studio.
-
-### Release new version
-
-Run ["CI & Release" workflow](https://github.com/sanity-io/form-toolkit/actions/workflows/main.yml).
-Make sure to select the main branch and check "Release new version".
-
-Semantic release will only release on configured branches, so it is safe to run release on any branch.

--- a/plugins/@sanity/form-toolkit/package.json
+++ b/plugins/@sanity/form-toolkit/package.json
@@ -54,11 +54,13 @@
   "devDependencies": {
     "@sanity/tsconfig": "catalog:",
     "@sanity/tsdown-config": "catalog:",
+    "@testing-library/react": "catalog:",
     "@types/mailchimp__mailchimp_marketing": "^3.0.22",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
+    "jsdom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "catalog:",

--- a/plugins/@sanity/form-toolkit/package.json
+++ b/plugins/@sanity/form-toolkit/package.json
@@ -75,11 +75,13 @@
     "@repo/package.config": "workspace:*",
     "@repo/tsconfig": "workspace:*",
     "@sanity/pkg-utils": "catalog:",
+    "@testing-library/react": "^16.3.2",
     "@types/mailchimp__mailchimp_marketing": "^3.0.22",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
+    "jsdom": "^29.0.1",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "catalog:"

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
@@ -53,7 +53,7 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
             onBlur={onBlur}
             placeholder={options.placeholder}
             {...validationRules}
-            {...textValueProps()}
+            {...textValueProps(options.defaultValue)}
           />
         )
 

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
@@ -35,11 +35,11 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
     }
   }
 
-  // Controlled inputs bind `value`/`onChange`; uncontrolled ones use `defaultValue`.
+  // Controlled inputs bind `value`/`onChange` from form state only — never the
+  // schema default, which would desync the UI from what the form library submits.
+  // Uncontrolled (native) inputs use `defaultValue` so the browser owns state.
   const textValueProps = (fallback?: string) =>
-    isControlled
-      ? {value: value ?? fallback ?? '', onChange: handleChange}
-      : {defaultValue: fallback}
+    isControlled ? {value: value ?? '', onChange: handleChange} : {defaultValue: fallback}
 
   const renderInput = () => {
     switch (type) {

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/default-field.tsx
@@ -13,11 +13,15 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
     return acc
   }, {})
   const {value, onChange, onBlur, ref} = fieldState
+  // Without an onChange handler the fields render as uncontrolled inputs, so the
+  // browser keeps them interactive (e.g. the default native-form usage). When a
+  // handler is provided (react-hook-form, TanStack Form, etc.) they're controlled.
+  const isControlled = typeof onChange === 'function'
 
   const handleChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
-    onChange(e.target.value)
+    onChange?.(e.target.value)
   }
 
   const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>, choiceValue: string) => {
@@ -25,11 +29,17 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
       const newValue = e.target.checked
         ? [...value, choiceValue]
         : value.filter((v: string) => v !== choiceValue)
-      onChange(newValue)
+      onChange?.(newValue)
     } else {
-      onChange(e.target.checked ? choiceValue : '')
+      onChange?.(e.target.checked ? choiceValue : '')
     }
   }
+
+  // Controlled inputs bind `value`/`onChange`; uncontrolled ones use `defaultValue`.
+  const textValueProps = (fallback?: string) =>
+    isControlled
+      ? {value: value ?? fallback ?? '', onChange: handleChange}
+      : {defaultValue: fallback}
 
   const renderInput = () => {
     switch (type) {
@@ -40,11 +50,10 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
           <textarea
             ref={toRef<HTMLTextAreaElement>(ref)}
             name={name}
-            onChange={handleChange}
             onBlur={onBlur}
             placeholder={options.placeholder}
             {...validationRules}
-            value={value ?? ''}
+            {...textValueProps()}
           />
         )
 
@@ -53,8 +62,7 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
           <select
             ref={toRef<HTMLSelectElement>(ref)}
             name={name}
-            value={value ?? ''}
-            onChange={handleChange}
+            {...textValueProps()}
             {...validationRules}
             onBlur={onBlur}
           >
@@ -74,10 +82,9 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
               name={name}
               ref={toRef<HTMLInputElement>(ref)}
               value={choice.value}
-              checked={value === choice.value}
-              onChange={handleChange}
               onBlur={onBlur}
               {...validationRules}
+              {...(isControlled ? {checked: value === choice.value, onChange: handleChange} : {})}
             />
             {choice.label}
           </label>
@@ -91,10 +98,17 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
               name={name}
               ref={toRef<HTMLInputElement>(ref)}
               value={choice.value}
-              checked={Array.isArray(value) ? value.includes(choice.value) : value === choice.value}
-              onChange={(e) => handleCheckboxChange(e, choice.value)}
               onBlur={onBlur}
               {...validationRules}
+              {...(isControlled
+                ? {
+                    checked: Array.isArray(value)
+                      ? value.includes(choice.value)
+                      : value === choice.value,
+                    onChange: (e: ChangeEvent<HTMLInputElement>) =>
+                      handleCheckboxChange(e, choice.value),
+                  }
+                : {})}
             />
             {choice.label}
           </label>
@@ -106,8 +120,7 @@ export const DefaultField: FC<FieldComponentProps> = ({field, fieldState, error}
             type={type}
             ref={toRef<HTMLInputElement>(ref)}
             name={name}
-            value={value ?? options.defaultValue ?? ''}
-            onChange={handleChange}
+            {...textValueProps(options.defaultValue)}
             {...validationRules}
             onBlur={onBlur}
             placeholder={options.placeholder}

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
@@ -93,6 +93,48 @@ describe('FormRenderer', () => {
     expect(onChange).toHaveBeenCalledWith('Ada')
   })
 
+  test('controlled fields ignore options.defaultValue when form state is empty', () => {
+    const onChange = vi.fn()
+    const formWithDefaults: FormDataProps = {
+      title: 'Contact',
+      id: {current: 'contact'},
+      fields: [
+        {
+          type: 'text',
+          name: 'firstName',
+          label: 'First name',
+          options: {defaultValue: 'Ada'},
+        },
+        {
+          type: 'textarea',
+          name: 'message',
+          label: 'Message',
+          options: {defaultValue: 'Hello there'},
+        },
+      ],
+    }
+    const getFieldState = (): FieldState => ({
+      value: undefined,
+      onChange,
+    })
+
+    const {container} = render(
+      <FormRenderer formData={formWithDefaults} getFieldState={getFieldState} />,
+    )
+
+    const input = container.querySelector('input[name="firstName"]')
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected a text input for "firstName"')
+    }
+    expect(input.value).toBe('')
+
+    const textarea = container.querySelector('textarea[name="message"]')
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+      throw new Error('Expected a textarea for "message"')
+    }
+    expect(textarea.value).toBe('')
+  })
+
   test('falls back to field.name for the React key when _key is missing', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
@@ -39,6 +39,41 @@ describe('FormRenderer', () => {
     expect(textarea.value).toBe('Hello there')
   })
 
+  test('applies options.defaultValue on uncontrolled text and textarea fields', () => {
+    const formWithDefaults: FormDataProps = {
+      title: 'Contact',
+      id: {current: 'contact'},
+      fields: [
+        {
+          type: 'text',
+          name: 'firstName',
+          label: 'First name',
+          options: {defaultValue: 'Ada'},
+        },
+        {
+          type: 'textarea',
+          name: 'message',
+          label: 'Message',
+          options: {defaultValue: 'Hello there'},
+        },
+      ],
+    }
+
+    const {container} = render(<FormRenderer formData={formWithDefaults} />)
+
+    const input = container.querySelector('input[name="firstName"]')
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected a text input for "firstName"')
+    }
+    expect(input.value).toBe('Ada')
+
+    const textarea = container.querySelector('textarea[name="message"]')
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+      throw new Error('Expected a textarea for "message"')
+    }
+    expect(textarea.value).toBe('Hello there')
+  })
+
   test('supports controlled inputs via getFieldState/onChange', () => {
     const onChange = vi.fn()
     const getFieldState = (fieldName: string): FieldState => ({

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import {cleanup, fireEvent, render} from '@testing-library/react'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {FormRenderer} from './form-renderer'
+import type {FieldState, FormDataProps} from './types'
+
+const formData: FormDataProps = {
+  title: 'Contact',
+  id: {current: 'contact'},
+  fields: [
+    {type: 'text', name: 'firstName', label: 'First name'},
+    {type: 'textarea', name: 'message', label: 'Message'},
+  ],
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('FormRenderer', () => {
+  test('renders interactive (uncontrolled) inputs when no getFieldState is provided', () => {
+    const {container} = render(<FormRenderer formData={formData} />)
+
+    const input = container.querySelector('input[name="firstName"]')
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected a text input for "firstName"')
+    }
+    // The previous default returned a no-op onChange, which locked the controlled
+    // input. As an uncontrolled input the typed value now sticks.
+    fireEvent.change(input, {target: {value: 'Ada'}})
+    expect(input.value).toBe('Ada')
+
+    const textarea = container.querySelector('textarea[name="message"]')
+    if (!(textarea instanceof HTMLTextAreaElement)) {
+      throw new Error('Expected a textarea for "message"')
+    }
+    fireEvent.change(textarea, {target: {value: 'Hello there'}})
+    expect(textarea.value).toBe('Hello there')
+  })
+
+  test('supports controlled inputs via getFieldState/onChange', () => {
+    const onChange = vi.fn()
+    const getFieldState = (fieldName: string): FieldState => ({
+      value: fieldName === 'firstName' ? 'Grace' : '',
+      onChange,
+    })
+
+    const {container} = render(<FormRenderer formData={formData} getFieldState={getFieldState} />)
+
+    const input = container.querySelector('input[name="firstName"]')
+    if (!(input instanceof HTMLInputElement)) {
+      throw new Error('Expected a text input for "firstName"')
+    }
+    expect(input.value).toBe('Grace')
+
+    fireEvent.change(input, {target: {value: 'Ada'}})
+    expect(onChange).toHaveBeenCalledWith('Ada')
+  })
+
+  test('falls back to field.name for the React key when _key is missing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<FormRenderer formData={formData} />)
+
+    const duplicateKeyWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some((arg) => typeof arg === 'string' && arg.includes('same key')),
+    )
+    expect(duplicateKeyWarnings).toEqual([])
+
+    errorSpy.mockRestore()
+  })
+})

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.test.tsx
@@ -98,10 +98,17 @@ describe('FormRenderer', () => {
 
     render(<FormRenderer formData={formData} />)
 
-    const duplicateKeyWarnings = errorSpy.mock.calls.filter((args) =>
-      args.some((arg) => typeof arg === 'string' && arg.includes('same key')),
+    const keyWarnings = errorSpy.mock.calls.filter((args) =>
+      args.some(
+        (arg) =>
+          typeof arg === 'string' &&
+          // React warns differently for missing vs duplicate keys
+          (arg.includes('same key') ||
+            arg.includes('unique "key" prop') ||
+            arg.includes("unique 'key' prop")),
+      ),
     )
-    expect(duplicateKeyWarnings).toEqual([])
+    expect(keyWarnings).toEqual([])
 
     errorSpy.mockRestore()
   })

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.tsx
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/form-renderer.tsx
@@ -13,11 +13,11 @@ interface FormRendererProps extends HTMLProps<HTMLFormElement> {
   fieldComponents?: Record<string, ComponentType<FieldComponentProps>>
 }
 
-const defaultGetFieldState = (name: string) => ({
-  value: undefined,
-  onChange: () => {},
-  name, // Pass name to field for native form handling
-})
+// No field state by default: fields render as uncontrolled, interactive inputs
+// so the form works out of the box (e.g. as a native HTML form). Consumers can
+// pass `getFieldState` to make the fields controlled.
+const EMPTY_FIELD_STATE: FieldState = {}
+const defaultGetFieldState = (): FieldState => EMPTY_FIELD_STATE
 
 const defaultFieldComponents: Record<string, ComponentType<FieldComponentProps>> = {}
 
@@ -49,7 +49,7 @@ export const FormRenderer: FC<FormRendererProps> = (props) => {
   return (
     <form {...elProps} id={elProps.id ?? formData?.id?.current}>
       {formData?.fields?.map((field) => (
-        <div key={field._key} className="form-field">
+        <div key={field._key ?? field.name} className="form-field">
           {renderField(field)}
         </div>
       ))}

--- a/plugins/@sanity/form-toolkit/src/form-renderer/components/types.ts
+++ b/plugins/@sanity/form-toolkit/src/form-renderer/components/types.ts
@@ -39,7 +39,9 @@ export type FormDataProps = {
 
 export interface FieldState {
   value?: string | number | readonly string[]
-  onChange: (value: unknown) => void
+  // Optional: when omitted (e.g. the default native-form usage), fields render
+  // as uncontrolled inputs so the browser manages their state.
+  onChange?: (value: unknown) => void
   onBlur?: () => void
   ref?: unknown
 }

--- a/plugins/@sanity/form-toolkit/src/form-schema/index.ts
+++ b/plugins/@sanity/form-toolkit/src/form-schema/index.ts
@@ -10,7 +10,7 @@ import {schema} from './schema-types'
  *
  * ```ts
  * import {defineConfig} from 'sanity'
- * import {formSchema} from '@sanity/form-toolkit'
+ * import {formSchema} from '@sanity/form-toolkit/form-schema'
  *
  * export default defineConfig({
  *   // ...

--- a/plugins/@sanity/form-toolkit/src/formium/index.ts
+++ b/plugins/@sanity/form-toolkit/src/formium/index.ts
@@ -11,7 +11,7 @@ interface FormiumInputConfig {
  *
  * ```ts
  * import {defineConfig} from 'sanity'
- * import {formiumInput} from 'sanity-plugin-form-toolkit'
+ * import {formiumInput} from '@sanity/form-toolkit/formium'
  *
  * export default defineConfig({
  *   // ...

--- a/plugins/@sanity/form-toolkit/src/mailchimp/index.ts
+++ b/plugins/@sanity/form-toolkit/src/mailchimp/index.ts
@@ -17,7 +17,11 @@ interface MailchimpInputConfig {
  *
  * export default defineConfig({
  *   // ...
- *   plugins: [mailchimpInput()],
+ *   plugins: [
+ *    mailchimpInput({
+ *      url: 'http://localhost:3000/api/mailchimp'
+ *    })
+ *   ],
  * })
  * ```
  */

--- a/plugins/@sanity/form-toolkit/src/shared/create-handler.ts
+++ b/plugins/@sanity/form-toolkit/src/shared/create-handler.ts
@@ -15,7 +15,10 @@ const detectFramework = (): string => {
   } else if (process.env['ASTRO_ENV']) {
     return 'astro'
   }
-  throw new Error('Unable to detect framework.')
+  // Default to the Next.js-compatible handler. The framework env vars above
+  // aren't always set (e.g. Next.js API routes where NEXT_RUNTIME is absent),
+  // and throwing here would break the most common setup.
+  return 'nextjs'
 }
 
 // Create a generic handler with predefined logic
@@ -64,6 +67,13 @@ const createHandler = (handlerFunc: () => Promise<unknown>) => {
       res.setHeader('Access-Control-Allow-Origin', '*') // Allow all origins
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS') // Allowed HTTP methods
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization') // Allowed headers
+
+      // Short-circuit CORS preflight requests so we don't hit the upstream API
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204)
+        res.end()
+        return
+      }
 
       await handlerLogic({req, res})
     }

--- a/plugins/@sanity/form-toolkit/vitest.config.ts
+++ b/plugins/@sanity/form-toolkit/vitest.config.ts
@@ -2,6 +2,9 @@ import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
+    // Component tests opt into jsdom per-file via `// @vitest-environment jsdom`.
+    // The default stays `node` so the package-exports test keeps resolving `sanity`
+    // the same way it does in the published environment.
     server: {
       deps: {
         inline: ['vitest-package-exports'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,7 +245,7 @@ importers:
         version: 6.29.0
       vercel:
         specifier: ^56.5.0
-        version: 56.5.0
+        version: 56.5.0(supports-color@8.1.1)
 
   dev/e2e-studio:
     dependencies:
@@ -260,7 +260,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       sanity:
         specifier: ^6.7.0
-        version: 6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(terser@5.49.0)(typescript@7.0.2)
+        version: 6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)
       sanity-plugin-internationalized-array:
         specifier: workspace:*
         version: link:../../plugins/sanity-plugin-internationalized-array
@@ -530,7 +530,7 @@ importers:
     devDependencies:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(typescript@7.0.2)
+        version: 11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(supports-color@8.1.1)(typescript@7.0.2)
       '@sanity/tsconfig':
         specifier: 'catalog:'
         version: 2.2.1
@@ -1160,6 +1160,9 @@ importers:
       '@sanity/tsdown-config':
         specifier: 'catalog:'
         version: 0.21.2(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.14)(typescript@7.0.2)(vite@8.1.5)
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)
       '@types/mailchimp__mailchimp_marketing':
         specifier: ^3.0.22
         version: 3.0.22
@@ -1175,6 +1178,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -2842,7 +2848,7 @@ importers:
         version: 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       axios:
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(supports-color@8.1.1)
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -12098,7 +12104,7 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
@@ -12634,7 +12640,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
@@ -12703,7 +12709,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
@@ -14991,7 +14997,100 @@ snapshots:
       - vue-tsc
       - yaml
 
+  '@sanity/cli-build@5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
+      chokidar: 5.0.0
+      cjs-module-lexer: 2.2.0
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      lodash-es: 4.18.1
+      node-html-parser: 7.1.0
+      oneline: 2.0.0
+      picomatch: 4.0.5
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      semver: 7.8.5
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
+
   '@sanity/cli-core@2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
+      '@oclif/core': 4.13.0
+      '@sanity/client': 7.25.0
+      boxen: 8.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      get-it: 8.8.0
+      get-tsconfig: 4.14.0
+      import-meta-resolve: 4.2.0
+      jiti: 2.7.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+      json-lexer: 1.2.0
+      log-symbols: 7.0.1
+      ora: 9.4.1
+      rxjs: 7.8.2
+      tsx: 4.23.1
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 6.0.0(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - canvas
+      - esbuild
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - yaml
+
+  '@sanity/cli-core@2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@oclif/core': 4.13.0
@@ -15039,10 +15138,10 @@ snapshots:
       '@sanity/client': 7.25.0
       '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)
       '@sanity/descriptors': 1.3.0
-      '@sanity/export': 6.2.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
       '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       '@sanity/schema': 6.7.0(@types/react@19.2.17)
@@ -15050,6 +15149,206 @@ snapshots:
       '@sanity/template-validator': 3.1.0
       '@sanity/types': 6.7.0(@types/react@19.2.17)
       '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/worker-channels': 2.0.0
+      '@vercel/frameworks': 3.29.0
+      chokidar: 5.0.0
+      console-table-printer: 2.16.1
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      eventsource: 4.1.0
+      execa: 9.6.1
+      form-data: 4.0.6
+      get-latest-version: 6.0.1
+      groq-js: 1.30.3
+      gunzip-maybe: 1.4.2
+      import-meta-resolve: 4.2.0
+      is-installed-globally: 1.0.0
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      lodash-es: 4.18.1
+      minimist: 1.2.8
+      nanoid: 5.1.16
+      oneline: 2.0.0
+      open: 11.0.0
+      p-map: 7.0.6
+      package-directory: 8.2.0
+      peek-stream: 1.1.3
+      picomatch: 4.0.5
+      pluralize-esm: 9.0.5
+      pretty-ms: 9.3.0
+      promise-props-recursive: 2.0.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      rxjs: 7.8.2
+      semver: 7.8.5
+      skills: 1.5.20
+      smol-toml: 1.7.1
+      tar: 7.5.22
+      tar-fs: 3.1.3
+      tar-stream: 3.2.0
+      tinyglobby: 0.2.17
+      tsx: 4.23.1
+      typeid-js: 1.2.0
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      which: 6.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - xstate
+
+  '@sanity/cli@7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@oclif/plugin-help': 6.2.55
+      '@oclif/plugin-not-found': 3.2.90(@types/node@24.13.3)
+      '@sanity/cli-build': 5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.25.0
+      '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)(supports-color@8.1.1)
+      '@sanity/descriptors': 1.3.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/template-validator': 3.1.0
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/worker-channels': 2.0.0
+      '@vercel/frameworks': 3.29.0
+      chokidar: 5.0.0
+      console-table-printer: 2.16.1
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      eventsource: 4.1.0
+      execa: 9.6.1
+      form-data: 4.0.6
+      get-latest-version: 6.0.1
+      groq-js: 1.30.3
+      gunzip-maybe: 1.4.2
+      import-meta-resolve: 4.2.0
+      is-installed-globally: 1.0.0
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      lodash-es: 4.18.1
+      minimist: 1.2.8
+      nanoid: 5.1.16
+      oneline: 2.0.0
+      open: 11.0.0
+      p-map: 7.0.6
+      package-directory: 8.2.0
+      peek-stream: 1.1.3
+      picomatch: 4.0.5
+      pluralize-esm: 9.0.5
+      pretty-ms: 9.3.0
+      promise-props-recursive: 2.0.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      rxjs: 7.8.2
+      semver: 7.8.5
+      skills: 1.5.20
+      smol-toml: 1.7.1
+      tar: 7.5.22
+      tar-fs: 3.1.3
+      tar-stream: 3.2.0
+      tinyglobby: 0.2.17
+      tsx: 4.23.1
+      typeid-js: 1.2.0
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      which: 6.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - xstate
+
+  '@sanity/cli@7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@oclif/plugin-help': 6.2.55
+      '@oclif/plugin-not-found': 3.2.90(@types/node@24.13.3)
+      '@sanity/cli-build': 5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.25.0
+      '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)
+      '@sanity/descriptors': 1.3.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/template-validator': 3.1.0
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.29.0
       chokidar: 5.0.0
@@ -15140,7 +15439,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/register': 7.29.7(@babel/core@7.29.7)
@@ -15148,6 +15447,37 @@ snapshots:
       '@babel/types': 7.29.7
       '@oclif/core': 4.13.0
       '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/worker-channels': 2.0.0
+      chokidar: 3.6.0
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      groq: 6.7.0
+      groq-js: 1.30.3
+      json5: 2.2.3
+      lodash-es: 4.18.1
+      prettier: 3.9.6
+      reselect: 5.2.0
+      tsconfig-paths: 4.2.0
+      zod: 4.4.3
+    optionalDependencies:
+      oxfmt: 0.61.0
+    transitivePeerDependencies:
+      - react
+      - supports-color
+
+  '@sanity/codegen@7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@oclif/core': 4.13.0
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
       '@sanity/worker-channels': 2.0.0
       chokidar: 3.6.0
@@ -15200,7 +15530,7 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
-  '@sanity/export@6.2.0':
+  '@sanity/export@6.2.0(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.8.0
@@ -15230,7 +15560,7 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.4
 
-  '@sanity/import@6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)':
+  '@sanity/import@6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
       '@sanity/client': 7.25.0
@@ -15318,7 +15648,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@sanity/pkg-utils@11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(typescript@7.0.2)':
+  '@sanity/pkg-utils@11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
@@ -15356,7 +15686,7 @@ snapshots:
       rolldown: 1.2.0
       rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.0)(typescript@7.0.2)
       rollup: 4.62.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@8.1.1)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.23.1
@@ -15657,6 +15987,41 @@ snapshots:
     dependencies:
       '@module-federation/vite': 1.18.1(typescript@7.0.2)(vite@8.1.5)
       '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
+      form-data: 4.0.6
+      tar-fs: 3.1.3
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.9)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
+
+  '@sanity/workbench-cli@1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@module-federation/vite': 1.18.1(typescript@7.0.2)(vite@8.1.5)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
       '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
       form-data: 4.0.6
       tar-fs: 3.1.3
@@ -16497,7 +16862,7 @@ snapshots:
       global: 4.4.0
       pkcs7: 1.0.4
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -16619,11 +16984,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1:
+  axios@1.18.1(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -16637,11 +17002,11 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -16649,7 +17014,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -16657,7 +17022,7 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17987,9 +18352,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -19722,7 +20087,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -19810,7 +20175,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.4.0:
+  sandbox@3.4.0(supports-color@8.1.1):
     dependencies:
       '@vercel/sandbox': 2.4.0
       async-retry: 1.3.3
@@ -19997,7 +20362,153 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.8)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.9)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/client': 7.25.0
+      '@sanity/color': 3.0.8
+      '@sanity/comlink': 4.0.1
+      '@sanity/diff': 6.7.0
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/diff-patch': 5.0.0
+      '@sanity/eventsource': 5.0.4
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      '@sanity/id-utils': 1.0.0
+      '@sanity/image-url': 2.1.1
+      '@sanity/logos': 2.2.5(react@19.2.8)
+      '@sanity/media-library-types': 1.6.0
+      '@sanity/message-protocol': 0.24.0
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/mutate': 0.18.1(xstate@5.32.5)
+      '@sanity/mutator': 6.7.0(@types/react@19.2.17)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.25.0)(@sanity/types@6.7.0)
+      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.25.0)
+      '@sanity/prism-groq': 1.1.2
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/ui': 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
+      '@sanity/util': 6.7.0(@types/react@19.2.17)
+      '@sanity/uuid': 3.0.3
+      '@sanity/workbench': 0.1.0-alpha.30(@sanity/sdk@2.18.0)(react@19.2.8)(xstate@5.32.5)
+      '@sentry/react': 10.68.0(react@19.2.8)
+      '@tanstack/react-table': 8.21.3(react-dom@19.2.8)(react@19.2.8)
+      '@tanstack/react-virtual': 3.14.8(react-dom@19.2.8)(react@19.2.8)
+      '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5)
+      clsx: 2.1.1
+      color2k: 2.0.4
+      dataloader: 2.2.3
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      groq-js: 2.0.0
+      history: 5.3.0
+      i18next: 26.3.6(typescript@7.0.2)
+      is-hotkey-esm: 1.0.0
+      is-network-error: 1.3.2
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json-reduce: 3.0.0
+      json-stable-stringify: 1.3.0
+      lodash-es: 4.18.1
+      mendoza: 3.0.8
+      motion: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)
+      nano-pubsub: 3.0.0
+      nanoid: 6.0.0
+      observable-callback: 1.0.3(rxjs@7.8.2)
+      path-to-regexp: 8.4.2
+      player.style: 0.3.4(react@19.2.8)
+      polished: 4.3.1
+      quick-lru: 7.3.0
+      raf: 3.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.7(@types/react@19.2.17)(react@19.2.8)
+      react-i18next: 17.0.11(i18next@26.3.6)(react-dom@19.2.8)(react@19.2.8)(typescript@7.0.2)
+      react-is: 19.2.8
+      react-refractor: 4.0.0(react@19.2.8)
+      react-rx: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+      refractor: 5.0.0
+      rxjs: 7.8.2
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
+      scroll-into-view-if-needed: 3.1.0
+      scrollmirror: 1.2.4
+      semver: 7.8.5
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
+      swr: 2.4.2(react@19.2.8)
+      urlpattern-polyfill: 10.1.0
+      use-device-pixel-ratio: 1.1.2(react@19.2.8)
+      use-hot-module-reload: 2.0.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      uuid: 14.0.1
+      web-vitals: 6.0.1
+      xstate: 5.32.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@emotion/is-prop-valid'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@sanity/sdk'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - prismjs
+      - react-native
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  sanity@6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2):
+    dependencies:
+      '@algorithm.ts/lcs': 4.0.6
+      '@date-fns/tz': 1.5.0
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8)(react@19.2.8)
+      '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1)(react@19.2.8)
+      '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1)(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      '@isaacs/ttlcache': 2.1.5
+      '@mux/mux-player-react': 3.13.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)
+      '@portabletext/editor': 7.10.13(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/html': 1.1.1
+      '@portabletext/patches': 2.0.5
+      '@portabletext/plugin-dnd': 1.0.25(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-list-index': 1.0.25(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-markdown-shortcuts': 8.0.41(@portabletext/editor@7.10.13)(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/plugin-one-line': 7.0.40(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-paste-link': 4.0.40(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-table': 1.3.10(@portabletext/editor@7.10.13)(react-dom@19.2.8)(react@19.2.8)
+      '@portabletext/plugin-typography': 8.0.41(@portabletext/editor@7.10.13)(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/react': 7.0.1(react@19.2.8)
+      '@portabletext/sanity-bridge': 3.2.3(@types/react@19.2.17)
+      '@portabletext/to-html': 5.0.2
+      '@portabletext/toolkit': 5.0.2
+      '@rexxars/react-json-inspector': 9.0.1(react@19.2.8)
+      '@sanity/asset-utils': 2.3.0
+      '@sanity/bifur-client': 1.0.0
+      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
       '@sanity/client': 7.25.0
       '@sanity/color': 3.0.8
       '@sanity/comlink': 4.0.1
@@ -20796,7 +21307,7 @@ snapshots:
 
   validate-npm-package-name@8.0.0: {}
 
-  vercel@56.5.0:
+  vercel@56.5.0(supports-color@8.1.1):
     dependencies:
       '@vercel/blob': 2.4.0
       '@vercel/build-utils': 13.34.0
@@ -20810,7 +21321,7 @@ snapshots:
       jose: 5.9.6
       jsonc-parser: 3.3.1
       luxon: 3.7.2
-      sandbox: 3.4.0
+      sandbox: 3.4.0(supports-color@8.1.1)
       smol-toml: 1.5.2
       undici: 5.29.0
       zod: 4.1.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -951,6 +951,9 @@ importers:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
         version: 10.5.7(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.20.0)(typescript@5.9.3)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
       '@types/mailchimp__mailchimp_marketing':
         specifier: ^3.0.22
         version: 3.0.22
@@ -966,6 +969,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the `@sanity/form-toolkit` migration (#972), addressing the [Copilot review](https://github.com/sanity-io/plugins/pull/972#pullrequestreview-4506560913). That PR is already merged, so these fixes land in a new PR on top of `main`.

Rebased onto latest `main` (post-`tsdown` / catalog packaging migration) and addressed the Cursor Bugbot finding on textarea `defaultValue`.

## Code fixes

- **`FormRenderer` fields are interactive by default.** The default field state supplied a no-op `onChange`, which made `DefaultField` render *controlled* inputs locked to an empty value — so the documented native HTML form usage produced a non-interactive form. Fields now render as **uncontrolled** inputs (browser-managed) when no `getFieldState` is provided, and remain controlled when a form library (react-hook-form, TanStack Form, …) supplies a handler. `FieldState.onChange` is now optional.
- **Uncontrolled `defaultValue` for text + textarea.** `textValueProps(options.defaultValue)` is used for both the default text input and `textarea` paths (Bugbot caught the textarea omission).
- **Stable React keys.** `FormRenderer` falls back to `field.name` when a field has no `_key`, avoiding `key={undefined}` collisions.
- **Request handler robustness** (`shared/create-handler.ts`): `detectFramework()` now defaults to the Next.js-compatible handler instead of throwing when no framework env var is set (e.g. Next.js API routes where `NEXT_RUNTIME` is absent), and the Next.js handler short-circuits CORS preflight (`OPTIONS`) requests instead of forwarding them upstream.

## Docs fixes

- `formSchema` usage now imports from `@sanity/form-toolkit/form-schema` (the package has no root export).
- `formiumInput` usage imports from `@sanity/form-toolkit/formium` (was the old `sanity-plugin-form-toolkit` name).
- `mailchimpInput` usage passes the required `url` option.
- README: fixed the `schma` typos, pointed the `/examples` references at the in-repo [`examples/form-schema`](https://github.com/sanity-io/plugins/tree/main/plugins/%40sanity/form-toolkit/examples/form-schema) directory (with direct links to `react-hook-form.tsx` / `tanstack-form.tsx`), removed the stray top-of-file `## Usage` heading, and dropped the stale `## Develop & test` / `### Release new version` sections that referenced the standalone repo's `@sanity/plugin-kit` workflow.

## Testing

Added a jsdom component test (`form-renderer.test.tsx`) that renders the real `FormRenderer` and asserts default fields are interactive, controlled mode still works, `options.defaultValue` applies to text + textarea, and no duplicate-key warnings occur.

- ✅ `pnpm format` / `oxfmt`
- ✅ `oxlint --deny-warnings` on the package
- ✅ `pnpm --filter @sanity/form-toolkit build` (`tsdown`)
- ✅ `pnpm exec vitest run plugins/@sanity/form-toolkit` (5 tests)

A patch changeset for `@sanity/form-toolkit` is included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c4be3df-5f55-4558-a919-d22517f7c0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4be3df-5f55-4558-a919-d22517f7c0ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

