### PR TITLE
fix(google-maps-input): guard map rendering against empty geopoint values

### DIFF
--- a/.changeset/fix-google-maps-empty-geopoint-marker.md
+++ b/.changeset/fix-google-maps-empty-geopoint-marker.md
@@ -1,0 +1,5 @@
+---
+"@sanity/google-maps-input": patch
+---
+
+Fix `InvalidValueError` thrown when editing an empty geopoint (e.g. a newly added array item). Map markers, circles, the map center and the radius preview are now only rendered once the value has finite `lat`/`lng` coordinates, so adding a new item to an array of geopoints no longer crashes the input.

--- a/dev/test-studio/sanity.types.ts
+++ b/dev/test-studio/sanity.types.ts
@@ -922,6 +922,11 @@ export type GoogleMapsTest = {
       _key: string
     } & Geopoint
   >
+  serviceAreas?: Array<
+    {
+      _key: string
+    } & GeopointRadius
+  >
 }
 
 export type GeopointRadius = {

--- a/dev/test-studio/schema.json
+++ b/dev/test-studio/schema.json
@@ -4966,6 +4966,28 @@
           }
         },
         "optional": true
+      },
+      "serviceAreas": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "geopointRadius"
+            }
+          }
+        },
+        "optional": true
       }
     }
   },

--- a/dev/test-studio/src/google-maps-input/index.tsx
+++ b/dev/test-studio/src/google-maps-input/index.tsx
@@ -34,6 +34,13 @@ const googleMapsTest = defineType({
       type: 'array',
       of: [{type: 'geopoint', components: {diff: GeopointDiff}}],
     },
+    {
+      name: 'serviceAreas',
+      title: 'Service areas',
+      description: 'An array of geopointRadius items',
+      type: 'array',
+      of: [{type: 'geopointRadius'}],
+    },
   ],
 })
 

--- a/plugins/@sanity/google-maps-input/src/input/GeopointInput.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointInput.tsx
@@ -7,6 +7,7 @@ import {type ObjectInputProps, set, setIfMissing, unset, ChangeIndicator, type P
 import {MapApiGate} from '../map/MapApiGate'
 import {getGeopointStaticMapUrl} from '../map/staticMapUrl'
 import type {Geopoint, GoogleMapsInputConfig, LatLng} from '../types'
+import {getValidLatLng} from '../utils'
 import {MissingApiKeyCard} from './ApiKeyMessages'
 import {DialogInnerContainer} from './GeopointInput.styles'
 import {GeopointSelect} from './GeopointSelect'
@@ -82,11 +83,15 @@ export function GeopointInput(props: GeopointInputProps) {
     return <MissingApiKeyCard typeTitle="Geopoint" />
   }
 
-  const staticImageUrl = value ? getGeopointStaticMapUrl(value, config.apiKey) : null
+  // A geopoint is only renderable on a map once it has finite coordinates. A
+  // freshly added array item is `{_type, _key}` with no lat/lng yet, so gate the
+  // map preview and "edit" affordances on having a real location.
+  const position = getValidLatLng(value)
+  const staticImageUrl = position ? getGeopointStaticMapUrl(position, config.apiKey) : null
 
   return (
     <Stack gap={3}>
-      {value && staticImageUrl && (
+      {staticImageUrl && (
         <ChangeIndicator path={path} isChanged={changed} hasFocus={!!focused}>
           <StaticMapPreview
             url={staticImageUrl}
@@ -97,21 +102,21 @@ export function GeopointInput(props: GeopointInputProps) {
       )}
 
       <Box>
-        <Grid gridTemplateColumns={value ? 2 : 1} gap={3}>
+        <Grid gridTemplateColumns={position ? 2 : 1} gap={3}>
           <Button
             aria-describedby={ariaDescribedBy}
             disabled={readOnly}
-            icon={value && EditIcon}
+            icon={position ? EditIcon : undefined}
             id={id}
             mode="ghost"
             onClick={handleToggleModal}
             onFocus={handleFocus}
             padding={3}
             ref={inputRef}
-            text={value ? 'Edit' : 'Set location'}
+            text={position ? 'Edit' : 'Set location'}
           />
 
-          {value && (
+          {position && (
             <Button
               disabled={readOnly}
               icon={TrashIcon}

--- a/plugins/@sanity/google-maps-input/src/input/GeopointRadiusInput.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointRadiusInput.tsx
@@ -7,6 +7,7 @@ import {type ObjectInputProps, set, setIfMissing, unset, ChangeIndicator, type P
 import {MapApiGate} from '../map/MapApiGate'
 import {getGeopointRadiusStaticMapUrl} from '../map/staticMapUrl'
 import type {GeopointRadius, GoogleMapsInputConfig, LatLng} from '../types'
+import {getValidLatLng} from '../utils'
 import {MissingApiKeyCard} from './ApiKeyMessages'
 import {DialogInnerContainer} from './GeopointInput.styles'
 import {GeopointRadiusSelect} from './GeopointRadiusSelect'
@@ -93,11 +94,21 @@ export function GeopointRadiusInput(props: GeopointRadiusInputProps) {
     return <MissingApiKeyCard typeTitle="Geopoint Radius" />
   }
 
-  const staticImageUrl = value ? getGeopointRadiusStaticMapUrl(value, config.apiKey) : null
+  // A geopoint is only renderable on a map once it has finite coordinates. A
+  // freshly added array item is `{_type, _key}` with no lat/lng yet, so gate the
+  // map preview, radius control and "edit" affordances on having a real location.
+  const position = getValidLatLng(value)
+  const radius = Math.round(value?.radius || config.defaultRadius || 1000)
+  const staticImageUrl = position
+    ? getGeopointRadiusStaticMapUrl(
+        {lat: position.lat, lng: position.lng, radius: value?.radius ?? 0},
+        config.apiKey,
+      )
+    : null
 
   return (
     <Stack gap={3}>
-      {value && staticImageUrl && (
+      {staticImageUrl && (
         <ChangeIndicator path={path} isChanged={changed} hasFocus={!!focused}>
           <StaticMapPreview
             url={staticImageUrl}
@@ -107,12 +118,12 @@ export function GeopointRadiusInput(props: GeopointRadiusInputProps) {
         </ChangeIndicator>
       )}
 
-      {value && (
+      {position && (
         <Stack gap={2}>
           <Label>Radius (meters)</Label>
           <TextInput
             type="number"
-            value={Math.round(value.radius || config.defaultRadius || 1000)}
+            value={radius}
             onChange={handleRadiusChange}
             disabled={readOnly}
             min={1}
@@ -123,21 +134,21 @@ export function GeopointRadiusInput(props: GeopointRadiusInputProps) {
       )}
 
       <Box>
-        <Grid gridTemplateColumns={value ? 2 : 1} gap={3}>
+        <Grid gridTemplateColumns={position ? 2 : 1} gap={3}>
           <Button
             aria-describedby={ariaDescribedBy}
             disabled={readOnly}
-            icon={value && EditIcon}
+            icon={position ? EditIcon : undefined}
             id={id}
             mode="ghost"
             onClick={handleToggleModal}
             onFocus={handleFocus}
             padding={3}
             ref={inputRef}
-            text={value ? 'Edit' : 'Set location and radius'}
+            text={position ? 'Edit' : 'Set location and radius'}
           />
 
-          {value && (
+          {position && (
             <Button
               disabled={readOnly}
               icon={TrashIcon}

--- a/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
@@ -11,6 +11,7 @@ import {useCallback} from 'react'
 import {MAP_ID} from '../map/constants'
 import {SearchInput} from '../map/SearchInput'
 import type {GeopointRadius, LatLng} from '../types'
+import {getValidLatLng} from '../utils'
 
 const fallbackLatLng: LatLng = {lat: 40.7058254, lng: -74.1180863}
 const defaultMapLocation: LatLng = {lng: 10.74609, lat: 59.91273}
@@ -30,10 +31,11 @@ export function GeopointRadiusSelect({
   defaultRadiusZoom = 12,
   defaultRadius = 1000,
 }: SelectProps) {
+  const position = getValidLatLng(value)
   const center: LatLng = {
     ...fallbackLatLng,
     ...defaultLocation,
-    ...(value ? {lat: value.lat, lng: value.lng} : {}),
+    ...(position ?? {}),
   }
   const currentRadius = value?.radius ?? defaultRadius
 
@@ -99,16 +101,16 @@ export function GeopointRadiusSelect({
       <MapControl position={ControlPosition.TOP_RIGHT}>
         <SearchInput onSelect={handleSelect} />
       </MapControl>
-      {value && (
+      {position && (
         <>
           <AdvancedMarker
-            position={{lat: value.lat, lng: value.lng}}
+            position={position}
             draggable={Boolean(onChange)}
             onDragEnd={handleMarkerDragEnd}
           />
           <Circle
-            center={{lat: value.lat, lng: value.lng}}
-            radius={value.radius}
+            center={position}
+            radius={currentRadius}
             editable={Boolean(onChange)}
             draggable={Boolean(onChange)}
             fillColor="#4285F4"

--- a/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointRadiusSelect.tsx
@@ -35,7 +35,7 @@ export function GeopointRadiusSelect({
   const center: LatLng = {
     ...fallbackLatLng,
     ...defaultLocation,
-    ...(position ?? {}),
+    ...position,
   }
   const currentRadius = value?.radius ?? defaultRadius
 

--- a/plugins/@sanity/google-maps-input/src/input/GeopointSelect.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointSelect.tsx
@@ -10,6 +10,7 @@ import {useCallback} from 'react'
 import {MAP_ID} from '../map/constants'
 import {SearchInput} from '../map/SearchInput'
 import type {Geopoint, LatLng} from '../types'
+import {getValidLatLng} from '../utils'
 
 const fallbackLatLng: LatLng = {lat: 40.7058254, lng: -74.1180863}
 const defaultMapLocation: LatLng = {lng: 10.74609, lat: 59.91273}
@@ -27,10 +28,11 @@ export function GeopointSelect({
   defaultLocation = defaultMapLocation,
   defaultZoom = 8,
 }: SelectProps) {
+  const position = getValidLatLng(value)
   const center: LatLng = {
     ...fallbackLatLng,
     ...defaultLocation,
-    ...(value ? {lat: value.lat, lng: value.lng} : {}),
+    ...(position ?? {}),
   }
 
   const handleMapClick = useCallback(
@@ -72,9 +74,9 @@ export function GeopointSelect({
       <MapControl position={ControlPosition.TOP_RIGHT}>
         <SearchInput onSelect={handleSelect} />
       </MapControl>
-      {value && (
+      {position && (
         <AdvancedMarker
-          position={{lat: value.lat, lng: value.lng}}
+          position={position}
           draggable={Boolean(onChange)}
           onDragEnd={handleMarkerDragEnd}
         />

--- a/plugins/@sanity/google-maps-input/src/input/GeopointSelect.tsx
+++ b/plugins/@sanity/google-maps-input/src/input/GeopointSelect.tsx
@@ -32,7 +32,7 @@ export function GeopointSelect({
   const center: LatLng = {
     ...fallbackLatLng,
     ...defaultLocation,
-    ...(position ?? {}),
+    ...position,
   }
 
   const handleMapClick = useCallback(

--- a/plugins/@sanity/google-maps-input/src/plugin.tsx
+++ b/plugins/@sanity/google-maps-input/src/plugin.tsx
@@ -62,9 +62,13 @@ export const googleMapsInput = definePlugin<GoogleMapsInputConfig>((config) => {
               lng: 'lng',
               radius: 'radius',
             },
-            prepare({lat, lng, radius}: {lat: number; lng: number; radius: number}) {
+            prepare({lat, lng, radius}: {lat?: number; lng?: number; radius?: number}) {
+              const title =
+                typeof lat === 'number' && typeof lng === 'number'
+                  ? `${lat.toFixed(6)}, ${lng.toFixed(6)}`
+                  : 'No location set'
               return {
-                title: `${lat.toFixed(6)}, ${lng.toFixed(6)}`,
+                title,
                 subtitle: radius ? `Radius: ${radius}m` : 'No radius set',
               }
             },

--- a/plugins/@sanity/google-maps-input/src/utils.ts
+++ b/plugins/@sanity/google-maps-input/src/utils.ts
@@ -1,0 +1,23 @@
+import type {LatLng} from './types'
+
+/**
+ * Geopoint values can exist in a partial/empty state — a freshly added array
+ * item is just `{_type, _key}` with no coordinates yet. Passing such a value's
+ * `lat`/`lng` (which are `undefined`, or could be `NaN`/`Infinity`) to Google
+ * Maps markers, circles or the map center throws an `InvalidValueError`. Use
+ * this to extract a usable `LatLng` only when both coordinates are finite
+ * numbers, and `null` otherwise.
+ */
+export function getValidLatLng(value: {lat?: number; lng?: number} | undefined): LatLng | null {
+  const lat = value?.lat
+  const lng = value?.lng
+  if (
+    typeof lat === 'number' &&
+    Number.isFinite(lat) &&
+    typeof lng === 'number' &&
+    Number.isFinite(lng)
+  ) {
+    return {lat, lng}
+  }
+  return null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Adding a new item to an array of geopoints (or `geopointRadius`) crashes the input with:

```
<gmp-advanced-marker>: Cannot set property "position" to [object Object]: not an instance of LatLngAltitude; and not an instance of LatLng; and in property lat: not a number
```

A freshly added array item is initialized to `{_type, _key}` with **no** `lat`/`lng`. That partial value is truthy, so the components rendered an `AdvancedMarker`/`Circle` with `position={{lat: undefined, lng: undefined}}`, set the map center to undefined coordinates (a second `setCenter` `InvalidValueError`), and the `geopointRadius` preview crashed in `prepare` calling `lat.toFixed()` ("Invalid Preview Config").

## Fix

- Add a small `getValidLatLng()` helper that returns a `LatLng` only when both coordinates are finite numbers, and `null` otherwise.
- `GeopointSelect` / `GeopointRadiusSelect`: render the marker, circle and map-center override only for a valid position.
- `GeopointInput` / `GeopointRadiusInput`: render the static map preview, radius control and "Edit"/"Remove" affordances only when there's a real location; empty items now show a plain "Set location" button instead of a broken preview.
- `geopointRadius` preview `prepare` tolerates missing coordinates ("No location set").
- Test studio: add a `serviceAreas` (`geopointRadius`) array field so the array-editing path is covered for both input types (and regenerated `schema.json` / `sanity.types.ts`).

## Walkthrough

Demo — adding items to both arrays no longer errors; placing a location works (marker for geopoints, marker + radius circle for `geopointRadius`):

[google_maps_array_geopoint_add_item_no_error.mp4](https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_maps_array_geopoint_add_item_no_error.mp4)

Before (the reported crash in the console):

[Before: gmp-advanced-marker InvalidValueError](https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_gmp_marker_error_console.webp)

After — an empty array item shows a "Set location" button instead of an error card:

[After: empty geopoint shows Set location button](https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_empty_geopoint_set_location.webp)

After — `geopointRadius` array item with marker + radius circle, and a clean console:

[After: geopointRadius marker and radius circle](https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_geopointradius_marker_circle.webp)
[After: console with no InvalidValueError](https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_console_no_errors.webp)

## Testing

- Reproduced the crash before the fix for both the `Locations` (geopoint) and `Service areas` (geopointRadius) arrays.
- Verified after the fix that adding + editing empty array items no longer errors, and that placing/saving a location still works.
- `pnpm lint`, `pnpm build`, `pnpm test run` all pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30b83e1a-09f3-47be-8021-4e21a93fba1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30b83e1a-09f3-47be-8021-4e21a93fba1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

