### PR TITLE
chore: remove obsolete recast packageExtensions workaround

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,6 @@ overrides:
   sanity: ^6.1.0
   styled-components: npm:@sanity/styled-components@latest
 
-packageExtensionsChecksum: sha256-QdsDQ365DNzG5j0yKBdbmCG5qJluk5hWMfq/xNOQOao=
-
 patchedDependencies:
   '@bynder/compact-view':
     hash: c71de21a98b99e126cf6a513070404932603d4254f3614440c3a5f5ee7e7e8a6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,16 +70,6 @@ overrides:
   sanity: 'catalog:'
   styled-components: npm:@sanity/styled-components@latest
 
-packageExtensions:
-  # recast (bundled by @sanity/pkg-utils for d.ts generation) lazily requires
-  # @babel/parser without declaring it, so it only resolves when @babel/parser
-  # happens to be hoisted. Declare it as a dependency so the d.ts build works
-  # under any hoisting configuration. (sanity-plugin-media/-mux-input build with
-  # the recast-based pkg-utils v7/v8 toolchain.)
-  recast:
-    dependencies:
-      '@babel/parser': ^7.28.0
-
 patchedDependencies:
   '@bynder/compact-view': patches/@bynder__compact-view.patch
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `packageExtensions.recast` block in `pnpm-workspace.yaml` can be removed — it is now dead configuration.

```yaml
packageExtensions:
  recast:
    dependencies:
      '@babel/parser': ^7.28.0
```

### Why it was added

It was introduced in `61e7ed11` to fix d.ts builds for `sanity-plugin-media` and `sanity-plugin-mux-input`. At that time those plugins resolved `@sanity/pkg-utils@7.x`/`8.x`, whose toolchain pulled in `recast@0.23.11`. `recast` lazily `require`s `@babel/parser` without declaring it, so the d.ts build only worked when `@babel/parser` happened to be hoisted within reach. The extension forced `@babel/parser` into `recast`'s own scope.

### Why it can go now

- Both plugins (and the catalog) now use `@sanity/pkg-utils@10.5.7`, whose d.ts pipeline switched to `rolldown-plugin-dts` + `@microsoft/api-extractor`. Its `package.json` no longer depends on `recast`.
- `recast` is **absent** from the resolved graph: `0` occurrences in `pnpm-lock.yaml` and no `recast` directory in `node_modules`. The only remaining `@sanity/pkg-utils` references below v10 are inert test fixtures under `plugin-kit/test/fixtures/` that aren't part of the install graph.
- pnpm's `packageExtensions` only apply to packages that exist in the tree, so this entry now applies to nothing.

### Effect of removal

Re-running `pnpm install` after deleting the block changes the resolved dependency tree by **nothing** — the only lockfile delta is dropping the now-unused `packageExtensionsChecksum` line. No published package's dependencies or output change, so no changeset is included.

## Testing

- ✅ `pnpm install` — only removes `packageExtensionsChecksum`; `recast` count in lockfile stays `0`, no other resolution churn.
- ✅ `pnpm turbo build --filter=sanity-plugin-media --filter=sanity-plugin-mux-input --force` — both d.ts (`--strict --check`) builds pass (the originally affected plugins).
- ✅ `pnpm turbo build --filter='./plugins/**' --force` — all 48 plugin packages build (0 cached), confirming no monorepo-wide d.ts regression.
- ⚠️ `pnpm build` (full) — fails only on the pre-existing, unrelated `@repo/generators#build` (`Failed to import module "unrun"`, an optional `tsdown` peer dep not installed in this environment). Verified the identical failure on pristine `main`, so it is not caused by this change.

> Note: this PR intentionally leaves the separate `publicHoistPattern: '@types/node'` entry untouched (it has a similar stale comment but is a different mechanism and out of scope for this request).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d72b1ba2-c523-47cd-b20b-9ac1586698d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d72b1ba2-c523-47cd-b20b-9ac1586698d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

