### PR TITLE
chore: remove @types/node from publicHoistPattern

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,8 +109,3 @@ allowBuilds:
 publicHoistPattern:
   # Allows setting vite/client in dev/test-studio/tsconfig.json without installing vite
   - 'vite'
-  # Keep @types/node resolvable for every package's d.ts build regardless of how
-  # the dependency graph hoists it (the recast-based pkg-utils v7/v8 toolchain used
-  # by sanity-plugin-media/-mux-input needs the NodeJS/process globals during
-  # api-extractor type extraction).
-  - '@types/node'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `@types/node` entry from `publicHoistPattern` in `pnpm-workspace.yaml`. The `vite` hoist is unchanged.

## Why this is safe now

The hoist was added during the `sanity-plugin-media` / `sanity-plugin-mux-input` migration to keep `@types/node` resolvable for recast-based `@sanity/pkg-utils` v7/v8 d.ts extraction (api-extractor). That toolchain is no longer in use:

- All plugins now build with `@sanity/pkg-utils` v10, which uses rolldown for type generation
- The workspace already pins `@types/node` via the catalog override (`'@types/node': 'catalog:'`)
- Packages that need Node types declare `@types/node` as a devDependency

## Verification

- `pnpm install` — clean
- `pnpm --filter sanity-plugin-media --filter sanity-plugin-mux-input build` — passes
- `pnpm turbo build --filter='./plugins/**' --filter='./packages/**'` — all 49 packages pass
- `pnpm lint` — passes

`@types/node` still resolves normally from plugin packages through the dependency graph (e.g. via `@sanity/pkg-utils`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589ec391-8ce4-43ee-8c7e-1cdaa76711fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589ec391-8ce4-43ee-8c7e-1cdaa76711fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

