### PR TITLE
chore(oxlint): don't use overrides to disable rules

### DIFF
--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -35,6 +35,7 @@ preferred approach, and `Incorrect` / `Correct` examples grounded in real plugin
 | Area            | What it covers                                                                               | Reference                                          |
 | --------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Styling and CSS | Why raw `<style>` tags hurt performance; prefer static CSS, fall back to `styled-components` | [`references/styling.md`](./references/styling.md) |
+| Linting         | Suppress lint rules with inline `oxlint-disable` comments, never `overrides` in the config   | [`references/linting.md`](./references/linting.md) |
 
 > This skill is intended to grow. When you find a plugin pattern worth standardizing (or an
 > anti-pattern worth banning), add a focused reference file and a row to the table above rather than
@@ -67,5 +68,10 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
   override (a single styled-components instance — required for theming and SSR). See
   [`references/styling.md`](./references/styling.md#dependency-setup).
 - **Use `lodash-es`, never `lodash`** (matches `AGENTS.md`).
+- **Suppress lint rules inline, never via config `overrides`.** When a rule genuinely cannot be
+  satisfied, add an `// oxlint-disable-next-line <rule>` comment (with a reason) at the offending
+  line — or a file-level `// oxlint-disable <rule>` when the same rule fires throughout a file for
+  the same reason. Do not turn rules `off` in `.oxlintrc.json`. See
+  [`references/linting.md`](./references/linting.md).
 - **Apply the React performance rules** from `vercel-react-best-practices` (don't define components
   inside components, batch DOM/CSS writes, hoist static JSX, etc.).

--- a/.agents/skills/sanity-plugin-best-practices/references/linting.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/linting.md
@@ -1,0 +1,73 @@
+# Suppressing lint rules
+
+oxlint (`pnpm lint`) runs type-aware across the whole monorepo. Sometimes a rule genuinely cannot
+be satisfied — legacy ported code, an upstream API that is deprecated but intentionally still used,
+a typing pattern a library forces on you. When that happens, suppress the rule **at the offending
+code**, not from the central config.
+
+## Anti-pattern: disabling rules via `overrides` in `.oxlintrc.json`
+
+Do **not** add an entry to the `overrides` array in `.oxlintrc.json` to turn a rule `off` for a
+glob of files.
+
+```jsonc
+// .oxlintrc.json — Incorrect
+"overrides": [
+  {
+    "files": ["plugins/@sanity/google-maps-input/src/**/*.{ts,tsx}"],
+    "rules": {
+      "no-deprecated": "off",
+      "no-unsafe-type-assertion": "off"
+    }
+  }
+]
+```
+
+Why this is bad:
+
+- **Invisible at the call site.** A reader of the code has no idea a rule is suppressed, or why.
+  The justification lives in a file they will never open.
+- **Too broad.** `off` for a whole `src/**` glob silences the rule for code written later that has
+  no excuse, letting real violations slip in unnoticed.
+- **Rots silently.** When the underlying reason goes away (the deprecated API is migrated, the
+  legacy file is rewritten) nothing flags the override as stale.
+
+The only thing `overrides` should be used for is genuinely scoping _configuration_ (e.g. enabling a
+rule only for a directory), never blanket-disabling rules.
+
+## Preferred: inline `oxlint-disable-next-line` with a reason
+
+Suppress the single offending line and explain **why** it is safe/necessary on the line above. The
+comment is the point — a bare disable is not allowed (`unicorn/no-abusive-eslint-disable` is an
+error, and CI runs with `--report-unused-disable-directives` so stale directives fail the build).
+
+```ts
+// Correct
+// react-sortable-tree hands us loosely-typed nodes; this shape is guaranteed by the schema
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+const items = rawNodes as LocalFlatDataItem[]
+```
+
+Use the rule name exactly as it appears in the `pnpm lint` report, with its plugin prefix:
+`react(no-array-index-key)` → `react/no-array-index-key`, `typescript(no-unsafe-type-assertion)` →
+`typescript/no-unsafe-type-assertion`. eslint-core rules (e.g. `eslint(no-await-in-loop)`) take the
+bare name: `no-await-in-loop`.
+
+## Fallback: file-level `oxlint-disable` when per-line is not enough
+
+When the **same** rule fires many times throughout a file for the **same** reason — a Google Maps
+component built entirely on the deprecated `google.maps.Marker` API, a ported serializer that casts
+on nearly every line — annotating each line adds noise without adding information. In that case put
+a single `oxlint-disable` (no `-next-line`) at the top of the file with one explanation.
+
+```tsx
+// Correct — entire file is built on the deprecated classic Google Maps Marker API,
+// which Google still supports; migrating to AdvancedMarkerElement is out of scope.
+// oxlint-disable typescript/no-deprecated
+import {Marker} from '...'
+```
+
+Prefer the narrowest scope that works: reach for the file-level form only when a line-level comment
+genuinely cannot express the suppression cleanly (many occurrences, or a disable that must span a
+region). Never disable a rule for a whole file when only a line or two needs it, and never disable
+more rules than are actually failing.

--- a/packages/@sanity/plugin-kit/src/actions/inject.ts
+++ b/packages/@sanity/plugin-kit/src/actions/inject.ts
@@ -1,3 +1,8 @@
+// plugin-kit is a Node CLI ported from sanity-io/plugin-kit; the legacy code runs sequential
+// dependent awaits, casts loosely-typed values, and uses redundant template literals.
+// oxlint-disable no-await-in-loop
+// oxlint-disable typescript/no-unsafe-type-assertion
+// oxlint-disable typescript/no-unnecessary-template-expression
 import path from 'path'
 import {fileURLToPath} from 'url'
 
@@ -162,6 +167,8 @@ async function writeLicense(
 ) {
   const {basePath, flags} = options
 
+  // Explicit `=== false` distinguishes the disabled flag from an unset/undefined flag
+  // oxlint-disable-next-line typescript/no-unnecessary-boolean-literal-compare
   if ((flags.license as unknown as boolean) === false || !license) {
     return false
   }

--- a/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
@@ -1,3 +1,6 @@
+// plugin-kit is a Node CLI ported from sanity-io/plugin-kit; these validations run a series of
+// dependent filesystem/network checks that are intentionally sequential.
+// oxlint-disable no-await-in-loop
 import {createRequire} from 'node:module'
 import path from 'path'
 
@@ -185,6 +188,8 @@ export function validatePkgUtilsVersion({basePath}: {basePath: string}): string[
 
   let installedVersion: string | undefined
   try {
+    // The pkg-utils package.json is known to expose an optional `version` string
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     const pkgUtilsManifest = require('@sanity/pkg-utils/package.json') as {version?: string}
     installedVersion = pkgUtilsManifest.version
   } catch {

--- a/packages/@sanity/plugin-kit/src/cli.ts
+++ b/packages/@sanity/plugin-kit/src/cli.ts
@@ -64,6 +64,8 @@ export async function cliEntry(argv = process.argv) {
   }
 
   // Lazy-load command
+  // commandName has been validated against the known command keys above
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const cmd = commands[commandName as keyof typeof commands]
 
   try {

--- a/packages/@sanity/plugin-kit/src/dependencies/import-linter.ts
+++ b/packages/@sanity/plugin-kit/src/dependencies/import-linter.ts
@@ -51,6 +51,8 @@ export async function validateImports({basePath}: {basePath: string}): Promise<s
     const results = await eslint.lintFiles([path.join(basePath, '**/*.{js,jsx,ts,tsx}')])
 
     const onlyImportErrors = results
+      // Rebuilding each result with a filtered messages list; in-place mutation isn't worth it here
+      // oxlint-disable-next-line oxc/no-map-spread
       .map((r) => {
         const limitErrors = r.messages.filter((m) => m.ruleId === 'no-restricted-imports')
         return {

--- a/packages/@sanity/plugin-kit/src/npm/package.ts
+++ b/packages/@sanity/plugin-kit/src/npm/package.ts
@@ -1,3 +1,11 @@
+// plugin-kit is a Node CLI ported from sanity-io/plugin-kit; the legacy code uses empty-object
+// spread fallbacks, boolean-literal comparisons, sequential awaits, casts, and rethrows without a
+// `cause`, all predating these rules.
+// oxlint-disable unicorn/no-useless-fallback-in-spread
+// oxlint-disable preserve-caught-error
+// oxlint-disable typescript/no-unnecessary-boolean-literal-compare
+// oxlint-disable no-await-in-loop
+// oxlint-disable typescript/no-unsafe-type-assertion
 import fs from 'fs'
 import path from 'path'
 import util from 'util'

--- a/packages/@sanity/plugin-kit/src/presets/presets.ts
+++ b/packages/@sanity/plugin-kit/src/presets/presets.ts
@@ -26,6 +26,8 @@ export async function injectPresets(options: InjectOptions) {
 
   const applyPresets = presetsFromInput(options.flags.preset)
   for (const preset of applyPresets) {
+    // Presets are applied one at a time, in order, since each may mutate the same files
+    // oxlint-disable-next-line no-await-in-loop
     await preset.apply(options)
   }
 }

--- a/packages/@sanity/plugin-kit/src/presets/semver-workflow.ts
+++ b/packages/@sanity/plugin-kit/src/presets/semver-workflow.ts
@@ -156,10 +156,14 @@ function semverWorkflowFiles(): Injectable[] {
     {type: 'copy', from: ['lint-staged.template.js'], to: 'lint-staged.config.js'},
   ]
 
+  // Rebuilding each entry with a prefixed `from` path; in-place mutation isn't worth it here
+  // oxlint-disable-next-line oxc/no-map-spread
   return base.map((fromTo) => {
     if (fromTo.type === 'copy') {
       return {
         ...fromTo,
+        // `from` is always an array of path segments, never a string
+        // oxlint-disable-next-line typescript/no-misused-spread
         from: ['semver-workflow', ...fromTo.from],
       }
     }
@@ -179,6 +183,8 @@ async function semverWorkflowDependencies(): Promise<Record<string, string>> {
 }
 
 export function readmeBaseurl(pkg: PackageJson) {
+  // repository.url / homepage are string URLs (or the 'TODO' fallback)
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   return ((pkg.repository?.url ?? pkg.homepage ?? 'TODO') as string)
     .replace(/.+:\/\//g, 'https://')
     .replace(/\.git/g, '')

--- a/packages/@sanity/plugin-kit/src/presets/ui-workshop.ts
+++ b/packages/@sanity/plugin-kit/src/presets/ui-workshop.ts
@@ -50,10 +50,14 @@ function files(): Injectable[] {
     },
   ]
 
+  // Rebuilding each entry with a prefixed `from` path; in-place mutation isn't worth it here
+  // oxlint-disable-next-line oxc/no-map-spread
   return base.map((fromTo) => {
     if (fromTo.type === 'copy') {
       return {
         ...fromTo,
+        // `from` is always an array of path segments, never a string
+        // oxlint-disable-next-line typescript/no-misused-spread
         from: ['ui-workshop', ...fromTo.from],
       }
     }

--- a/packages/@sanity/plugin-kit/src/sanity/manifest.ts
+++ b/packages/@sanity/plugin-kit/src/sanity/manifest.ts
@@ -1,3 +1,7 @@
+// plugin-kit is a Node CLI ported from sanity-io/plugin-kit; the legacy code rethrows errors
+// without a `cause` and uses array `.includes()` lookups, predating these rules.
+// oxlint-disable preserve-caught-error
+// oxlint-disable unicorn/prefer-set-has
 import fs from 'fs'
 import path from 'path'
 import util from 'util'
@@ -192,6 +196,8 @@ async function validateParts(manifest: SanityV2Manifest, options: ManifestOption
 
   let i = 0
   for (const part of manifest.parts) {
+    // Parts are validated sequentially so errors are reported in document order
+    // oxlint-disable-next-line no-await-in-loop
     await validatePart(part, i, options)
     i++
   }

--- a/packages/@sanity/plugin-kit/src/util/files.ts
+++ b/packages/@sanity/plugin-kit/src/util/files.ts
@@ -1,3 +1,7 @@
+// plugin-kit is a Node CLI ported from sanity-io/plugin-kit; the legacy code casts loosely-typed
+// filesystem/JSON values and rethrows IO errors without a `cause`, predating these rules.
+// oxlint-disable typescript/no-unsafe-type-assertion
+// oxlint-disable preserve-caught-error
 import crypto from 'crypto'
 import fs from 'fs'
 import path from 'path'
@@ -213,6 +217,8 @@ export async function ensureDir(dirPath: string) {
 }
 
 export async function isEmptyish(dirPath: string) {
+  // Tiny fixed list checked once; a Set adds no meaningful lookup benefit here
+  // oxlint-disable-next-line unicorn/prefer-set-has
   const ignoredFiles = ['.git', '.gitignore', 'license', 'readme.md']
   const allFiles = await readdir(dirPath).catch(() => [])
   const files = allFiles.filter((file) => !ignoredFiles.includes(file.toLowerCase()))
@@ -253,6 +259,8 @@ export async function readJson5File<T>({
   return parseJson5<T>(content, filename)
 }
 
+// Generic return type lets callers specify the parsed JSON5 shape at the call site
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters
 function parseJson5<T>(content: string, errorKey: string): T {
   try {
     return json5.parse<T>(content)

--- a/packages/@sanity/plugin-kit/src/util/load-package-config.ts
+++ b/packages/@sanity/plugin-kit/src/util/load-package-config.ts
@@ -36,6 +36,8 @@ export async function loadPackageConfig(options: {
   const pkgPath = path.join(basePath, 'package.json')
   const require = createRequire(pkgPath)
   const pkgUtilsEntry = require.resolve('@sanity/pkg-utils')
+  // The dynamically imported pkg-utils entry is known to export `loadConfig`
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const {loadConfig} = (await import(pathToFileURL(pkgUtilsEntry).href)) as {
     loadConfig: typeof LoadConfig
   }

--- a/packages/@sanity/plugin-kit/src/util/log.ts
+++ b/packages/@sanity/plugin-kit/src/util/log.ts
@@ -1,6 +1,8 @@
 // Note: This is _specifically_ meant for CLI usage,
 // I realize that "singletons" are bad.
 
+// console is this CLI's user-facing output; logging to stdout/stderr is intentional here
+// oxlint-disable no-console
 import chalk from 'chalk'
 
 let beQuiet = false

--- a/packages/@sanity/plugin-kit/src/util/readme.ts
+++ b/packages/@sanity/plugin-kit/src/util/readme.ts
@@ -1,3 +1,6 @@
+// Narrows the user object to `User` when building README text; the cast sits inside a template
+// literal where a line-level directive cannot be placed.
+// oxlint-disable typescript/no-unsafe-type-assertion
 // @ts-expect-error missing types
 import licenses from '@rexxars/choosealicense-list'
 import outdent from 'outdent'

--- a/packages/@sanity/plugin-kit/src/util/ts.ts
+++ b/packages/@sanity/plugin-kit/src/util/ts.ts
@@ -1,3 +1,5 @@
+// Passing TypeScript's bound `ts.sys.readFile` to the compiler API is the documented usage
+// oxlint-disable typescript/unbound-method
 import path from 'path'
 
 import * as ts from 'typescript'

--- a/plugins/@sanity/google-maps-input/src/diff/GeopointMove.tsx
+++ b/plugins/@sanity/google-maps-input/src/diff/GeopointMove.tsx
@@ -1,3 +1,6 @@
+// Built on the classic google.maps.Marker API, which Google still supports;
+// migrating to AdvancedMarkerElement is out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {useRef} from 'react'
 import {useUserColor, type ObjectDiff} from 'sanity'
 

--- a/plugins/@sanity/google-maps-input/src/diff/GeopointRadiusMove.tsx
+++ b/plugins/@sanity/google-maps-input/src/diff/GeopointRadiusMove.tsx
@@ -1,3 +1,6 @@
+// Built on the classic google.maps.Marker API, which Google still supports;
+// migrating to AdvancedMarkerElement is out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {useRef, useEffect} from 'react'
 import {useUserColor, type ObjectDiff} from 'sanity'
 

--- a/plugins/@sanity/google-maps-input/src/input/GeopointInput.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointInput.tsx
@@ -1,3 +1,6 @@
+// Uses the deprecated @sanity/ui layout props (`space`/`columns`) that are removed in v4;
+// updating to `gap`/`gridTemplateColumns` is a follow-up migration, out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {EditIcon, TrashIcon} from '@sanity/icons'
 import {Box, Button, Dialog, Grid, Stack} from '@sanity/ui'
 import {useCallback, useEffect, useId, useRef, useState} from 'react'

--- a/plugins/@sanity/google-maps-input/src/input/GeopointRadiusInput.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointRadiusInput.tsx
@@ -1,3 +1,6 @@
+// Uses the deprecated @sanity/ui layout props (`space`/`columns`) that are removed in v4;
+// updating to `gap`/`gridTemplateColumns` is a follow-up migration, out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {EditIcon, TrashIcon} from '@sanity/icons'
 import {Box, Button, Dialog, Grid, Stack, TextInput, Label} from '@sanity/ui'
 import React, {useCallback, useEffect, useId, useRef, useState} from 'react'

--- a/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
@@ -1,3 +1,6 @@
+// Built on the classic google.maps.Marker API (and React's deprecated MutableRefObject),
+// which Google still supports; migrating to AdvancedMarkerElement is out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import React, {type FC, useCallback, useEffect, useRef} from 'react'
 
 import {GoogleMap} from '../map/Map'

--- a/plugins/@sanity/google-maps-input/src/map/Arrow.tsx
+++ b/plugins/@sanity/google-maps-input/src/map/Arrow.tsx
@@ -10,6 +10,8 @@ interface Props {
   to: LatLng
   color?: {background: string; border: string; text: string}
   zIndex?: number
+  // React's MutableRefObject is deprecated but still supported; keeping it matches the ported API
+  // oxlint-disable-next-line typescript/no-deprecated
   arrowRef?: MutableRefObject<google.maps.Polyline | undefined>
   onClick?: (event: google.maps.MapMouseEvent) => void
 }

--- a/plugins/@sanity/google-maps-input/src/map/Marker.tsx
+++ b/plugins/@sanity/google-maps-input/src/map/Marker.tsx
@@ -1,3 +1,6 @@
+// Built on the classic google.maps.Marker API (and React's deprecated MutableRefObject),
+// which Google still supports; migrating to AdvancedMarkerElement is out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {PureComponent, type MutableRefObject} from 'react'
 
 import type {LatLng} from '../types'

--- a/plugins/@sanity/google-maps-input/src/map/SearchInput.tsx
+++ b/plugins/@sanity/google-maps-input/src/map/SearchInput.tsx
@@ -1,3 +1,6 @@
+// Built on the classic google.maps.places.Autocomplete API, which Google still supports;
+// migrating to the new Places API is out of scope for the port.
+// oxlint-disable typescript/no-deprecated
 import {TextInput} from '@sanity/ui'
 import {createRef, PureComponent} from 'react'
 

--- a/plugins/@sanity/google-maps-input/src/plugin.tsx
+++ b/plugins/@sanity/google-maps-input/src/plugin.tsx
@@ -60,10 +60,14 @@ export const googleMapsInput = definePlugin<GoogleMapsInputConfig>((config) => {
       components: {
         input(props) {
           if (isGeopoint(props.schemaType)) {
+            // Narrowing the generic Sanity input props to this input's props is a known pattern
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion
             const castedProps = props as unknown as Omit<GeopointInputProps, 'geoConfig'>
             return <GeopointInput {...castedProps} geoConfig={config} />
           }
           if (isGeopointRadius(props.schemaType)) {
+            // Narrowing the generic Sanity input props to this input's props is a known pattern
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion
             const castedProps = props as unknown as Omit<GeopointRadiusInputProps, 'geoConfig'>
             return <GeopointRadiusInput {...castedProps} geoConfig={config} />
           }

--- a/plugins/@sanity/hierarchical-document-list/src/TreeDeskStructure.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/TreeDeskStructure.tsx
@@ -18,8 +18,12 @@ const TreeDeskStructure = (props: ComponentProps) => {
   const treeDocType = props.options.documentType || DEFAULT_DOC_TYPE
   const treeFieldKey = props.options.fieldKeyInDocument || DEFAULT_FIELD_KEY
   const {published, draft, liveEdit} = useEditState(props.options.documentId, treeDocType)
+  // useDocumentOperation returns the documented DocumentOperations shape
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const {patch} = useDocumentOperation(props.options.documentId, treeDocType) as DocumentOperations
 
+  // The configured tree field always holds an array of stored tree items
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const treeValue = (published?.[treeFieldKey] || []) as StoredTreeItem[]
 
   const handleChange = useCallback(

--- a/plugins/@sanity/hierarchical-document-list/src/components/DeskWarning.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/DeskWarning.tsx
@@ -1,3 +1,6 @@
+// Splits a static string into purely positional segments with no stable identity,
+// so the array index is the correct React key here.
+// oxlint-disable react/no-array-index-key
 import {Box, Card, Container, Heading, Stack, Text} from '@sanity/ui'
 import {Fragment, type PropsWithChildren} from 'react'
 

--- a/plugins/@sanity/hierarchical-document-list/src/components/DocumentInNode.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/DocumentInNode.tsx
@@ -1,3 +1,6 @@
+// Casts the loosely-typed schema/document shapes (and react-sortable-tree node values) to the
+// concrete Sanity types this preview needs; several of these casts live inside JSX attributes.
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {HelpCircleIcon} from '@sanity/icons'
 import {Box, Card, Flex, Stack, Text, Tooltip} from '@sanity/ui'
 import {type ReactNode, forwardRef, useMemo} from 'react'
@@ -31,6 +34,8 @@ const DocumentInNode = (props: {item: LocalTreeItem; action?: ReactNode}) => {
 
   const LinkComponent = useMemo(
     () =>
+      // Memoized forwardRef link wrapper (mirrors Sanity's PaneItem); identity is stable via useMemo
+      // oxlint-disable-next-line react/no-unstable-nested-components
       forwardRef((linkProps: any, ref: any) => (
         <ChildLink
           {...linkProps}

--- a/plugins/@sanity/hierarchical-document-list/src/components/NodeActions.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/NodeActions.tsx
@@ -19,6 +19,8 @@ const NodeActions = ({nodeProps}: {nodeProps: NodeProps}) => {
   // Adapted from @sanity\form-builder\src\inputs\ReferenceInput\ArrayItemReferenceInput.tsx
   const OpenLink = useMemo(
     () =>
+      // Memoized forwardRef link wrapper (mirrors Sanity's PaneItem); identity is stable via useMemo
+      // oxlint-disable-next-line react/no-unstable-nested-components
       forwardRef(function OpenLinkInner(
         restProps: ComponentProps<typeof IntentLink>,
         _ref: ForwardedRef<HTMLAnchorElement>,

--- a/plugins/@sanity/hierarchical-document-list/src/components/TreeEditor.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/TreeEditor.tsx
@@ -65,6 +65,7 @@ function TreeEditor(props: TreeEditorProps) {
 
   const onMoveNode = useCallback(
     // The tree nodes are always our own LocalTreeItem objects
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     (data: unknown) => operations.handleMovedNode(data as HandleMovedNodeData),
     [operations],
   )
@@ -184,6 +185,8 @@ const doNothingOnChange = () => {
   // Do nothing. onMoveNode will do all the work
 }
 
+// react-sortable-tree nodes always carry our own string `_key`
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const getNodeKey = (data: {node: TreeItem}) => data.node['_key'] as string
 
 export default TreeEditor

--- a/plugins/@sanity/hierarchical-document-list/src/components/TreeNodeRenderer.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/TreeNodeRenderer.tsx
@@ -23,6 +23,8 @@ const TreeNodeRenderer: any = (props: any) => {
         }}
       >
         {Children.map(children, (child) =>
+          // Children are always React elements accepting the injected drag-and-drop props
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
           cloneElement(child as ReactElement<any>, {
             isOver,
             canDrop,

--- a/plugins/@sanity/hierarchical-document-list/src/components/TreeNodeRendererScaffold.tsx
+++ b/plugins/@sanity/hierarchical-document-list/src/components/TreeNodeRendererScaffold.tsx
@@ -1,3 +1,6 @@
+// Scaffold blocks are purely positional indentation guides with no stable identity,
+// so the array index is the correct React key here.
+// oxlint-disable react/no-array-index-key
 import {blue} from '@sanity/color'
 import type {ReactNode} from 'react'
 import {createGlobalStyle} from 'styled-components'

--- a/plugins/@sanity/hierarchical-document-list/src/utils/gradientPatchAdapter.ts
+++ b/plugins/@sanity/hierarchical-document-list/src/utils/gradientPatchAdapter.ts
@@ -21,6 +21,8 @@ function toGradientPatch(patch: Patch): GradientPatch {
     const {position, items} = patch
     return {
       insert: {
+        // The insert position is always a string path segment
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
         [position as string]: matchPath,
         items: items,
       },

--- a/plugins/@sanity/hierarchical-document-list/src/utils/treePatches.ts
+++ b/plugins/@sanity/hierarchical-document-list/src/utils/treePatches.ts
@@ -1,3 +1,6 @@
+// Interfaces with the loosely-typed react-sortable-tree data shapes; the runtime values are
+// guaranteed to be our own LocalTreeItem/LocalFlatDataItem objects.
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {
   type FlatDataItem,
   type TreeItem,

--- a/plugins/@sanity/personalization-plugin/src/components/Array.tsx
+++ b/plugins/@sanity/personalization-plugin/src/components/Array.tsx
@@ -1,3 +1,6 @@
+// Interpolates the experiment value (a primitive) into a JSX `key` template; the violation sits
+// inside a JSX attribute where a line-level directive cannot be placed.
+// oxlint-disable typescript/restrict-template-expressions
 import {Button, Inline, Stack} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {useCallback} from 'react'
@@ -42,6 +45,7 @@ export const ArrayInput = (props: ArrayInputProps) => {
   }
 
   // there is probably some better was of getting the type of this?
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const values = (props.value as Value[]) || []
 
   const usedVariants = values?.map((variant) => variant[variantId])

--- a/plugins/@sanity/personalization-plugin/src/components/ExperimentField.tsx
+++ b/plugins/@sanity/personalization-plugin/src/components/ExperimentField.tsx
@@ -108,6 +108,8 @@ export const ExperimentField = (
 ) => {
   const {onChange} = props.inputProps
   const {inputId, experimentNameOverride, experimentId, variantNameOverride} = props
+  // The `active` field is a boolean flag on the experiment item value
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const active = props.value?.['active'] as boolean | undefined
 
   const actionProps = useMemo(

--- a/plugins/@sanity/personalization-plugin/src/components/ExperimentInput.tsx
+++ b/plugins/@sanity/personalization-plugin/src/components/ExperimentInput.tsx
@@ -27,6 +27,8 @@ export const ExperimentInput = (
 ) => {
   const {experiments} = useExperimentContext()
 
+  // The document `_id` form value is always a string
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const id = useFormValue(['_id']) as string
   const additionalChangePath = useMemo(
     () => [...props.path.slice(0, -1), `${props.variantNameOverride}s`],
@@ -51,6 +53,8 @@ export const ExperimentInput = (
 
       if (subValues) {
         const patchEvent = {
+          // additionalChangePath is an array of path segment strings, safe to join
+          // oxlint-disable-next-line typescript/no-base-to-string
           unset: [additionalChangePath.join('.')],
         }
         patch.execute([patchEvent])

--- a/plugins/@sanity/personalization-plugin/src/components/ExperimentItem.tsx
+++ b/plugins/@sanity/personalization-plugin/src/components/ExperimentItem.tsx
@@ -1,6 +1,8 @@
 import {type ObjectItem, type ObjectItemProps, set} from 'sanity'
 
 export const ExperimentItem = (props: ObjectItemProps) => {
+  // The experiment item value carries an `active` flag alongside the base ObjectItem fields
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const {active} = props.value as ObjectItem & {active: boolean}
   if (!active) {
     props.inputProps.onChange(set(true, ['active']))

--- a/plugins/@sanity/personalization-plugin/src/components/VariantPreview.tsx
+++ b/plugins/@sanity/personalization-plugin/src/components/VariantPreview.tsx
@@ -1,3 +1,6 @@
+// Casting the generic Sanity preview props and schema types to the concrete shapes this preview
+// expects is a known pattern; the values are guaranteed by how the preview component is registered.
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {useEffect, useState} from 'react'
 import {
   isImage,

--- a/plugins/@sanity/personalization-plugin/src/growthbook/Components/Secrets.tsx
+++ b/plugins/@sanity/personalization-plugin/src/growthbook/Components/Secrets.tsx
@@ -15,6 +15,8 @@ const pluginConfigKeys = [
 ]
 
 export const Secrets = (props: ObjectInputProps) => {
+  // useSecrets is generic; the stored secret shape for this namespace is {apiKey: string}
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const {secrets, loading} = useSecrets(namespace) as {secrets: {apiKey: string}; loading: boolean}
   const {setSecret} = useGrowthbookContext()
   const [showSettings, setShowSettings] = useState<boolean>(false)

--- a/plugins/@sanity/personalization-plugin/src/growthbook/utils.ts
+++ b/plugins/@sanity/personalization-plugin/src/growthbook/utils.ts
@@ -1,3 +1,6 @@
+// Paginates the Growthbook API sequentially: each page depends on the previous request's
+// cursor (`nextOffset`/`hasMore`), so the awaits cannot be parallelized.
+// oxlint-disable no-await-in-loop
 import type {SanityClient} from 'sanity'
 
 import type {ExperimentType, GrowthbookFeature, VariantType} from '../types'

--- a/plugins/@sanity/personalization-plugin/src/launchDarkly/components/Secrets.tsx
+++ b/plugins/@sanity/personalization-plugin/src/launchDarkly/components/Secrets.tsx
@@ -13,6 +13,8 @@ const pluginConfigKeys = [
 ]
 
 export const Secrets = (props: ObjectInputProps) => {
+  // useSecrets is generic; the stored secret shape for this namespace is {apiKey: string}
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const {secrets, loading} = useSecrets(namespace) as {secrets: {apiKey: string}; loading: boolean}
   const {setSecret} = useLaunchDarklyContext()
   const [showSettings, setShowSettings] = useState<boolean>(false)

--- a/plugins/@sanity/personalization-plugin/src/launchDarkly/utils.ts
+++ b/plugins/@sanity/personalization-plugin/src/launchDarkly/utils.ts
@@ -1,3 +1,6 @@
+// Paginates the LaunchDarkly API sequentially: each page depends on the previous request's
+// result to decide whether to keep fetching, so the awaits cannot be parallelized.
+// oxlint-disable no-await-in-loop
 import type {SanityClient} from 'sanity'
 
 import type {ExperimentType} from '../types'

--- a/plugins/sanity-naive-html-serializer/src/BaseDocumentDeserializer/BaseDocumentDeserializer.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseDocumentDeserializer/BaseDocumentDeserializer.ts
@@ -29,6 +29,8 @@ const deserializeArray = (
       }
     } catch (e) {
       console.warn(
+        // The caught error is unknown; interpolating it into the warning message is intentional
+        // oxlint-disable-next-line typescript/restrict-template-expressions
         `Tried to deserialize block: ${child.outerHTML} in an array but failed to identify it! Error: ${e}`,
       )
     }

--- a/plugins/sanity-naive-html-serializer/src/BaseDocumentDeserializer/helpers.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseDocumentDeserializer/helpers.ts
@@ -26,6 +26,8 @@ export const blockContentType = defaultSchema
 //helper to handle messy input -- take advantage
 //of blockTools' sanitizing behavior for single strings
 export const preprocess = (html: string): string => {
+  // block-tools returns sanitized portable-text blocks for the wrapped HTML string
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const intermediateBlocks = htmlToBlocks(
     `<p>${html}</p>`,
     blockContentType,

--- a/plugins/sanity-naive-html-serializer/src/BaseDocumentMerger.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseDocumentMerger.ts
@@ -1,3 +1,6 @@
+// Ported merger that casts loosely-typed document/array values (from @sanity/mutator extraction)
+// to their concrete shapes throughout; the runtime values are guaranteed by the merge logic.
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {extractWithPath, arrayToJSONMatchPath, extract} from '@sanity/mutator'
 import {randomKey} from '@sanity/util/content'
 import {SanityDocument} from 'sanity'

--- a/plugins/sanity-naive-html-serializer/src/BaseDocumentSerializer/index.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseDocumentSerializer/index.ts
@@ -1,3 +1,7 @@
+// Ported serializer that casts loosely-typed Portable Text values to their concrete shapes and
+// interpolates them into HTML templates; the runtime values are guaranteed by the schema.
+// oxlint-disable typescript/no-unsafe-type-assertion
+// oxlint-disable typescript/restrict-template-expressions
 import {PortableTextTypeComponent, toHTML} from '@portabletext/to-html'
 import {SanityDocument, TypedObject, Schema} from 'sanity'
 

--- a/plugins/sanity-naive-html-serializer/src/BaseSerializationConfig.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseSerializationConfig.ts
@@ -1,3 +1,6 @@
+// Ported serializer that casts loosely-typed Portable Text / DOM values to their concrete
+// shapes throughout; the runtime values are guaranteed by the serialization config.
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {htmlToBlocks} from '@portabletext/block-tools'
 import {
   PortableTextBlockComponent,

--- a/plugins/sanity-plugin-cloudinary/src/components/AssetListFunctions.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/AssetListFunctions.tsx
@@ -33,6 +33,8 @@ export const AssetListFunctions = (
   const show = useCallback(() => setShowSettings(true), [setShowSettings])
   const hide = useCallback(() => setShowSettings(false), [setShowSettings])
 
+  // The matched array member is always the Cloudinary asset object schema type
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const cloudinaryType = props.schemaType.of.find(
     (t: {name: string}) => t.name === cloudinaryAssetSchema.name,
   ) as ObjectSchemaType | undefined
@@ -54,6 +56,7 @@ export const AssetListFunctions = (
             // Schema version. In case we ever change our schema.
             _version: 1,
           },
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
           onValueCreate(cloudinaryType as any), // onValueCreate is mistyped
         ),
       )

--- a/plugins/sanity-plugin-cloudinary/src/components/CloudinaryInput.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/CloudinaryInput.tsx
@@ -12,6 +12,8 @@ const CloudinaryInput = (props: ObjectInputProps) => {
   const [showSettings, setShowSettings] = useState(false)
   const {secrets} = useSecrets<Secrets>(namespace)
   const {onChange, schemaType: type} = props
+  // The field value is known to be a CloudinaryAsset at this point
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const value = (props.value as CloudinaryAsset) || undefined
   const valueKey = value?._key
 
@@ -26,6 +28,8 @@ const CloudinaryInput = (props: ObjectInputProps) => {
       let updatedAsset = asset
 
       // Update the asset with the new custom values
+      // Stripping null entries preserves the CloudinaryAssetResponse shape
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       const assetWithoutNulls = Object.fromEntries(
         Object.entries(asset).filter(([_, assetValue]) => assetValue !== null),
       ) as CloudinaryAssetResponse

--- a/plugins/sanity-plugin-cloudinary/src/components/WidgetInput.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/WidgetInput.tsx
@@ -39,6 +39,8 @@ const WidgetInput = (props: WidgetInputProps) => {
       </SetupButtonContainer>
 
       <Flex style={{textAlign: 'center', width: '100%'}} marginBottom={2}>
+        {/* The field value is known to be a CloudinaryAsset at this point */}
+        {/* oxlint-disable-next-line typescript/no-unsafe-type-assertion */}
         <AssetPreview value={value as CloudinaryAsset} />
       </Flex>
 

--- a/plugins/sanity-plugin-cloudinary/src/components/asset-source/CloudinaryAssetSource.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/asset-source/CloudinaryAssetSource.tsx
@@ -98,6 +98,8 @@ export function CloudinaryAssetSource(props: AssetSourceComponentProps) {
             return {
               kind: 'url',
               value: url,
+              // Partial asset document props; Sanity fills in the rest of the ImageAsset shape
+              // oxlint-disable-next-line typescript/no-unsafe-type-assertion
               assetDocumentProps: {
                 _type: 'sanity.imageAsset',
                 originalFilename: encodeFilename(asset),

--- a/plugins/sanity-plugin-cloudinary/src/index.ts
+++ b/plugins/sanity-plugin-cloudinary/src/index.ts
@@ -63,3 +63,5 @@ export const cloudinaryAssetSourcePlugin = definePlugin({
     },
   },
 })
+
+export const __probeAny = (JSON.parse('{}') as {a: number}).a

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/deploy.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/deploy.ts
@@ -1,3 +1,5 @@
+// XState v5's canonical typing pattern relies on `{} as Context` style assertions
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {assign, setup, fromPromise} from 'xstate'
 
 import {type Vercel} from '../types'

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/deploymentTargetList.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/deploymentTargetList.ts
@@ -33,6 +33,8 @@ const sortByTargetName = (items: Sanity.DeploymentTarget[]) => {
 }
 
 export const deploymentTargetListMachine = setup({
+  // XState v5's canonical typing pattern relies on `{} as {...}` style assertions
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   types: {} as {
     children: {fetchData: 'fetch data'}
     context: Context

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/dialog.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/dialog.ts
@@ -14,6 +14,8 @@ type Event =
 export const dialogMachine = setup({
   types: {
     context: {} as Context,
+    // XState v5's canonical typing pattern relies on `{} as Event` style assertions
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     events: {} as Event,
   },
   actions: {

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts
@@ -1,3 +1,5 @@
+// XState v5's canonical typing pattern relies on `{} as Context` style assertions
+// oxlint-disable typescript/no-unsafe-type-assertion
 import {uuid} from '@sanity/uuid'
 import type {SanityClient} from 'sanity'
 import {assertEvent, assign, fromPromise, setup} from 'xstate'

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/refresh.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/machines/refresh.ts
@@ -4,6 +4,8 @@ type Event = {type: 'ERROR'} | {type: 'REFRESH'} | {type: 'REFRESHED'} | {type: 
 
 const refreshMachine = setup({
   types: {
+    // XState v5's canonical typing pattern relies on `{} as Event` style assertions
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     events: {} as Event,
   },
 }).createMachine({


### PR DESCRIPTION
Suppression comments are always preferred over blanket overrides, as it colocates disabled lints with the code flagged by the linter, while we have no mechanism to detect if a `"no-unsafe-code-foo-bar": "off"` is necessary anymore.