### PR TITLE
docs: add missing plugins to README Current Plugins table

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Sessions can be compared in the DevTools UI to diff bundle changes between build
 | [`@sanity/presets`](./plugins/@sanity/presets)                                                           | Experimental preset patterns for Sanity Studio                      |
 | [`@sanity/rich-date-input`](./plugins/@sanity/rich-date-input)                                           | Timezone-aware datetime input for Sanity Studio                     |
 | [`@sanity/sanity-plugin-async-list`](./plugins/@sanity/sanity-plugin-async-list)                         | Autocomplete string input with options loaded from an external API  |
+| [`@sanity/sfcc`](./plugins/@sanity/sfcc)                                                                   | Salesforce Commerce Cloud integration with synced product data      |
 | [`@sanity/studio-secrets`](./plugins/@sanity/studio-secrets)                                             | Manage Studio secrets at runtime                                    |
 | [`@sanity/table`](./plugins/@sanity/table)                                                               | Table schema type and input component for Sanity Studio             |
 | [`@sanity/vercel-protection-bypass`](./plugins/@sanity/vercel-protection-bypass)                         | Setup tool for Vercel Deployment Protection in previews             |
@@ -109,6 +110,7 @@ Sessions can be compared in the DevTools UI to diff bundle changes between build
 | [`sanity-plugin-dashboard-widget-netlify`](./plugins/sanity-plugin-dashboard-widget-netlify)             | Dashboard widget for triggering Netlify builds                      |
 | [`sanity-plugin-dashboard-widget-vercel`](./plugins/sanity-plugin-dashboard-widget-vercel)               | Dashboard widget for managing Vercel deployments                    |
 | [`sanity-plugin-documents-pane`](./plugins/sanity-plugin-documents-pane)                                 | Display GROQ-queried document lists in a view pane                  |
+| [`sanity-plugin-google-translate`](./plugins/sanity-plugin-google-translate)                             | Translate content with Google Translate directly from Studio        |
 | [`sanity-plugin-graph-view`](./plugins/sanity-plugin-graph-view)                                         | Visual graph tool for exploring content relationships               |
 | [`sanity-plugin-hotspot-array`](./plugins/sanity-plugin-hotspot-array)                                   | Add and update array items by clicking on an image                  |
 | [`sanity-plugin-iframe-pane`](./plugins/sanity-plugin-iframe-pane)                                       | Display external URLs in a Studio pane                              |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The README **Current Plugins** table was missing two packages that exist in the monorepo:

- `@sanity/sfcc`
- `sanity-plugin-google-translate`

This PR adds both entries in alphabetical order with descriptions aligned to their `package.json` metadata.

## Verification

Compared all plugin `package.json` files under `plugins/` against the README table:

- Before: 45 listed / 47 in repo
- After: 47 listed / 47 in repo

No changeset is included because this is documentation-only and does not modify any published packages.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-015fbbcf-d1cc-4dac-93c2-de4069ebb292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-015fbbcf-d1cc-4dac-93c2-de4069ebb292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

