### PR TITLE
fix(cloudinary): address PR #970 review feedback

### DIFF
--- a/.changeset/cloudinary-review-fixes.md
+++ b/.changeset/cloudinary-review-fixes.md
@@ -1,0 +1,9 @@
+---
+'sanity-plugin-cloudinary': patch
+---
+
+- Fix the `cloudinaryAssetSourcePlugin` name, which was mistakenly registered as `cloudinart-asset-source`
+- Wait for the Cloudinary Media Library script to finish loading before opening it, avoiding runtime errors when several inputs mount at once
+- Fix a user-facing typo in the asset source loading message ("Media Libary" → "Media Library")
+- Remove an invalid `src`-less `<track>` element from the video preview
+- Correct the README usage examples (`defineConfg` → `defineConfig`) and drop stale standalone-repo "Develop & test" / "Release new version" instructions

--- a/plugins/sanity-plugin-cloudinary/README.md
+++ b/plugins/sanity-plugin-cloudinary/README.md
@@ -33,10 +33,10 @@ Also see notes below on how Cloudinary config should be provided.
 ### Add Cloudinary as an asset source to all images
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinaryAssetSourcePlugin} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   plugins: [cloudinaryAssetSourcePlugin()],
 })
@@ -45,10 +45,10 @@ export default defineConfg({
 ### Fine tune image sources
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinaryImageSource} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   form: {
     image: {
@@ -72,10 +72,10 @@ export default defineConfg({
 ## Cloudinary assets
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinarySchemaPlugin} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   plugins: [cloudinarySchemaPlugin()],
 })
@@ -255,18 +255,3 @@ Video assets gets a video player preview in the Studio
 ## License
 
 MIT-licensed. See LICENSE.
-
-## Develop & test
-
-This plugin uses [@sanity/plugin-kit](https://github.com/sanity-io/plugin-kit)
-with default configuration for build & watch scripts.
-
-See [Testing a plugin in Sanity Studio](https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio)
-on how to run this plugin with hotreload in the studio.
-
-### Release new version
-
-Run ["CI & Release" workflow](https://github.com/sanity-io/sanity-plugin-cloudinary/actions/workflows/main.yml).
-Make sure to select the main branch and check "Release new version".
-
-Semantic release will only release on configured branches, so it is safe to run release on any branch.

--- a/plugins/sanity-plugin-cloudinary/README.md
+++ b/plugins/sanity-plugin-cloudinary/README.md
@@ -32,10 +32,10 @@ Also see notes below on how Cloudinary config should be provided.
 ### Add Cloudinary as an asset source to all images
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinaryAssetSourcePlugin} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   plugins: [cloudinaryAssetSourcePlugin()],
 })
@@ -44,10 +44,10 @@ export default defineConfg({
 ### Fine tune image sources
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinaryImageSource} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   form: {
     image: {
@@ -57,10 +57,10 @@ export default defineConfg({
           return [...previousAssetSources, cloudinaryImageSource]
         }
         if (context.currentUser?.roles.includes('onlyCloudinaryAccess')) {
-          // only use clooudinary as an asset source
+          // only use cloudinary as an asset source
           return [cloudinaryImageSource]
         }
-        // dont add cloudnary as an asset sources
+        // don't add cloudinary as an asset source
         return previousAssetSources
       },
     },
@@ -71,10 +71,10 @@ export default defineConfg({
 ## Cloudinary assets
 
 ```js
-import {defineConfg} from 'sanity'
+import {defineConfig} from 'sanity'
 import {cloudinarySchemaPlugin} from 'sanity-plugin-cloudinary'
 
-export default defineConfg({
+export default defineConfig({
   /*...*/
   plugins: [cloudinarySchemaPlugin()],
 })
@@ -218,18 +218,3 @@ Video assets gets a video player preview in the Studio
 ## License
 
 MIT-licensed. See LICENSE.
-
-## Develop & test
-
-This plugin uses [@sanity/plugin-kit](https://github.com/sanity-io/plugin-kit)
-with default configuration for build & watch scripts.
-
-See [Testing a plugin in Sanity Studio](https://github.com/sanity-io/plugin-kit#testing-a-plugin-in-sanity-studio)
-on how to run this plugin with hotreload in the studio.
-
-### Release new version
-
-Run ["CI & Release" workflow](https://github.com/sanity-io/sanity-plugin-cloudinary/actions/workflows/main.yml).
-Make sure to select the main branch and check "Release new version".
-
-Semantic release will only release on configured branches, so it is safe to run release on any branch.

--- a/plugins/sanity-plugin-cloudinary/package.json
+++ b/plugins/sanity-plugin-cloudinary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-plugin-cloudinary",
   "version": "2.0.16",
-  "description": "Cloudinary integration for Sanity Studio V3.",
+  "description": "Cloudinary integration for Sanity Studio.",
   "keywords": [
     "sanity",
     "sanity-plugin"

--- a/plugins/sanity-plugin-cloudinary/package.json
+++ b/plugins/sanity-plugin-cloudinary/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-plugin-cloudinary",
   "version": "2.0.0",
-  "description": "Cloudinary integration for Sanity Studio V3.",
+  "description": "Cloudinary integration for Sanity Studio.",
   "keywords": [
     "sanity",
     "sanity-plugin"

--- a/plugins/sanity-plugin-cloudinary/src/components/VideoPlayer.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/VideoPlayer.tsx
@@ -16,9 +16,11 @@ export default function VideoPlayer(props: VideoPlayerProps) {
   }
 
   return (
+    // Cloudinary videos are user-uploaded and have no caption files to point a
+    // `<track>` at; a `src`-less `<track>` would be invalid HTML, so omit it.
+    // eslint-disable-next-line jsx-a11y/media-has-caption -- no captions available for arbitrary Cloudinary videos
     <video controls aria-label="Cloudinary video preview" style={style}>
       <source src={src} type="video/mp4" />
-      <track kind="captions" />
     </video>
   )
 }

--- a/plugins/sanity-plugin-cloudinary/src/components/asset-source/CloudinaryAssetSource.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/asset-source/CloudinaryAssetSource.tsx
@@ -17,21 +17,21 @@ export function CloudinaryAssetSource(props: AssetSourceComponentProps) {
   const {onClose, dialogHeaderTitle} = props
 
   const [loadingMessage, setLoadingMessage] = useState<string | undefined>(
-    'Loading Cloudinary Media Libary',
+    'Loading Cloudinary Media Library',
   )
   const library = useRef<CloudinaryMediaLibrary | undefined>(undefined)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const {secrets} = useSecrets<Secrets>(namespace)
   const cloudName = secrets?.cloudName
   const apiKey = secrets?.apiKey
-  const [widgetId] = useState(() => `cloundinaryWidget-${Date.now()}`)
+  const [widgetId] = useState(() => `cloudinaryWidget-${Date.now()}`)
   const [showSettings, setShowSettings] = useState(false)
 
   const propsRef = useRef(props)
 
   useEffect(() => {
     // because we have to access props after loading js in a callback,
-    // we cannot pass props as dependecnies as that will cause infinite updates
+    // we cannot pass props as dependencies as that will cause infinite updates
     // this takes a snapshot of props, so we can access them later
     propsRef.current = props
   }, [props])

--- a/plugins/sanity-plugin-cloudinary/src/index.ts
+++ b/plugins/sanity-plugin-cloudinary/src/index.ts
@@ -56,7 +56,7 @@ export const cloudinaryImageSource: AssetSource = {
 }
 
 export const cloudinaryAssetSourcePlugin = definePlugin({
-  name: 'cloudinart-asset-source',
+  name: 'cloudinary-asset-source',
   form: {
     image: {
       assetSources: [cloudinaryImageSource],

--- a/plugins/sanity-plugin-cloudinary/src/types.ts
+++ b/plugins/sanity-plugin-cloudinary/src/types.ts
@@ -71,7 +71,8 @@ export type AssetDocument = {
 
 declare global {
   interface Window {
-    cloudinary: {
+    // Only defined after the Cloudinary Media Library widget script has loaded.
+    cloudinary?: {
       openMediaLibrary: (config: any, callbacks: any) => void
       createMediaLibrary: (config: any, callbacks?: any) => CloudinaryMediaLibrary
     }

--- a/plugins/sanity-plugin-cloudinary/src/types.ts
+++ b/plugins/sanity-plugin-cloudinary/src/types.ts
@@ -63,7 +63,8 @@ export type AssetDocument = {
 
 declare global {
   interface Window {
-    cloudinary: {
+    // Only defined after the Cloudinary Media Library widget script has loaded.
+    cloudinary?: {
       openMediaLibrary: (config: any, callbacks: any) => void
       createMediaLibrary: (config: any, callbacks?: any) => CloudinaryMediaLibrary
     }

--- a/plugins/sanity-plugin-cloudinary/src/utils.ts
+++ b/plugins/sanity-plugin-cloudinary/src/utils.ts
@@ -167,10 +167,15 @@ function loadJS(url: string, callback: (cloudinary: NonNullable<Window['cloudina
     return
   }
 
+  // Guard against double-invocation if load fires in the same tick as the
+  // post-listener readiness re-check below.
+  let settled = false
   const handleLoad = () => {
-    if (window.cloudinary) {
-      callback(window.cloudinary)
+    if (settled || !window.cloudinary) {
+      return
     }
+    settled = true
+    callback(window.cloudinary)
   }
 
   const existingScript = document.getElementById('damWidget')
@@ -179,6 +184,10 @@ function loadJS(url: string, callback: (cloudinary: NonNullable<Window['cloudina
     // loading yet (the global isn't ready). Wait for the load event instead
     // of invoking the callback too early.
     existingScript.addEventListener('load', handleLoad, {once: true})
+    // Re-check immediately: the load event may have fired between the initial
+    // `window.cloudinary` check and registering this listener, in which case
+    // the event will never fire again and the callback would otherwise hang.
+    handleLoad()
     return
   }
 

--- a/plugins/sanity-plugin-cloudinary/src/utils.ts
+++ b/plugins/sanity-plugin-cloudinary/src/utils.ts
@@ -97,7 +97,7 @@ export const openMediaSelector = (
   showHandler?: (params: ShowHandlerParams) => void,
   folder?: {resource_type?: 'image' | 'video'; path?: string},
 ) => {
-  loadJS(widgetSrc, () => {
+  loadJS(widgetSrc, (cloudinary) => {
     const options: Record<string, any> = {
       cloud_name: cloudName,
       api_key: apiKey,
@@ -129,7 +129,7 @@ export const openMediaSelector = (
       callbacks.showHandler = showHandler
     }
 
-    window.cloudinary.openMediaLibrary(options, callbacks)
+    cloudinary.openMediaLibrary(options, callbacks)
   })
 }
 
@@ -146,7 +146,7 @@ export const createMediaLibrary = ({
   libraryCreated: (library: CloudinaryMediaLibrary) => void
   insertHandler: (params: InsertHandlerParams) => void
 }) => {
-  loadJS(widgetSrc, () => {
+  loadJS(widgetSrc, (cloudinary) => {
     const options: Record<string, any> = {
       cloud_name: cloudName,
       api_key: apiKey,
@@ -155,25 +155,38 @@ export const createMediaLibrary = ({
       remove_header: true,
     }
 
-    libraryCreated(window.cloudinary.createMediaLibrary(options, {insertHandler}))
+    libraryCreated(cloudinary.createMediaLibrary(options, {insertHandler}))
   })
 }
 
-function loadJS(url: string, callback: () => void) {
+function loadJS(url: string, callback: (cloudinary: NonNullable<Window['cloudinary']>) => void) {
+  // The widget exposes `window.cloudinary` only once the script has finished
+  // loading. When it's already available, run the callback right away.
+  if (window.cloudinary) {
+    callback(window.cloudinary)
+    return
+  }
+
+  const handleLoad = () => {
+    if (window.cloudinary) {
+      callback(window.cloudinary)
+    }
+  }
+
   const existingScript = document.getElementById('damWidget')
-  if (!existingScript) {
-    const script = document.createElement('script')
-    script.src = url
-    script.id = 'damWidget'
-    document.body.appendChild(script)
-    script.addEventListener('load', () => {
-      callback()
-    })
+  if (existingScript) {
+    // Another input already injected the script, but it hasn't finished
+    // loading yet (the global isn't ready). Wait for the load event instead
+    // of invoking the callback too early.
+    existingScript.addEventListener('load', handleLoad, {once: true})
+    return
   }
-  if (existingScript && callback) {
-    return callback()
-  }
-  return true
+
+  const script = document.createElement('script')
+  script.src = url
+  script.id = 'damWidget'
+  script.addEventListener('load', handleLoad, {once: true})
+  document.body.appendChild(script)
 }
 
 export function encodeSourceId(asset: CloudinaryAssetResponse): string {

--- a/plugins/sanity-plugin-cloudinary/src/utils.ts
+++ b/plugins/sanity-plugin-cloudinary/src/utils.ts
@@ -28,7 +28,7 @@ export const openMediaSelector = (
   insertHandler: (params: InsertHandlerParams) => void,
   selectedAsset?: CloudinaryAsset,
 ) => {
-  loadJS(widgetSrc, () => {
+  loadJS(widgetSrc, (cloudinary) => {
     const options: Record<string, any> = {
       cloud_name: cloudName,
       api_key: apiKey,
@@ -44,7 +44,7 @@ export const openMediaSelector = (
       }
     }
 
-    window.cloudinary.openMediaLibrary(options, {insertHandler})
+    cloudinary.openMediaLibrary(options, {insertHandler})
   })
 }
 
@@ -61,7 +61,7 @@ export const createMediaLibrary = ({
   libraryCreated: (library: CloudinaryMediaLibrary) => void
   insertHandler: (params: InsertHandlerParams) => void
 }) => {
-  loadJS(widgetSrc, () => {
+  loadJS(widgetSrc, (cloudinary) => {
     const options: Record<string, any> = {
       cloud_name: cloudName,
       api_key: apiKey,
@@ -70,25 +70,38 @@ export const createMediaLibrary = ({
       remove_header: true,
     }
 
-    libraryCreated(window.cloudinary.createMediaLibrary(options, {insertHandler}))
+    libraryCreated(cloudinary.createMediaLibrary(options, {insertHandler}))
   })
 }
 
-function loadJS(url: string, callback: () => void) {
+function loadJS(url: string, callback: (cloudinary: NonNullable<Window['cloudinary']>) => void) {
+  // The widget exposes `window.cloudinary` only once the script has finished
+  // loading. When it's already available, run the callback right away.
+  if (window.cloudinary) {
+    callback(window.cloudinary)
+    return
+  }
+
+  const handleLoad = () => {
+    if (window.cloudinary) {
+      callback(window.cloudinary)
+    }
+  }
+
   const existingScript = document.getElementById('damWidget')
-  if (!existingScript) {
-    const script = document.createElement('script')
-    script.src = url
-    script.id = 'damWidget'
-    document.body.appendChild(script)
-    script.addEventListener('load', () => {
-      callback()
-    })
+  if (existingScript) {
+    // Another input already injected the script, but it hasn't finished
+    // loading yet (the global isn't ready). Wait for the load event instead
+    // of invoking the callback too early.
+    existingScript.addEventListener('load', handleLoad, {once: true})
+    return
   }
-  if (existingScript && callback) {
-    return callback()
-  }
-  return true
+
+  const script = document.createElement('script')
+  script.src = url
+  script.id = 'damWidget'
+  script.addEventListener('load', handleLoad, {once: true})
+  document.body.appendChild(script)
 }
 
 export function encodeSourceId(asset: CloudinaryAssetResponse): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the Copilot review on [#970](https://github.com/sanity-io/plugins/pull/970#pullrequestreview-4506540788) for the migrated `sanity-plugin-cloudinary`.

## Changes

Behavioral / correctness fixes:

- **Plugin name typo** — `cloudinaryAssetSourcePlugin` was registered as `cloudinart-asset-source`; renamed to `cloudinary-asset-source` (matches the package and `cloudinaryImageSource`).
- **Media Library load race** — `loadJS` previously invoked its callback immediately whenever a `#damWidget` script tag already existed, even if that script was still loading, which could call `window.cloudinary.*` before the global existed. It now runs the callback only when the global is ready, otherwise waits for the script's `load` event. `window.cloudinary` is now typed as optional (it only exists after the widget loads) and the loaded global is passed into the callback.
- **Invalid video `<track>`** — removed the `src`-less `<track kind="captions">` (invalid HTML / console warnings). Cloudinary videos are user-uploaded with no caption files, so `jsx-a11y/media-has-caption` is disabled inline with an explanation.

Docs / user-facing copy:

- Fixed the asset-source loading message (`Media Libary` → `Media Library`), the `cloundinaryWidget` DOM id prefix, and a `dependecnies` code-comment typo.
- README: `defineConfg` → `defineConfig` in all usage examples, fixed the `clooudinary`/`cloudnary`/`dont` comment typos, and removed the stale standalone-repo `Develop & test` / `Release new version` sections (building/releasing is centralized in the monorepo).
- `package.json` description reworded from "Sanity Studio V3." to a version-agnostic "Sanity Studio." (the package now targets Sanity v5+).

A `patch` changeset is included.

## Testing

- `pnpm format`, `pnpm lint` (full, type-aware), scoped `turbo build` + Vitest package-exports test for the plugin all pass.
- Manually verified in the test studio (Kitchen Sink). The `Cloudinary` document renders the custom asset input; `Cloudinary` shows up as an asset source on the image field (confirming the renamed plugin registers correctly); the asset-source dialog loads the widget end-to-end (it exercises the `loadJS` path — the widget script loads and `createMediaLibrary` is invoked, then Cloudinary returns its own demo-credential error); and the config/secrets dialog renders.

[cloudinary_asset_source_and_dialogs_demo.mp4](https://cursor.com/agents/bc-bbef6ba4-0ff1-4f91-bc20-6ed7fbbfca9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloudinary_asset_source_and_dialogs_demo.mp4)

`Cloudinary` listed as an asset source on the image field, and the configuration dialog:

[Cloudinary listed as an image asset source](https://cursor.com/agents/bc-bbef6ba4-0ff1-4f91-bc20-6ed7fbbfca9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloudinary_asset_source_listed.webp)
[Cloudinary config dialog](https://cursor.com/agents/bc-bbef6ba4-0ff1-4f91-bc20-6ed7fbbfca9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloudinary_config_dialog.webp)

> Note: `pnpm build` for the whole repo currently fails only in the unrelated `@repo/generators` package (`tsdown` can't import the optional `unrun` peer dep, which isn't installed in this VM). CI builds it fine, so verification here was scoped around that package.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbef6ba4-0ff1-4f91-bc20-6ed7fbbfca9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbef6ba4-0ff1-4f91-bc20-6ed7fbbfca9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

