### PR TITLE
Enable test type-checking and fix test typings

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,6 @@
     "**/dist/*",
     "**/sanity.types.ts",
     "turbo/generators/config.ts",
-    "plugins/sanity-naive-html-serializer/test/**",
     // Illustrative docs referencing optional third-party form libraries
     // (formik, react-hook-form, @tanstack/react-form, zod); not built or published
     "plugins/@sanity/form-toolkit/examples/**",

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
@@ -324,8 +324,8 @@ test('Content with anonymous inline objects deserializes all fields, at any dept
   expect(deserialized.tabs.config.title).toEqual(inlineDocumentLevelArticle.tabs.config.title)
 
   //array in object in object
-  expect(deserialized.tabs.config.objectAsField.content[0].children[0].text).toEqual(
-    inlineDocumentLevelArticle.tabs.config.objectAsField.content[0].children[0].text,
+  expect(deserialized.tabs.config.objectAsField.content[0]!.children[0]!.text).toEqual(
+    inlineDocumentLevelArticle.tabs.config.objectAsField.content[0]!.children[0]!.text,
   )
 
   //arrays
@@ -351,6 +351,6 @@ test('Content with anonymous inline objects deserializes all fields, at any dept
   const origArray = inlineDocumentLevelArticle.tabs.arrayWithAnonymousObjects
   const deserializedArray = deserialized.tabs.arrayWithAnonymousObjects
   expect(deserializedArray.length).toEqual(origArray.length)
-  expect(deserializedArray[0]._key).toEqual(origArray[0]._key)
+  expect(deserializedArray[0]!._key).toEqual(origArray[0]!._key)
   expect(Object.keys(deserializedArray[0])).not.toContain('span')
 })

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
@@ -2,7 +2,7 @@ import {readFileSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
-import {PortableTextBlock, PortableTextTextBlock} from 'sanity'
+import type {PortableTextBlock, PortableTextTextBlock} from 'sanity'
 import {beforeEach, expect, test, vi} from 'vitest'
 
 import {

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/baseDeserialization.test.ts
@@ -93,7 +93,7 @@ test('Custom deserialization should manifest at all levels', () => {
   expect(deserialized.config.title).toEqual(documentLevelArticle.config.title)
   expect(deserialized.config._type).toEqual(documentLevelArticle.config._type)
 
-  const origArrayObj = documentLevelArticle.content.find(
+  const origArrayObj: any = documentLevelArticle.content.find(
     (b: Record<string, any>) => b._type === 'objectField',
   )
   const deserializedArrayObj = deserialized.content.find(
@@ -118,10 +118,10 @@ test('Content with custom styles deserializes correctly and maintains style', ()
   )
 
   const deserialized = BaseDocumentDeserializer.deserializeDocument(serialized.content)
-  const origCustomStyleBlock = customStyledDocument.content.find(
+  const origCustomStyleBlock: any = customStyledDocument.content.find(
     (b: Record<string, any>) => b._type === 'block' && b.style === 'custom1',
   )
-  const origCustomStyleListItem = customStyledDocument.content.find(
+  const origCustomStyleListItem: any = customStyledDocument.content.find(
     (b: Record<string, any>) =>
       b._type === 'block' && b.listItem === 'number' && b.style === 'custom1',
   )
@@ -163,7 +163,7 @@ test('Handled inline objects should be accurately deserialized', () => {
     addedBlockDeserializers,
   )
 
-  const getInlineObj = (content: PortableTextBlock[], level?: number | undefined) => {
+  const getInlineObj = (content: PortableTextBlock[], level?: number) => {
     let child: Record<string, any> = {}
     const blocks = content.filter((block: PortableTextBlock) => {
       if (level) {
@@ -249,13 +249,13 @@ test('Handled annotations should be accurately deserialized', () => {
  */
 test('Deserialized content should preserve style tags', () => {
   const deserialized = getDeserialized(documentLevelArticle, 'document')
-  const origH1 = documentLevelArticle.content.find(
+  const origH1: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h1',
   )
   const deserializedH1 = deserialized.content.find(
     (block: PortableTextBlock) => block.style === 'h1',
   )
-  const origH2 = documentLevelArticle.content.find(
+  const origH2: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h2',
   )
   const deserializedH2 = deserialized.content.find(
@@ -274,13 +274,13 @@ test('Deserialized content should preserve style tags', () => {
  */
 test('Deserialized list items should preserve level, style and tag', () => {
   const deserialized = getDeserialized(documentLevelArticle, 'document')
-  const origListItem = documentLevelArticle.content.find(
+  const origListItem: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.style === 'h2',
   )
   const deserializedListItem = deserialized.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.style === 'h2',
   )
-  const origNestedListItem = documentLevelArticle.content.find(
+  const origNestedListItem: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.level === 2,
   )
   const deserializedNestedListItem = deserialized.content.find(
@@ -335,7 +335,7 @@ test('Content with anonymous inline objects deserializes all fields, at any dept
   )
 
   //object in array
-  const origObj = inlineDocumentLevelArticle.tabs.content.find(
+  const origObj: any = inlineDocumentLevelArticle.tabs.content.find(
     (block: any) => block._type === 'objectField',
   )
   const deserializedObj = deserialized.tabs.content.find(

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/documentLevelDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/documentLevelDeserialization.test.ts
@@ -76,19 +76,21 @@ test('Object in array contains accurate values in nested object -- document leve
   const deserialized = getDeserialized(documentLevelArticle, 'document')
   const origTitle = documentLevelArticle.content.find(
     (block: Record<string, any>) => block._type === 'objectField',
-  ).objectAsField.title
+  )!.objectAsField!.title
   const deserializedTitle = deserialized.content.find(
     (block: Record<string, any>) => block._type === 'objectField',
   ).objectAsField.title
   expect(deserializedTitle).toEqual(origTitle)
 
   const origBlockText = toPlainText(
-    documentLevelArticle.content.find((block: Record<string, any>) => block._type === 'objectField')
-      .objectAsField.content,
+    documentLevelArticle.content.find(
+      (block: Record<string, any>) => block._type === 'objectField',
+    )!.objectAsField!.content,
   ).trim()
   const deserializedBlockText = toPlainText(
-    documentLevelArticle.content.find((block: Record<string, any>) => block._type === 'objectField')
-      .objectAsField.content,
+    documentLevelArticle.content.find(
+      (block: Record<string, any>) => block._type === 'objectField',
+    )!.objectAsField!.content,
   ).trim()
   expect(deserializedBlockText).toEqual(origBlockText)
 })

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/documentLevelDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/documentLevelDeserialization.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {expect, test} from 'vitest'
 
 import {documentLevelArticle} from '../BaseDocumentSerializer/utils'

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/fieldLevelDeserialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/fieldLevelDeserialization.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {expect, test} from 'vitest'
 
 import {fieldLevelArticle} from '../BaseDocumentSerializer/utils'
@@ -76,19 +76,21 @@ test('Object in array contains accurate values in nested object -- field level',
   const deserialized = getDeserialized(fieldLevelArticle, 'field')
   const origTitle = fieldLevelArticle.content.en.find(
     (block: Record<string, any>) => block._type === 'objectField',
-  ).objectAsField.title
+  )!.objectAsField!.title
   const deserializedTitle = deserialized.content.en.find(
     (block: Record<string, any>) => block._type === 'objectField',
   ).objectAsField.title
   expect(deserializedTitle).toEqual(origTitle)
 
   const origBlockText = toPlainText(
-    fieldLevelArticle.content.en.find((block: Record<string, any>) => block._type === 'objectField')
-      .objectAsField.content,
+    fieldLevelArticle.content.en.find(
+      (block: Record<string, any>) => block._type === 'objectField',
+    )!.objectAsField!.content,
   ).trim()
   const deserializedBlockText = toPlainText(
-    fieldLevelArticle.content.en.find((block: Record<string, any>) => block._type === 'objectField')
-      .objectAsField.content,
+    fieldLevelArticle.content.en.find(
+      (block: Record<string, any>) => block._type === 'objectField',
+    )!.objectAsField!.content,
   ).trim()
   expect(deserializedBlockText).toEqual(origBlockText)
 })

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/internationalizedArrayDeserializer.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentDeserializer/internationalizedArrayDeserializer.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {expect, test, describe} from 'vitest'
 
 import {internationalizedArrayArticle} from '../BaseDocumentSerializer/utils'

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/baseMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/baseMerge.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {expect, test} from 'vitest'
 
 import {BaseDocumentMerger} from '../../src'

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/baseMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/baseMerge.test.ts
@@ -11,10 +11,10 @@ import {getNewDocument} from './utils'
 test('Merged document should maintain style tags', () => {
   const newDocument = getNewDocument()
   const mergedDocument = BaseDocumentMerger.documentLevelMerge(newDocument, documentLevelArticle)
-  const origH1Block = documentLevelArticle.content.find(
+  const origH1Block: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h1',
   )
-  const origH2Block = documentLevelArticle.content.find(
+  const origH2Block: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h2',
   )
   const mergedH1Block = mergedDocument.content.find(

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/documentLevelMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/documentLevelMerge.test.ts
@@ -45,7 +45,7 @@ test('Arrays will use new objects when they exist', () => {
     newDocument.content[0].children[0].text,
   )
   expect(mergedDocument.content[0].children[0].text).not.toEqual(
-    documentLevelArticle.content[0].children[0].text,
+    documentLevelArticle.content[0].children![0].text,
   )
 })
 

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/documentLevelMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/documentLevelMerge.test.ts
@@ -24,11 +24,11 @@ test('Top-level string / text fields from new document override old document', (
 test('Nested object fields override old object fields', () => {
   expect(mergedDocument.config.title).toEqual(newDocument.config.title)
   expect(mergedDocument.config.title).not.toEqual(documentLevelArticle.config.title)
-  expect(mergedDocument.config.nestedArrayField[0].children[0].text).toEqual(
-    newDocument.config.nestedArrayField[0].children[0].text,
+  expect(mergedDocument.config.nestedArrayField[0]!.children[0]!.text).toEqual(
+    newDocument.config.nestedArrayField[0]!.children[0]!.text,
   )
-  expect(mergedDocument.config.nestedArrayField[0].children[0].text).not.toEqual(
-    documentLevelArticle.config.nestedArrayField[0].children[0].text,
+  expect(mergedDocument.config.nestedArrayField[0]!.children[0]!.text).not.toEqual(
+    documentLevelArticle.config.nestedArrayField[0]!.children[0]!.text,
   )
 })
 
@@ -41,18 +41,18 @@ test('Nested object merge uses old fields when not present on new object', () =>
  * Arrays
  */
 test('Arrays will use new objects when they exist', () => {
-  expect(mergedDocument.content[0].children[0].text).toEqual(
-    newDocument.content[0].children[0].text,
+  expect(mergedDocument.content[0]!.children[0]!.text).toEqual(
+    newDocument.content[0]!.children[0]!.text,
   )
-  expect(mergedDocument.content[0].children[0].text).not.toEqual(
-    documentLevelArticle.content[0].children![0].text,
+  expect(mergedDocument.content[0]!.children[0]!.text).not.toEqual(
+    documentLevelArticle.content[0]!.children![0]!.text,
   )
 })
 
 test('Arrays will use old blocks if they do not exist on new object', () => {
   expect(newDocument.content[1]).toBeUndefined()
   expect(mergedDocument.content[1]).toBeDefined()
-  expect(mergedDocument.content[1]._key).toEqual(documentLevelArticle.content[1]._key)
+  expect(mergedDocument.content[1]!._key).toEqual(documentLevelArticle.content[1]!._key)
 })
 
 test('Arrays will merge objects in the array', () => {
@@ -61,7 +61,7 @@ test('Arrays will merge objects in the array', () => {
 
   //add a new block with some new content, but not all new content
   documentWithIncompleteObj.content.push({
-    _key: documentLevelArticle.content[1]._key,
+    _key: documentLevelArticle.content[1]!._key,
     objectAsField: incompleteObj.objectAsField,
     title: incompleteObj.title,
   })

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/fieldLevelMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/fieldLevelMerge.test.ts
@@ -54,7 +54,7 @@ test('Arrays will use new objects when they exist', () => {
     newDocument.content.en[0].children[0].text,
   )
   expect(fieldLevelPatches['content.es_ES'][0].children[0].text).not.toEqual(
-    fieldLevelArticle.content.en[0].children[0].text,
+    fieldLevelArticle.content.en[0].children![0].text,
   )
 })
 
@@ -97,7 +97,7 @@ test('Arrays will merge objects in the array', () => {
 test('nested locale fields will be merged', () => {
   const newNestedFields = clone(nestedLanguageFields)
   newNestedFields.pageFields.name.en = 'This is a new page field name'
-  newNestedFields.slices[0].en[0].children[0].text = 'This is new slice text'
+  ;(newNestedFields as any).slices[0].en[0].children[0].text = 'This is new slice text'
   const baseDocumentWithNestedFields = {...fieldLevelArticle, ...nestedLanguageFields}
   const newDocumentWithNestedFields = getDeserialized(
     {...fieldLevelArticle, ...newNestedFields},

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/fieldLevelMerge.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/fieldLevelMerge.test.ts
@@ -32,11 +32,11 @@ test('Top-level string / text fields from new document patch to new field, and w
 test('Nested object fields override old object fields', () => {
   expect(fieldLevelPatches['config.es_ES'].title).toEqual(newDocument.config.en.title)
   expect(fieldLevelPatches['config.es_ES'].title).not.toEqual(fieldLevelArticle.config.en.title)
-  expect(fieldLevelPatches['config.es_ES'].nestedArrayField[0].children[0].text).toEqual(
-    newDocument.config.en.nestedArrayField[0].children[0].text,
+  expect(fieldLevelPatches['config.es_ES'].nestedArrayField[0]!.children[0]!.text).toEqual(
+    newDocument.config.en.nestedArrayField[0]!.children[0]!.text,
   )
-  expect(fieldLevelPatches['config.es_ES'].nestedArrayField[0].children[0].text).not.toEqual(
-    fieldLevelArticle.config.en.nestedArrayField[0].children[0].text,
+  expect(fieldLevelPatches['config.es_ES'].nestedArrayField[0]!.children[0]!.text).not.toEqual(
+    fieldLevelArticle.config.en.nestedArrayField[0]!.children[0]!.text,
   )
 })
 
@@ -50,18 +50,18 @@ test('Nested object merge uses old fields when not present on new object', () =>
  * Arrays
  */
 test('Arrays will use new objects when they exist', () => {
-  expect(fieldLevelPatches['content.es_ES'][0].children[0].text).toEqual(
-    newDocument.content.en[0].children[0].text,
+  expect(fieldLevelPatches['content.es_ES'][0]!.children[0]!.text).toEqual(
+    newDocument.content.en[0]!.children[0]!.text,
   )
-  expect(fieldLevelPatches['content.es_ES'][0].children[0].text).not.toEqual(
-    fieldLevelArticle.content.en[0].children![0].text,
+  expect(fieldLevelPatches['content.es_ES'][0]!.children[0]!.text).not.toEqual(
+    fieldLevelArticle.content.en[0]!.children![0]!.text,
   )
 })
 
 test('Arrays will use old blocks if they do not exist on new object', () => {
   expect(newDocument.content.en[1]).toBeUndefined()
   expect(fieldLevelPatches['content.es_ES'][1]).toBeDefined()
-  expect(fieldLevelPatches['content.es_ES'][1]._key).toEqual(fieldLevelArticle.content.en[1]._key)
+  expect(fieldLevelPatches['content.es_ES'][1]!._key).toEqual(fieldLevelArticle.content.en[1]!._key)
 })
 
 test('Arrays will merge objects in the array', () => {
@@ -70,7 +70,7 @@ test('Arrays will merge objects in the array', () => {
 
   //add a new block with some new content, but not all new content
   documentWithIncompleteObj.content.en.push({
-    _key: fieldLevelArticle.content.en[1]._key,
+    _key: fieldLevelArticle.content.en[1]!._key,
     objectAsField: incompleteObj.objectAsField,
     title: incompleteObj.title,
     //does not include "content" field -- we want that to be merged with the old

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/utils.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentMerger/utils.ts
@@ -14,7 +14,7 @@ export const getNewObject = (): Record<string, any> => {
     objectAsField: {title: 'A new nested title'},
     _key: null,
   }
-  newObject.nestedArrayField[0].children[0].text = 'New text'
+  newObject.nestedArrayField[0]!.children[0]!.text = 'New text'
   return newObject
 }
 
@@ -36,7 +36,7 @@ export const getNewFieldLevelObject = (): Record<string, any> => {
     objectAsField: {title: 'A new nested title'},
     _key: null,
   }
-  newObject.nestedArrayField[0].children[0].text = 'New text'
+  newObject.nestedArrayField[0]!.children[0]!.text = 'New text'
   return newObject
 }
 

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/baseSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/baseSerialization.test.ts
@@ -70,7 +70,7 @@ test('Custom serialization should manifest at all levels', () => {
     defaultStopTypes,
     addedCustomSerializers,
   )
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
 
   const topLevelCustomSerialized = findByClass(docTree.children, 'config')
   const requiredTopLevelTitle = documentLevelArticle.config.title
@@ -88,7 +88,7 @@ test('Custom serialization should manifest at all levels', () => {
 
 test('Fields marked "localize: false" should not be serialized', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   //"meta" is localize: false field
   const meta = findByClass(docTree.children, 'meta')
   expect(documentLevelArticle.meta).toBeDefined()
@@ -97,7 +97,7 @@ test('Fields marked "localize: false" should not be serialized', () => {
 
 test('Expect default stop types to be absent', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   //"hidden" is boolean field
   const hidden = findByClass(docTree.children, 'hidden')
   expect(documentLevelArticle.hidden).toBeDefined()
@@ -115,7 +115,7 @@ test('Expect custom stop types to be absent at all levels', () => {
     customSerializers,
   )
 
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const config = findByClass(docTree.children, 'config')
   expect(documentLevelArticle.config).toBeDefined()
   expect(config).toBeUndefined()
@@ -141,7 +141,7 @@ test('Unhandled inline objects and annotations should not hinder translation flo
     ...annotationAndInlineBlocks,
   }
   const serialized = getSerialized(inlineDocument, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const arrayField = findByClass(docTree.children, 'content')
 
   //expect annotated object to have underlying text
@@ -174,7 +174,7 @@ test('Handled inline objects should be accurately represented per serializer', (
     defaultStopTypes,
     addedCustomSerializers,
   )
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const arrayField = findByClass(docTree.children, 'content')
   let inlineObject: Element | null = null
   let inlineObjectBlock: Record<string, any> | null = null
@@ -212,7 +212,7 @@ test('Handled annotations should be accurately represented per serializer', () =
     defaultStopTypes,
     addedCustomSerializers,
   )
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const arrayField = findByClass(docTree.children, 'content')
   let annotation: Element | null = null
   let annotationBlock: Record<string, any> | null = null
@@ -241,7 +241,7 @@ test('Handled annotations should be accurately represented per serializer', () =
  */
 test('Serialized content should preserve style tags from Portable Text', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const arrayField = findByClass(docTree.children, 'content')
   const blockH1: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h1',
@@ -264,13 +264,13 @@ test('Content with anonymous inline objects serializes all fields, at any depth'
     inlineDocumentLevelArticle,
     'document',
   )
-  const docTree = getHTMLNode(serialized).body.children[0]
-  const tabs = findByClass(docTree.children, 'tabs')!.children[0]
-  const config = findByClass(tabs.children, 'config')!.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
+  const tabs = findByClass(docTree.children, 'tabs')!.children[0]!
+  const config = findByClass(tabs.children, 'config')!.children[0]!
   const fieldNames = getValidFields(inlineDocumentLevelArticle.tabs.config)
   const foundFieldNames = Array.from(config.children).map((child) => child.className)
   expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
-  const nestedObjHTML = findByClass(config.children, 'objectAsField')!.children[0]
+  const nestedObjHTML = findByClass(config.children, 'objectAsField')!.children[0]!
   const nestedObj = inlineDocumentLevelArticle.tabs.config.objectAsField
   const nestedFieldNames = Array.from(nestedObjHTML.children).map((child) => child.className)
   expect(nestedFieldNames.sort()).toEqual(getValidFields(nestedObj).sort())
@@ -295,7 +295,7 @@ test('Content with anonymous inline objects serializes all fields, at any depth'
  */
 test('Serialized content should preserve list style and depth from Portable text', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const arrayField = findByClass(docTree.children, 'content')
   const listItem: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.style === 'h2',
@@ -315,7 +315,7 @@ test('Serialized content should preserve list style and depth from Portable text
 
 test('Values in a field are not repeated (indicating serializers are stateless)', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
   const HTMLList = findByClass(docTree.children, 'tags')
   const tags = documentLevelArticle.tags
   expect(HTMLList?.innerHTML).toContain(tags[0])

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/baseSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/baseSerialization.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {describe, expect, test, vi} from 'vitest'
 
 import {BaseDocumentSerializer, customSerializers, defaultStopTypes} from '../../src'
@@ -80,9 +80,9 @@ test('Custom serialization should manifest at all levels', () => {
 
   const arrayField = findByClass(docTree.children, 'content')
   const nestedSerialized = findByClass(arrayField!.children, 'objectField')
-  const requiredNestedTitle = documentLevelArticle.content.find(
+  const requiredNestedTitle: any = documentLevelArticle.content.find(
     (b: Record<string, any>) => b._type === 'objectField',
-  ).title
+  )!.title
   expect(nestedSerialized?.innerHTML).toContain(createCustomInnerHTML(requiredNestedTitle))
 })
 
@@ -243,11 +243,11 @@ test('Serialized content should preserve style tags from Portable Text', () => {
   const serialized = getSerialized(documentLevelArticle, 'document')
   const docTree = getHTMLNode(serialized).body.children[0]
   const arrayField = findByClass(docTree.children, 'content')
-  const blockH1 = documentLevelArticle.content.find(
+  const blockH1: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h1',
   )
   const serializedH1 = arrayField?.querySelector('h1')
-  const blockH2 = documentLevelArticle.content.find(
+  const blockH2: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.style === 'h2',
   )
   const serializedH2 = arrayField?.querySelector('h2')
@@ -277,14 +277,14 @@ test('Content with anonymous inline objects serializes all fields, at any depth'
 
   const content = findByClass(tabs.children, 'content')!
   const keysHTML = Array.from(content.children).map((child) => child.id)
-  const keysJSON = inlineDocumentLevelArticle.tabs.content.map((child: any) => child._key)
+  const keysJSON = inlineDocumentLevelArticle.tabs.content.map((child: any) => child._key as string)
   expect(keysHTML.sort()).toEqual(keysJSON.sort())
 
   const objectInArrayHTML = findByClass(content.children, 'objectField')
   const objectInArrayHTMLFieldNames = Array.from(objectInArrayHTML!.children).map(
     (child) => child.className,
   )
-  const objectInArray = inlineDocumentLevelArticle.tabs.content.find(
+  const objectInArray: any = inlineDocumentLevelArticle.tabs.content.find(
     (obj: any) => obj._type === 'objectField',
   )
   expect(objectInArrayHTMLFieldNames.sort()).toEqual(getValidFields(objectInArray).sort())
@@ -297,12 +297,12 @@ test('Serialized content should preserve list style and depth from Portable text
   const serialized = getSerialized(documentLevelArticle, 'document')
   const docTree = getHTMLNode(serialized).body.children[0]
   const arrayField = findByClass(docTree.children, 'content')
-  const listItem = documentLevelArticle.content.find(
+  const listItem: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.style === 'h2',
   )
 
   const serializedListItem = arrayField?.querySelectorAll('li')[2]
-  const nestedListItem = documentLevelArticle.content.find(
+  const nestedListItem: any = documentLevelArticle.content.find(
     (block: PortableTextBlock) => block.listItem === 'bullet' && block.level === 2,
   )
   const serializedNestedListItem = arrayField?.querySelectorAll('li')[1]

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/documentLevelSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/documentLevelSerialization.test.ts
@@ -1,11 +1,11 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {describe, expect, test} from 'vitest'
 
 import {getSerialized, getValidFields, toPlainText} from '../helpers'
 import {documentLevelArticle, findByClass, getHTMLNode} from './utils'
 
 const serialized = getSerialized(documentLevelArticle, 'document')
-const docTree = getHTMLNode(serialized).body.children[0]
+const docTree = getHTMLNode(serialized).body.children[0]!
 
 test('Global test of working doc-level functionality and snapshot match', () => {
   expect(serialized).toMatchSnapshot()
@@ -27,7 +27,7 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
   //parent node is always div with classname of field with a nested div
   //that has classname of obj type
   const configObj = findByClass(docTree.children, 'config')
-  const objectField = configObj!.children[0]
+  const objectField = configObj!.children[0]!
 
   test('Top-level nested objects contain all serializable fields -- document level', () => {
     const fieldNames = getValidFields(documentLevelArticle.config)
@@ -36,7 +36,7 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
   })
 
   test('Nested object in object contains all serializable fields -- document level', () => {
-    const nestedObject = findByClass(objectField.children, 'objectAsField')!.children[0]
+    const nestedObject = findByClass(objectField.children, 'objectAsField')!.children[0]!
     const fieldNames = getValidFields(documentLevelArticle.config.objectAsField)
     const foundFieldNames = Array.from(nestedObject.children).map((child) => child.className)
     expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
@@ -51,7 +51,7 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
   })
 
   test('Nested object in an object contains accurate values -- document level', () => {
-    const nestedObject = findByClass(objectField.children, 'objectAsField')!.children[0]
+    const nestedObject = findByClass(objectField.children, 'objectAsField')!.children[0]!
     const title = documentLevelArticle.config.objectAsField.title
     const blockText = toPlainText(documentLevelArticle.config.objectAsField.content)
 

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/documentLevelSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/documentLevelSerialization.test.ts
@@ -80,7 +80,7 @@ describe('Presence and accuracy of fields in vanilla deserialization -- arrays',
     const fieldNames = getValidFields(
       documentLevelArticle.content.find(
         (block: Record<string, any>) => block._type === 'objectField',
-      ),
+      )!,
     )
     const foundFieldNames = Array.from(objectInArray!.children).map((child) => child.className)
     expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
@@ -91,11 +91,11 @@ describe('Presence and accuracy of fields in vanilla deserialization -- arrays',
     const nestedObject = findByClass(objectInArray!.children, 'objectAsField')
     const title = documentLevelArticle.content.find(
       (block: Record<string, any>) => block._type === 'objectField',
-    ).objectAsField.title
+    )!.objectAsField!.title
     const blockText = toPlainText(
       documentLevelArticle.content.find(
         (block: Record<string, any>) => block._type === 'objectField',
-      ).objectAsField.content,
+      )!.objectAsField!.content,
     ).trim()
     expect(nestedObject?.innerHTML).toContain(title)
     expect(nestedObject?.innerHTML).toContain(blockText)

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/fieldLevelSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/fieldLevelSerialization.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {describe, expect, test} from 'vitest'
 
 import {getSerialized, getValidFields, toPlainText} from '../helpers'
@@ -88,7 +88,7 @@ describe('Presence and accurancy of fields in "vanilla" deserialization -- array
     const fieldNames = getValidFields(
       fieldLevelArticle.content.en.find(
         (block: Record<string, any>) => block._type === 'objectField',
-      ),
+      )!,
     )
     const foundFieldNames = Array.from(objectInArray!.children).map((child) => child.className)
     expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
@@ -99,11 +99,11 @@ describe('Presence and accurancy of fields in "vanilla" deserialization -- array
     const nestedObject = findByClass(objectInArray!.children, 'objectAsField')
     const title = fieldLevelArticle.content.en.find(
       (block: Record<string, any>) => block._type === 'objectField',
-    ).objectAsField.title
+    )!.objectAsField!.title
     const blockText = toPlainText(
       fieldLevelArticle.content.en.find(
         (block: Record<string, any>) => block._type === 'objectField',
-      ).objectAsField.content,
+      )!.objectAsField!.content,
     ).trim()
     expect(nestedObject?.innerHTML).toContain(title)
     expect(nestedObject?.innerHTML).toContain(blockText)
@@ -116,9 +116,13 @@ test('Nested locale fields make it to serialization, but only base lang', () => 
   const nestedDocTree = getHTMLNode(nestedSerialized).body.children[0]
   const slices = findByClass(nestedDocTree.children, 'slices')
   const pageFields = findByClass(nestedDocTree.children, 'pageFields')
-  expect(slices?.innerHTML).toContain(nestedLanguageFields.slices[0].en[0].children[0].text)
+  expect(slices?.innerHTML).toContain(
+    (nestedLanguageFields as any).slices[0].en[0].children[0].text,
+  )
   expect(pageFields?.innerHTML).toContain(nestedLanguageFields.pageFields.name.en)
-  expect(slices?.innerHTML).not.toContain(nestedLanguageFields.slices[0].fr_FR[0].children[0].text)
+  expect(slices?.innerHTML).not.toContain(
+    (nestedLanguageFields as any).slices[0].fr_FR[0].children[0].text,
+  )
   expect(pageFields?.innerHTML).not.toContain(nestedLanguageFields.pageFields.name.fr_FR)
 })
 

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/fieldLevelSerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/fieldLevelSerialization.test.ts
@@ -5,7 +5,7 @@ import {getSerialized, getValidFields, toPlainText} from '../helpers'
 import {fieldLevelArticle, findByClass, getHTMLNode, nestedLanguageFields} from './utils'
 
 const serialized = getSerialized(fieldLevelArticle, 'field')
-const docTree = getHTMLNode(serialized).body.children[0]
+const docTree = getHTMLNode(serialized).body.children[0]!
 
 test('Global test of working field-level functionality and snapshot match', () => {
   expect(serialized).toMatchSnapshot()
@@ -40,7 +40,7 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
   test('Nested object in object contains all serializable fields -- field Level', () => {
     const nestedObject = findByClass(objectField!.children, 'objectAsField')!.children[0]
     const fieldNames = getValidFields(fieldLevelArticle.config.en.objectAsField)
-    const foundFieldNames = Array.from(nestedObject.children).map((child) => child.className)
+    const foundFieldNames = Array.from(nestedObject!.children).map((child) => child.className)
     expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
   })
 
@@ -57,8 +57,8 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
     const title = fieldLevelArticle.config.en.objectAsField.title
     const blockText = toPlainText(fieldLevelArticle.config.en.objectAsField.content)
 
-    expect(nestedObject.innerHTML).toContain(title)
-    expect(nestedObject.innerHTML).toContain(blockText)
+    expect(nestedObject!.innerHTML).toContain(title)
+    expect(nestedObject!.innerHTML).toContain(blockText)
   })
 })
 
@@ -113,7 +113,7 @@ describe('Presence and accurancy of fields in "vanilla" deserialization -- array
 test('Nested locale fields make it to serialization, but only base lang', () => {
   const nestedLocales = {...fieldLevelArticle, ...nestedLanguageFields}
   const nestedSerialized = getSerialized(nestedLocales, 'field')
-  const nestedDocTree = getHTMLNode(nestedSerialized).body.children[0]
+  const nestedDocTree = getHTMLNode(nestedSerialized).body.children[0]!
   const slices = findByClass(nestedDocTree.children, 'slices')
   const pageFields = findByClass(nestedDocTree.children, 'pageFields')
   expect(slices?.innerHTML).toContain(

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
@@ -5,7 +5,7 @@ import {getI18nArrayItem, getSerialized, getValidFields, toPlainText} from '../h
 import {findByClass, getHTMLNode, internationalizedArrayArticle} from './utils'
 
 const serialized = getSerialized(internationalizedArrayArticle, 'internationalizedArray')
-const docTree = getHTMLNode(serialized).body.children[0]
+const docTree = getHTMLNode(serialized).body.children[0]!
 
 const findById = (children: HTMLCollection, id: string): Element | undefined => {
   return Array.from(children).find((node) => {
@@ -56,7 +56,7 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
   test('Nested object in object contains all serializable fields -- internationalized array', () => {
     const nestedObject = findByClass(objectField!.children, 'objectAsField')!.children[0]
     const fieldNames = getValidFields(origObjectField.objectAsField)
-    const foundFieldNames = Array.from(nestedObject.children).map((child) => child.className)
+    const foundFieldNames = Array.from(nestedObject!.children).map((child) => child.className)
     expect(foundFieldNames.sort()).toEqual(fieldNames.sort())
   })
 
@@ -73,8 +73,8 @@ describe('Presence and accuracy of fields in "vanilla" deserialization -- object
     const title = origObjectField.objectAsField.title
     const blockText = toPlainText(origObjectField.objectAsField.content)
 
-    expect(nestedObject.innerHTML).toContain(title)
-    expect(nestedObject.innerHTML).toContain(blockText)
+    expect(nestedObject!.innerHTML).toContain(title)
+    expect(nestedObject!.innerHTML).toContain(blockText)
   })
 })
 

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
@@ -128,7 +128,7 @@ describe('Presence and accurancy of fields in "vanilla" deserialization -- array
 //works, but requires another schema declaration. resolve later.
 test('Nested locale fields make it to serialization, but only base lang', () => {
   const slices = findByClass(docTree.children, 'slices')?.children[0]
-  const origSlices: any = internationalizedArrayArticle.slices[0].content
+  const origSlices: any = internationalizedArrayArticle.slices[0]!.content
   const engSlice = getI18nArrayItem(origSlices, 'en').value
   const frenchSlice = getI18nArrayItem(origSlices, 'fr_FR').value
   // @ts-expect-error i18n array item value is typed as unknown

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArraySerialization.test.ts
@@ -1,4 +1,4 @@
-import {PortableTextBlock} from 'sanity'
+import type {PortableTextBlock} from 'sanity'
 import {expect, test, describe} from 'vitest'
 
 import {getI18nArrayItem, getSerialized, getValidFields, toPlainText} from '../helpers'
@@ -20,11 +20,11 @@ test('Global test of working internationalized array-level functionality and sna
 test('String and text types get serialized correctly at top-level -- internationalized array', () => {
   const titleObj = findByClass(docTree.children, 'title')
   const englishTitleHTML = findById(titleObj!.children, 'en')
-  const englishTitleValueHTML = findByClass(englishTitleHTML?.children, 'value')
+  const englishTitleValueHTML = findByClass(englishTitleHTML!.children, 'value')
 
   const snippetObj = findByClass(docTree.children, 'snippet')
   const englishSnippetHTML = findById(snippetObj!.children, 'en')
-  const englishSnippetValueHTML = findByClass(englishSnippetHTML?.children, 'value')
+  const englishSnippetValueHTML = findByClass(englishSnippetHTML!.children, 'value')
 
   expect(englishTitleValueHTML?.innerHTML).toEqual(
     getI18nArrayItem(internationalizedArrayArticle.title, 'en')?.value,
@@ -128,11 +128,11 @@ describe('Presence and accurancy of fields in "vanilla" deserialization -- array
 //works, but requires another schema declaration. resolve later.
 test('Nested locale fields make it to serialization, but only base lang', () => {
   const slices = findByClass(docTree.children, 'slices')?.children[0]
-  const origSlices = internationalizedArrayArticle.slices[0].content
+  const origSlices: any = internationalizedArrayArticle.slices[0].content
   const engSlice = getI18nArrayItem(origSlices, 'en').value
   const frenchSlice = getI18nArrayItem(origSlices, 'fr_FR').value
-  //@ts-expect-error
+  // @ts-expect-error i18n array item value is typed as unknown
   expect(slices?.innerHTML).toContain(engSlice[0]!.children![0].text)
-  //@ts-expect-error
+  // @ts-expect-error i18n array item value is typed as unknown
   expect(slices?.innerHTML).not.toContain(frenchSlice[0]!.children![0].text)
 })

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArrayV5.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArrayV5.test.ts
@@ -19,7 +19,7 @@ const toV5 = (value: any): any => {
       value.length > 0 &&
       typeof value[0] === 'object' &&
       value[0] !== null &&
-      /^internationalizedArray/.test(value[0]._type)
+      value[0]._type.startsWith('internationalizedArray')
 
     return value.map((item) => {
       if (isI18nArray && item && typeof item === 'object') {
@@ -46,7 +46,7 @@ describe('Serialization supports v5 (language field) internationalized arrays', 
   test('Base language string fields are exported for v5 data', () => {
     const titleObj = findByClass(docTree.children, 'title')
     const englishTitleHTML = findById(titleObj!.children, 'en')
-    const englishTitleValueHTML = findByClass(englishTitleHTML?.children, 'value')
+    const englishTitleValueHTML = findByClass(englishTitleHTML!.children, 'value')
 
     expect(englishTitleValueHTML?.innerHTML).toEqual(
       getI18nArrayItem(internationalizedArrayArticle.title, 'en')?.value,

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArrayV5.test.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/internationalizedArrayV5.test.ts
@@ -41,7 +41,7 @@ const v5Article = toV5(internationalizedArrayArticle)
 
 describe('Serialization supports v5 (language field) internationalized arrays', () => {
   const serialized = getSerialized(v5Article, 'internationalizedArray')
-  const docTree = getHTMLNode(serialized).body.children[0]
+  const docTree = getHTMLNode(serialized).body.children[0]!
 
   test('Base language string fields are exported for v5 data', () => {
     const titleObj = findByClass(docTree.children, 'title')

--- a/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/utils.ts
+++ b/plugins/sanity-naive-html-serializer/test/BaseDocumentSerializer/utils.ts
@@ -1,4 +1,4 @@
-import {SerializedDocument} from '../../src'
+import type {SerializedDocument} from '../../src'
 import annotationAndInlineBlocks from '../__fixtures__/annotationAndInlineBlocks.json'
 import documentLevelArticle from '../__fixtures__/documentLevelArticle.json'
 import fieldLevelArticle from '../__fixtures__/fieldLevelArticle.json'

--- a/plugins/sanity-naive-html-serializer/test/global.setup.ts
+++ b/plugins/sanity-naive-html-serializer/test/global.setup.ts
@@ -1,4 +1,4 @@
-import {PortableTextTextBlock} from 'sanity'
+import type {PortableTextTextBlock} from 'sanity'
 import {vi} from 'vitest'
 
 let mockTestKey = 0

--- a/plugins/sanity-naive-html-serializer/test/helpers.ts
+++ b/plugins/sanity-naive-html-serializer/test/helpers.ts
@@ -7,7 +7,7 @@ import {
   customDeserializers,
   customBlockDeserializers,
 } from '../src/BaseSerializationConfig'
-import {SerializedDocument, TranslationLevel} from '../src/types'
+import type {SerializedDocument, TranslationLevel} from '../src/types'
 import schema from './__fixtures__/schema'
 
 export const getSerialized = (

--- a/plugins/sanity-naive-html-serializer/test/helpers.ts
+++ b/plugins/sanity-naive-html-serializer/test/helpers.ts
@@ -1,5 +1,5 @@
 import clone from 'just-clone'
-import {PortableTextBlock, SanityDocument, TypedObject} from 'sanity'
+import type {PortableTextBlock, SanityDocument, TypedObject} from 'sanity'
 
 import {BaseDocumentSerializer, BaseDocumentDeserializer} from '../src'
 import {

--- a/plugins/sanity-naive-html-serializer/test/helpers.ts
+++ b/plugins/sanity-naive-html-serializer/test/helpers.ts
@@ -88,7 +88,7 @@ export const addedCustomSerializers = tempSerializers
 
 export const addedDeserializerTypes = {
   objectField: (html: HTMLElement): TypedObject => {
-    const title = html.innerHTML.split(':')[1].replace(/'/g, '').trim()
+    const title = html.innerHTML.split(':')[1]!.replace(/'/g, '').trim()
     const _type = html.className
     const _key = html.id
     return {title, _type, _key}
@@ -111,7 +111,7 @@ export const addedBlockDeserializers = [
         return undefined
       }
 
-      const title = el.innerHTML.split(':')[1].replace(/'/g, '').trim()
+      const title = el.innerHTML.split(':')[1]!.replace(/'/g, '').trim()
       const _type = el.className
       const _key = el.id
 

--- a/plugins/sanity-naive-html-serializer/tsconfig.json
+++ b/plugins/sanity-naive-html-serializer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@repo/tsconfig/check.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "noPropertyAccessFromIndexSignature": false,

--- a/plugins/sanity-naive-html-serializer/tsconfig.json
+++ b/plugins/sanity-naive-html-serializer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@repo/tsconfig/check.json",
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["dist", "node_modules", "test"],
+  "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "noPropertyAccessFromIndexSignature": false,
     "resolveJsonModule": true,


### PR DESCRIPTION
Include test files in linting/type-checking and update tests to satisfy stricter TypeScript checks. Removed the test ignore from .oxlintrc.json and stopped excluding tests in the plugin tsconfig; converted several imports to type-only, added non-null assertions (!), explicit casts/anys and small code tweaks (e.g. .startsWith usage, minor ts-expect-error comments) across many serializer/deserializer/merger tests to resolve type errors.
