### PR TITLE
fix(vercel-widget): remove direct javascript-time-ago dependency

### DIFF
--- a/.changeset/vercel-widget-javascript-time-ago.md
+++ b/.changeset/vercel-widget-javascript-time-ago.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-vercel": patch
+---
+
+Remove direct `javascript-time-ago` dependency now that `react-time-ago` bundles it

--- a/plugins/sanity-plugin-dashboard-widget-vercel/package.json
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/package.json
@@ -51,7 +51,6 @@
     "@sanity/uuid": "catalog:",
     "@tanstack/react-query": "^5.67.2",
     "@xstate/react": "^6.1.0",
-    "javascript-time-ago": "^2.6.4",
     "object-hash": "3.0.0",
     "react-hook-form": "catalog:",
     "react-time-ago": "^7.4.4",

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployment/index.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployment/index.tsx
@@ -1,6 +1,8 @@
 import {LinkIcon} from '@sanity/icons'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
+// oxlint-disable-next-line import/no-unassigned-import
+import 'react-time-ago/locale/en'
 import ReactTimeAgo from 'react-time-ago'
 
 import {type Vercel} from '../../types'

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
@@ -1,6 +1,4 @@
 import {type DashboardWidget, type LayoutConfig} from '@sanity/dashboard'
-// oxlint-disable-next-line import/no-unassigned-import
-import 'react-time-ago/locale/en'
 
 import Widget from './app'
 

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
@@ -1,11 +1,8 @@
 import {type DashboardWidget, type LayoutConfig} from '@sanity/dashboard'
-// Initialize `javascript-time-ago` locale (required for react-time-ago)
-import TimeAgo from 'javascript-time-ago'
-import en from 'javascript-time-ago/locale/en'
+// oxlint-disable-next-line import/no-unassigned-import
+import 'react-time-ago/locale/en'
 
 import Widget from './app'
-
-TimeAgo.addDefaultLocale(en)
 
 export function vercelWidget(config: {layout?: LayoutConfig} = {}): DashboardWidget {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2103,9 +2103,6 @@ importers:
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1)
-      javascript-time-ago:
-        specifier: ^2.6.4
-        version: 2.6.4
       object-hash:
         specifier: 3.0.0
         version: 3.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`react-time-ago` 7.4.0 now declares `javascript-time-ago` as a direct dependency instead of a peer dependency, and locale setup is exposed via `react-time-ago/locale/*` side-effect imports.

This PR removes the redundant direct `javascript-time-ago` dependency from `sanity-plugin-dashboard-widget-vercel` and updates locale initialization accordingly.

## Changes

- Removed `javascript-time-ago` from `sanity-plugin-dashboard-widget-vercel` dependencies
- Replaced manual `TimeAgo.addDefaultLocale()` setup with `import 'react-time-ago/locale/en'`
- Updated `pnpm-lock.yaml`

## Testing

- [x] `pnpm lint`
- [x] `pnpm build --filter sanity-plugin-dashboard-widget-vercel`
- [x] `pnpm exec vitest run` (in plugin directory)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14d3e5f3-e899-4298-ad03-c8f3b4cc5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14d3e5f3-e899-4298-ad03-c8f3b4cc5a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

