### PR TITLE
docs(skills): make vanilla-extract the styling solution for greenfield plugins

### DIFF
--- a/.agents/skills/plugin-transfer/SKILL.md
+++ b/.agents/skills/plugin-transfer/SKILL.md
@@ -104,6 +104,8 @@ To keep the plugin on the shared `sanity` variant, declare these in the plugin `
 
 Verify alignment by checking that the plugin importer's `sanity` version string in `pnpm-lock.yaml` matches other plugins (e.g. `plugins/@sanity/sfcc`).
 
+> **Do not migrate styling during a transfer.** When the plugin already uses `styled-components`, keep it as-is for the initial port — the goal is a faithful, low-risk move. Migrating to vanilla-extract (the preferred styling for new code) is a **separate follow-up PR**, done with care to preserve visual fidelity and avoid regressions. The `styled-components: catalog:` alignment above still applies. See the `sanity-plugin-best-practices` styling reference for the greenfield-vs-brownfield rule.
+
 ### Tests
 
 Vitest runs against built `dist/` output (`pretest` builds packages automatically). Fix path resolution and module import issues in legacy test files. The plugin's own `test/` suite (if present) runs via the root vitest config when included in the plugin workspace.
@@ -219,6 +221,7 @@ Example for `sanity-naive-html-serializer`:
 
 ## Anything Else To Consider
 
+- **Do not migrate styling during the transfer.** Keep an existing `styled-components` plugin on `styled-components` for the initial port; defer any vanilla-extract migration to a follow-up PR (see [the styling note above](#duplicate-sanity-peer-variants-break-type-aware-lint)).
 - Review copied dependencies and peer dependencies carefully.
 - Run the [Before Submitting a PR](#before-submitting-a-pr) verification suite—not just `pnpm build` and `pnpm dev`.
 - Use `pnpm dev` to manually verify the test-studio example after the automated checks pass.

--- a/.agents/skills/plugin-transfer/SKILL.md
+++ b/.agents/skills/plugin-transfer/SKILL.md
@@ -104,7 +104,7 @@ To keep the plugin on the shared `sanity` variant, declare these in the plugin `
 
 Verify alignment by checking that the plugin importer's `sanity` version string in `pnpm-lock.yaml` matches other plugins (e.g. `plugins/@sanity/sfcc`).
 
-> **Do not migrate styling during a transfer.** When the plugin already uses `styled-components`, keep it as-is for the initial port — the goal is a faithful, low-risk move. Migrating to vanilla-extract (the preferred styling for new code) is a **separate follow-up PR**, done with care to preserve visual fidelity and avoid regressions. The `styled-components: catalog:` alignment above still applies. See the `sanity-plugin-best-practices` styling reference for the greenfield-vs-brownfield rule.
+> **Do not migrate styling during a transfer.** When the plugin already uses `styled-components`, leave it in place for the initial port — the goal is a faithful, low-risk move. `styled-components` is still migrated to vanilla-extract (the styling target for every plugin), but in a **separate follow-up PR**, done with care to preserve visual fidelity and avoid regressions. The `styled-components: catalog:` alignment above applies until then. See the `sanity-plugin-best-practices` styling reference (`Migrating off styled-components`).
 
 ### Tests
 

--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -48,7 +48,7 @@ cost), is type-safe and scoped, and lives in a `.css.ts` next to the component:
 
 1. **vanilla-extract `style()`** — static styles (the common case).
 2. **vanilla-extract `createVar()` + `assignInlineVars()`** — dynamic styles that read the live
-   `@sanity/ui` theme (via the `useTheme()` hook) or vary with props/state. No `styled-components`
+   `@sanity/ui` theme (via the `useTheme_v2()` hook) or vary with props/state. No `styled-components`
    needed.
 3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
    (katex, easymde, …).
@@ -64,9 +64,8 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
 ## General principles
 
 - **Build on `@sanity/ui`.** Compose Studio primitives (`Box`, `Card`, `Flex`, `Stack`, `Text`,
-  `Button`, …) and read design tokens with the `useTheme()` hook (`theme.sanity.color...`,
-  `theme.sanity.space[...]`, `theme.sanity.radius[...]`) instead of hardcoding colors, spacing, or
-  fonts.
+  `Button`, …) and read design tokens with the `useTheme_v2()` hook (`color...`, `space[...]`,
+  `radius[...]`, `font...`) instead of hardcoding colors, spacing, or fonts.
 - **Style with the priority above:** vanilla-extract for all new styling — `style()` for static,
   `createVar()` + `assignInlineVars()` (from `@vanilla-extract/dynamic`) for dynamic; never raw
   `<style>` tags.

--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -32,9 +32,9 @@ Use this skill when you are:
 Read the reference file for the area you are working in. Each reference lists the anti-pattern, the
 preferred approach, and `Incorrect` / `Correct` examples grounded in real plugins in this repo.
 
-| Area            | What it covers                                                                                 | Reference                                          |
-| --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Styling and CSS | Use vanilla-extract (static + dynamic) for new styling; `styled-components` is brownfield-only | [`references/styling.md`](./references/styling.md) |
+| Area            | What it covers                                                                                                                    | Reference                                          |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Styling and CSS | Use vanilla-extract (static + dynamic) for new styling; encapsulate classes in components; `styled-components` is brownfield-only | [`references/styling.md`](./references/styling.md) |
 
 > This skill is intended to grow. When you find a plugin pattern worth standardizing (or an
 > anti-pattern worth banning), add a focused reference file and a row to the table above rather than
@@ -70,6 +70,12 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
 - **Style with the priority above:** vanilla-extract for all new styling — `style()` for static,
   `createVar()` + `assignInlineVars()` (from `@vanilla-extract/dynamic`) for dynamic; never raw
   `<style>` tags.
+- **Encapsulate styles in components; don't scatter `className`.** Wrap each vanilla-extract class in
+  a small component that spreads props onto the `@sanity/ui` primitive, keeping the same export name
+  and API as the old `styled()` so call sites are unchanged — composition stays as clean as before.
+  To override a primitive's own styles, use the `selectors: {'&&': {...}}` specificity trick
+  (styled-components guaranteed override ordering in the CSSOM; vanilla-extract does not). See
+  [`references/styling.md`](./references/styling.md#keep-the-component-layer-encapsulation).
 - **`styled-components` is brownfield only.** Keep existing usage; don't add it to new code. When
   maintaining it, import named (`import {css, keyframes, styled} from 'styled-components'`) and
   declare the shared peer so the plugin resolves to the workspace `@sanity/styled-components`

--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -51,13 +51,16 @@ per-instance cost), is type-safe and scoped, and lives in a `.css.ts` next to th
    `@sanity/ui` theme (via the `useTheme_v2()` hook) or vary with props/state.
 3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
    (katex, easymde, …).
-4. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, or by appending a
-   `<style>`/`<link>` to `document.head` from a component). They re-parse on every render, duplicate
-   per instance, bypass the theme, and are an injection risk.
+4. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, by appending a
+   `<style>`/`<link>` to `document.head`, or via `useInsertionEffect`). They re-parse on every
+   render, duplicate per instance, bypass the theme, and are an injection risk. CSS-in-JS is a last
+   resort: only when the CSS is genuinely dynamic (from runtime data, able to be _any_ CSS) reach for
+   `styled-components` — the most performant CSS-in-JS — and we try hard never to need it.
 
-`styled-components` is **legacy** — the Studio's old styling library, still in some plugins but never
-used in new code. Migrate existing usage to vanilla-extract (carefully, preserving visual fidelity;
-not during a transfer's initial port). See
+`styled-components` is **legacy** — the Studio's old styling library, still in some plugins. Migrate
+existing styling usage to vanilla-extract (carefully, preserving visual fidelity; not during a
+transfer's initial port). Its only remaining sanctioned use is the last-resort CSS-in-JS escape hatch
+in rule 4 (arbitrary CSS from runtime data). See
 [`references/styling.md`](./references/styling.md#migrating-off-styled-components).
 
 See [`references/styling.md`](./references/styling.md) for the full rationale and examples.
@@ -76,11 +79,12 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
   To override a primitive's own styles, use the `selectors: {'&&': {...}}` specificity trick
   (styled-components guaranteed override ordering in the CSSOM; vanilla-extract does not). See
   [`references/styling.md`](./references/styling.md#keep-the-component-layer-encapsulation).
-- **`styled-components` is legacy — migrate it to vanilla-extract.** Never add it to a plugin;
-  convert existing usage to vanilla-extract (carefully, preserving visual fidelity) using the
-  patterns above. Until a plugin is fully migrated, keep its `styled-components` peer + `catalog:`
-  devDependency aligned so it resolves to the workspace `@sanity/styled-components` override; remove
-  them once migrated, and lock it in with `no-restricted-imports`. See
+- **`styled-components` is legacy — migrate it to vanilla-extract.** Never add it for ordinary
+  styling (its only sanctioned use is the last-resort CSS-in-JS escape hatch for arbitrary runtime
+  CSS); convert existing styling usage to vanilla-extract (carefully, preserving visual fidelity)
+  using the patterns above. Until a plugin is fully migrated, keep its `styled-components` peer +
+  `catalog:` devDependency aligned so it resolves to the workspace `@sanity/styled-components`
+  override; remove them once migrated, and lock it in with `no-restricted-imports`. See
   [`references/styling.md`](./references/styling.md#migrating-off-styled-components).
 - **Use `lodash-es`, never `lodash`** (matches `AGENTS.md`).
 - **Apply the React performance rules** from `vercel-react-best-practices` (don't define components

--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sanity-plugin-best-practices
-description: Anti-patterns and best practices for building Sanity Studio plugins in this monorepo. Use when writing, reviewing, or refactoring plugin code under plugins/ — especially for styling/CSS, component performance, and runtime cost. Triggers on raw <style> tags, styled-components, theming, inline styles, or questions about how plugins should be structured here.
+description: Anti-patterns and best practices for building Sanity Studio plugins in this monorepo. Use when writing, reviewing, or refactoring plugin code under plugins/ — especially for styling/CSS, component performance, and runtime cost. Triggers on vanilla-extract, raw <style> tags, styled-components, theming, inline styles, or questions about how plugins should be structured here.
 metadata:
   author: Sanity.io
-  version: '1.0.0'
+  version: '1.1.0'
 ---
 
 # Sanity Plugin Best Practices
@@ -21,8 +21,8 @@ general React/Next.js patterns, and this skill for plugin-specific guidance.
 Use this skill when you are:
 
 - Writing or reviewing a plugin component under `plugins/` (`.ts`/`.tsx`) or a test-studio example.
-- Adding or changing styling: reaching for `<style>` tags, inline `style={{}}`, CSS files, or
-  `styled-components`.
+- Adding or changing styling: authoring `.css.ts` (vanilla-extract), reaching for `<style>` tags,
+  inline `style={{}}`, CSS files, or `styled-components`.
 - Migrating an external plugin into the monorepo (pair with the `plugin-transfer` skill).
 - Investigating runtime cost, re-renders, or styling that does not respect the Studio theme.
 - Deciding how a plugin should be structured to match the rest of the repo.
@@ -32,9 +32,9 @@ Use this skill when you are:
 Read the reference file for the area you are working in. Each reference lists the anti-pattern, the
 preferred approach, and `Incorrect` / `Correct` examples grounded in real plugins in this repo.
 
-| Area            | What it covers                                                                               | Reference                                          |
-| --------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Styling and CSS | Why raw `<style>` tags hurt performance; prefer static CSS, fall back to `styled-components` | [`references/styling.md`](./references/styling.md) |
+| Area            | What it covers                                                                                 | Reference                                          |
+| --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Styling and CSS | Use vanilla-extract (static + dynamic) for new styling; `styled-components` is brownfield-only | [`references/styling.md`](./references/styling.md) |
 
 > This skill is intended to grow. When you find a plugin pattern worth standardizing (or an
 > anti-pattern worth banning), add a focused reference file and a row to the table above rather than
@@ -42,14 +42,20 @@ preferred approach, and `Incorrect` / `Correct` examples grounded in real plugin
 
 ## Styling: the one-line rule
 
-When a plugin needs styles, pick the cheapest option that works, in this order:
+For new (greenfield) code, [vanilla-extract](https://vanilla-extract.style) is the styling solution
+for everything you author — it compiles to a static stylesheet (zero per-render and per-instance
+cost), is type-safe and scoped, and lives in a `.css.ts` next to the component:
 
-1. **Static CSS** — author or import plain CSS once at module scope. Parsed a single time, cached by
-   the browser, deduplicated by the bundler, zero per-render cost. **Prefer this.**
-2. **`styled-components`** — only when styles must be computed at runtime (depend on the
-   `@sanity/ui` theme, props, or state). This is the Studio's styling solution and an existing peer
-   dependency, so it shares one managed stylesheet and the Studio theme.
-3. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, or by appending a
+1. **vanilla-extract `style()`** — static styles (the common case).
+2. **vanilla-extract `createVar()` + `assignInlineVars()`** — dynamic styles that read the live
+   `@sanity/ui` theme (via the `useTheme()` hook) or vary with props/state. No `styled-components`
+   needed.
+3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
+   (katex, easymde, …).
+4. **`styled-components`** — **brownfield only.** Existing plugins keep it; never introduce it in new
+   code, and don't migrate styling speculatively (do it in a dedicated PR with care for visual
+   fidelity).
+5. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, or by appending a
    `<style>`/`<link>` to `document.head` from a component). They re-parse on every render, duplicate
    per instance, bypass the theme, and are an injection risk.
 
@@ -58,14 +64,17 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
 ## General principles
 
 - **Build on `@sanity/ui`.** Compose Studio primitives (`Box`, `Card`, `Flex`, `Stack`, `Text`,
-  `Button`, …) and read design tokens from the theme (`({theme}) => theme.sanity...`,
-  `theme.space[...]`, `theme.radius[...]`) instead of hardcoding colors, spacing, or fonts.
-- **Style with the priority above:** static CSS first, `styled-components` for runtime-dynamic
-  styling, never raw `<style>` tags.
-- **Import `styled-components` named, not default:** `import {css, keyframes, styled} from 'styled-components'`.
-- **Declare shared peers** so the plugin resolves to the workspace `@sanity/styled-components`
-  override (a single styled-components instance — required for theming and SSR). See
-  [`references/styling.md`](./references/styling.md#dependency-setup).
+  `Button`, …) and read design tokens with the `useTheme()` hook (`theme.sanity.color...`,
+  `theme.sanity.space[...]`, `theme.sanity.radius[...]`) instead of hardcoding colors, spacing, or
+  fonts.
+- **Style with the priority above:** vanilla-extract for all new styling — `style()` for static,
+  `createVar()` + `assignInlineVars()` (from `@vanilla-extract/dynamic`) for dynamic; never raw
+  `<style>` tags.
+- **`styled-components` is brownfield only.** Keep existing usage; don't add it to new code. When
+  maintaining it, import named (`import {css, keyframes, styled} from 'styled-components'`) and
+  declare the shared peer so the plugin resolves to the workspace `@sanity/styled-components`
+  override (a single instance — required for theming and SSR). See
+  [`references/styling.md`](./references/styling.md#brownfield-only-styled-components).
 - **Use `lodash-es`, never `lodash`** (matches `AGENTS.md`).
 - **Apply the React performance rules** from `vercel-react-best-practices` (don't define components
   inside components, batch DOM/CSS writes, hoist static JSX, etc.).

--- a/.agents/skills/sanity-plugin-best-practices/SKILL.md
+++ b/.agents/skills/sanity-plugin-best-practices/SKILL.md
@@ -3,7 +3,7 @@ name: sanity-plugin-best-practices
 description: Anti-patterns and best practices for building Sanity Studio plugins in this monorepo. Use when writing, reviewing, or refactoring plugin code under plugins/ — especially for styling/CSS, component performance, and runtime cost. Triggers on vanilla-extract, raw <style> tags, styled-components, theming, inline styles, or questions about how plugins should be structured here.
 metadata:
   author: Sanity.io
-  version: '1.1.0'
+  version: '1.2.0'
 ---
 
 # Sanity Plugin Best Practices
@@ -32,9 +32,9 @@ Use this skill when you are:
 Read the reference file for the area you are working in. Each reference lists the anti-pattern, the
 preferred approach, and `Incorrect` / `Correct` examples grounded in real plugins in this repo.
 
-| Area            | What it covers                                                                                                                    | Reference                                          |
-| --------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| Styling and CSS | Use vanilla-extract (static + dynamic) for new styling; encapsulate classes in components; `styled-components` is brownfield-only | [`references/styling.md`](./references/styling.md) |
+| Area            | What it covers                                                                                                                                   | Reference                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| Styling and CSS | Use vanilla-extract (static + dynamic) for all plugin styling; encapsulate classes in components; migrate `styled-components` to vanilla-extract | [`references/styling.md`](./references/styling.md) |
 
 > This skill is intended to grow. When you find a plugin pattern worth standardizing (or an
 > anti-pattern worth banning), add a focused reference file and a row to the table above rather than
@@ -42,22 +42,23 @@ preferred approach, and `Incorrect` / `Correct` examples grounded in real plugin
 
 ## Styling: the one-line rule
 
-For new (greenfield) code, [vanilla-extract](https://vanilla-extract.style) is the styling solution
-for everything you author — it compiles to a static stylesheet (zero per-render and per-instance
-cost), is type-safe and scoped, and lives in a `.css.ts` next to the component:
+[vanilla-extract](https://vanilla-extract.style) is the styling solution for everything you author —
+in new plugins and existing ones. It compiles to a static stylesheet (zero per-render and
+per-instance cost), is type-safe and scoped, and lives in a `.css.ts` next to the component:
 
 1. **vanilla-extract `style()`** — static styles (the common case).
 2. **vanilla-extract `createVar()` + `assignInlineVars()`** — dynamic styles that read the live
-   `@sanity/ui` theme (via the `useTheme_v2()` hook) or vary with props/state. No `styled-components`
-   needed.
+   `@sanity/ui` theme (via the `useTheme_v2()` hook) or vary with props/state.
 3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
    (katex, easymde, …).
-4. **`styled-components`** — **brownfield only.** Existing plugins keep it; never introduce it in new
-   code, and don't migrate styling speculatively (do it in a dedicated PR with care for visual
-   fidelity).
-5. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, or by appending a
+4. **Never** render raw `<style>` tags (in JSX, via `dangerouslySetInnerHTML`, or by appending a
    `<style>`/`<link>` to `document.head` from a component). They re-parse on every render, duplicate
    per instance, bypass the theme, and are an injection risk.
+
+`styled-components` is **legacy** — the Studio's old styling library, still in some plugins but never
+used in new code. Migrate existing usage to vanilla-extract (carefully, preserving visual fidelity;
+not during a transfer's initial port). See
+[`references/styling.md`](./references/styling.md#migrating-off-styled-components).
 
 See [`references/styling.md`](./references/styling.md) for the full rationale and examples.
 
@@ -75,11 +76,12 @@ See [`references/styling.md`](./references/styling.md) for the full rationale an
   To override a primitive's own styles, use the `selectors: {'&&': {...}}` specificity trick
   (styled-components guaranteed override ordering in the CSSOM; vanilla-extract does not). See
   [`references/styling.md`](./references/styling.md#keep-the-component-layer-encapsulation).
-- **`styled-components` is brownfield only.** Keep existing usage; don't add it to new code. When
-  maintaining it, import named (`import {css, keyframes, styled} from 'styled-components'`) and
-  declare the shared peer so the plugin resolves to the workspace `@sanity/styled-components`
-  override (a single instance — required for theming and SSR). See
-  [`references/styling.md`](./references/styling.md#brownfield-only-styled-components).
+- **`styled-components` is legacy — migrate it to vanilla-extract.** Never add it to a plugin;
+  convert existing usage to vanilla-extract (carefully, preserving visual fidelity) using the
+  patterns above. Until a plugin is fully migrated, keep its `styled-components` peer + `catalog:`
+  devDependency aligned so it resolves to the workspace `@sanity/styled-components` override; remove
+  them once migrated, and lock it in with `no-restricted-imports`. See
+  [`references/styling.md`](./references/styling.md#migrating-off-styled-components).
 - **Use `lodash-es`, never `lodash`** (matches `AGENTS.md`).
 - **Apply the React performance rules** from `vercel-react-best-practices` (don't define components
   inside components, batch DOM/CSS writes, hoist static JSX, etc.).

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -18,11 +18,16 @@ Decide as follows:
    `@sanity/ui` theme, or vary with props or state.
 3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
    (katex, easymde, react-photo-album).
-4. **Never** raw `<style>` tags or runtime stylesheet injection from a component.
+4. **Never** render raw `<style>` tags or insert CSS with the `useInsertionEffect` hook. If
+   installing CSS in JS is absolutely necessary — for example the CSS comes from runtime data and can
+   be _any_ CSS — use `styled-components`, the most performant way to do CSS-in-JS (though we try our
+   best to never have to reach for CSS-in-JS).
 
-`styled-components` is **not** one of the options above. It is the Studio's legacy styling library —
-still present in some plugins, but on its way out. Never add it to a plugin, and migrate existing
-usage to vanilla-extract (see [Migrating off styled-components](#migrating-off-styled-components)).
+`styled-components` is otherwise **not** one of the options above. It is the Studio's legacy styling
+library — still present in some plugins, but on its way out. Don't add it for ordinary styling, and
+migrate existing styling usage to vanilla-extract (see
+[Migrating off styled-components](#migrating-off-styled-components)). Its only sanctioned use is the
+last-resort CSS-in-JS escape hatch in rule 4.
 
 > There is no reason to write `styled-components`, even when the plugin is built on `@sanity/ui`
 > (most are). Using `@sanity/ui` does not make `styled-components` a good fit for customizing it or
@@ -33,8 +38,9 @@ usage to vanilla-extract (see [Migrating off styled-components](#migrating-off-s
 
 ## Anti-pattern: raw `<style>` tags
 
-Do not render `<style>` tags from a component, inject CSS through `dangerouslySetInnerHTML`, or
-append a `<style>` / `<link>` element to `document.head` from render or an effect.
+Do not render `<style>` tags from a component, inject CSS through `dangerouslySetInnerHTML`, append a
+`<style>` / `<link>` element to `document.head`, or insert CSS with the `useInsertionEffect` hook —
+whether from render or an effect.
 
 **Why it is bad:**
 
@@ -88,9 +94,28 @@ function useInjectStyles(css: string) {
 }
 ```
 
+**Incorrect (`useInsertionEffect` to inject a stylesheet — still hand-rolled CSS-in-JS):**
+
+```tsx
+function useInjectStyles(css: string) {
+  useInsertionEffect(() => {
+    const el = document.createElement('style')
+    el.textContent = css
+    document.head.appendChild(el)
+    return () => el.remove()
+  }, [css])
+}
+```
+
 > Note: `dangerouslySetInnerHTML` is fine for rendering already-sanitized **content** (for example
 > `sanity-plugin-latex-input` uses it for KaTeX's `renderToString` output). The anti-pattern is using
 > it — or `<style>` tags — to ship **CSS rules**.
+
+> **The one escape hatch.** If you genuinely must install CSS from JS — the CSS is built from runtime
+> data and can be _any_ CSS, so a fixed `style()` + `createVar()` cannot express it — reach for
+> `styled-components` instead of hand-rolling injection. It is the most performant CSS-in-JS option
+> and inserts styles correctly (via `useInsertionEffect` internally, deduplicated through the CSSOM).
+> This is genuinely rare — exhaust vanilla-extract first; we try our best to never need CSS-in-JS.
 
 ---
 
@@ -513,9 +538,12 @@ declare module 'katex/dist/katex.min.css'
 ## Migrating off styled-components
 
 `styled-components` is the Studio's legacy styling library (a `@sanity/ui` peer). It still works, but
-**no new code uses it and existing usage is migrated to vanilla-extract** — this skill is the guide
-for that migration. Don't add `styled-components` to a plugin, and convert a component's styling to
-vanilla-extract when you work on it rather than extending the styled-components code.
+**no new code uses it for styling and existing usage is migrated to vanilla-extract** — this skill is
+the guide for that migration. Don't add `styled-components` for ordinary styling, and convert a
+component's styling to vanilla-extract when you work on it rather than extending the styled-components
+code. (The one usage that legitimately stays is genuinely-dynamic CSS-in-JS — arbitrary CSS built
+from runtime data that no `style()` + `createVar()` can express, the escape hatch in the
+[priority order](#priority-order). Ordinary styling always migrates.)
 
 The migration is mechanical, reusing the patterns above:
 

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -24,7 +24,7 @@ Decide as follows:
 
 > There is essentially no reason to start new code on `styled-components`, even when the plugin is
 > built on `@sanity/ui` (most are). Using `@sanity/ui` does not make `styled-components` a good fit
-> for customizing it or reading its theme: read tokens with the `useTheme()` hook and forward them
+> for customizing it or reading its theme: read tokens with the `useTheme_v2()` hook and forward them
 > into vanilla-extract instead (see [Dynamic styling](#dynamic-styling-with-vanilla-extract)).
 
 ---
@@ -234,41 +234,47 @@ When a style must follow the live `@sanity/ui` theme, or change with props or st
 need `styled-components`. Declare a CSS variable with `createVar()`, reference it from a static
 `style()` rule, then assign its value at runtime with `assignInlineVars()` from
 `@vanilla-extract/dynamic` on the element's `style` prop. Read theme tokens with `@sanity/ui`'s
-`useTheme()` hook.
+`useTheme_v2()` hook (the v2 theme API — `color`, `space`, `radius`, `font`) and bridge them in a
+small wrapper component — the `ResultViewWrapper` pattern from
+[sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333):
 
 ```ts
-// MarkdownInput.css.ts
+// ResultView.css.ts
 import {createVar, style} from '@vanilla-extract/css'
 
-export const fg = createVar()
-export const border = createVar()
+export const codeFamilyVar = createVar()
+export const space2Var = createVar()
+export const syntaxStringVar = createVar()
 
-export const editor = style({
-  color: fg,
-  borderColor: border,
-  backgroundColor: 'inherit',
+export const resultViewWrapper = style({
+  fontFamily: codeFamilyVar,
+  padding: space2Var,
+  color: syntaxStringVar,
 })
 ```
 
 ```tsx
-// MarkdownInput.tsx
-import {Box, useTheme} from '@sanity/ui'
+// ResultView.tsx
+import {rem, useTheme_v2 as useThemeV2} from '@sanity/ui'
 import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {type ReactNode} from 'react'
 
-import {border, editor, fg} from './MarkdownInput.css'
+import {codeFamilyVar, resultViewWrapper, space2Var, syntaxStringVar} from './ResultView.css'
 
-export function MarkdownInput() {
-  const theme = useTheme()
+function ResultViewWrapper({children}: {children: ReactNode}) {
+  const {color, font, space} = useThemeV2()
+
   return (
-    <Box
-      className={editor}
+    <div
+      className={resultViewWrapper}
       style={assignInlineVars({
-        [fg]: theme.sanity.color.card.enabled.fg,
-        [border]: theme.sanity.color.card.enabled.border,
+        [codeFamilyVar]: font.code.family,
+        [space2Var]: `${rem(space[2])}`,
+        [syntaxStringVar]: color.syntax.string,
       })}
     >
-      ...
-    </Box>
+      {children}
+    </div>
   )
 }
 ```
@@ -589,4 +595,5 @@ that forces synchronous reflows. See the `vercel-react-best-practices` rule `js-
   `keyframes`, `globalStyle`; and
   [`@vanilla-extract/dynamic`](https://vanilla-extract.style/documentation/packages/dynamic/) for
   `assignInlineVars`.
-- [`@sanity/ui`](https://www.sanity.io/ui) for theme tokens, the `useTheme()` hook, and primitives.
+- [`@sanity/ui`](https://www.sanity.io/ui) for theme tokens, the `useTheme_v2()` hook, and
+  primitives.

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -130,7 +130,9 @@ export function StaticMapPreview({url}: {url: string}) {
 ```
 
 Compose `@sanity/ui` primitives and pass the class through their `className` prop just like a DOM
-element.
+element. For anything reused — or any `@sanity/ui` primitive you restyle — wrap it in its own small
+component rather than spreading `className` across the tree (see
+[Keep the component layer](#keep-the-component-layer-encapsulation)).
 
 ### vanilla-extract setup
 
@@ -312,6 +314,158 @@ For the remaining things `styled-components` was used for in this repo:
 
 ---
 
+## Keep the component layer (encapsulation)
+
+vanilla-extract hands you a class-name string, not a component — but a migration must **not** turn
+that into raw `className=` props sprinkled across the tree. A `styled(Box)` element already _is_ a
+named component with its own API; replacing it with `<Box className={...}>` at every call site leaks
+styling details into the markup and leaves the composition uglier than before. **The component
+composition should be as clean as it was with `styled-components`, or cleaner.**
+
+Wrap each styled element in a small component (keep it next to the `.css.ts`, e.g. in a
+`*.styled.tsx`) that spreads props onto the underlying `@sanity/ui` primitive or DOM element and
+applies the class. The import and JSX stay identical to the styled-components version — callers never
+touch a class name.
+
+Given a shared stylesheet:
+
+```ts
+// Component.css.ts
+import {style} from '@vanilla-extract/css'
+
+export const dot = style({
+  selectors: {
+    // override the default overflow
+    '&&': {overflow: 'sticky'},
+  },
+})
+```
+
+**Incorrect** — the class bleeds onto a raw primitive at the call site:
+
+```tsx
+// Component.tsx
+import {Box} from '@sanity/ui'
+
+import {dot} from './Component.css'
+
+function Component() {
+  return <Box className={dot} display="grid" />
+}
+```
+
+**Correct** — the class is encapsulated in a `Dot` component; the composition is unchanged:
+
+```tsx
+// Component.tsx
+import {Box} from '@sanity/ui'
+
+import {dot} from './Component.css'
+
+function Dot() {
+  return <Box className={dot} display="grid" />
+}
+
+function Component() {
+  return <Dot />
+}
+```
+
+This is how [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333) migrated
+`@sanity/vision`: each `*.styled.tsx` was kept (or recreated) as a thin component layer over the new
+`*.css.ts`, preserving every export name and call site.
+
+```tsx
+// QueryErrorDialog.styled.tsx — same `ErrorCode` API as the styled-components version
+import {Code} from '@sanity/ui'
+import {type ComponentProps} from 'react'
+
+import {errorCode} from './QueryErrorDialog.css'
+
+export function ErrorCode(props: ComponentProps<typeof Code>) {
+  return <Code {...props} className={errorCode} />
+}
+```
+
+- **Type the wrapper** with `ComponentProps<typeof Primitive>` (or `ComponentProps<'a'>` for a DOM
+  element), and spread props **before** `className` so the wrapper owns the class.
+- **Forward refs** when the original wrapped a ref-forwarding primitive:
+
+  ```tsx
+  export const Root = forwardRef<HTMLDivElement, ComponentProps<typeof Flex>>(
+    function Root(props, ref) {
+      return <Flex {...props} ref={ref} className={root} />
+    },
+  )
+  ```
+
+- **Map a boolean/variant prop to conditional classes** instead of a styled-components transient prop
+  (`$isInvalid`):
+
+  ```tsx
+  function ResultContainer({
+    isInvalid,
+    ...props
+  }: ComponentProps<typeof Card> & {isInvalid: boolean}) {
+    return (
+      <Card
+        {...props}
+        className={isInvalid ? `${resultContainer} ${resultContainerInvalid}` : resultContainer}
+      />
+    )
+  }
+  ```
+
+- **Map a dynamic scalar** (theme token, measured value, per-instance color) to a CSS variable with
+  `assignInlineVars` inside the wrapper (see
+  [Dynamic styling](#dynamic-styling-with-vanilla-extract)).
+
+---
+
+## Overriding `@sanity/ui` styles: the `&&` trick
+
+With styled-components, `const OverrideCard = styled(Card)` always wins: styled-components inserts the
+override's rules into the CSSOM **after** `Card`'s own rules, so equal-specificity declarations
+resolve in your favor and you never think about ordering. vanilla-extract does **not** control how or
+when stylesheets load, so a plain class can lose that ordering battle against the styles `@sanity/ui`
+sets on its own components.
+
+When an override doesn't take effect, double the class selector with `selectors: {'&&': {...}}` to
+raise specificity (it resolves to `.cls.cls`) so it reliably wins. Use `'&&::before'` / `'&&::after'`
+for pseudo-elements. (vanilla-extract's `selectors` must target the element via `&`; `&&` simply
+references it twice.)
+
+```ts
+// QueryErrorDialog.css.ts (sanity-io/sanity#13333)
+import {style} from '@vanilla-extract/css'
+
+// `&&` is needed to override the color @sanity/ui's Code sets on itself.
+export const errorCode = style({
+  selectors: {
+    '&&': {
+      color: 'var(--card-muted-fg-color)',
+    },
+  },
+})
+```
+
+```ts
+// VisionGui.css.ts (sanity-io/sanity#13333) — override the background @sanity/ui's Card sets
+export const header = style({
+  borderBottom: '1px solid var(--card-border-color)',
+  selectors: {
+    '&&': {
+      background: 'var(--card-bg-color)',
+    },
+  },
+})
+```
+
+Reach for `&&` only when you are genuinely overriding a primitive's built-in style; plain `style()`
+is enough for everything else.
+
+---
+
 ## Third-party CSS imports
 
 Prebuilt stylesheets shipped by a dependency are consumed by importing the `.css` once at module
@@ -350,6 +504,11 @@ Studio theme. **Keep working brownfield code on `styled-components`; do not rewr
 speculatively.** A migration to vanilla-extract must be done carefully — and usually in its own PR —
 to preserve visual fidelity and avoid regressions. The `plugin-transfer` skill makes this a rule:
 transfers never migrate styling in the initial port.
+
+> **Locking in a finished migration.** Once a plugin no longer imports `styled-components` at all,
+> ban it via `no-restricted-imports` in `.oxlintrc.json` so it cannot creep back — this is how
+> `@sanity/vision` locked in its migration in
+> [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333).
 
 For **new** code, prefer vanilla-extract (above). The notes below apply only when maintaining a
 plugin that is already on `styled-components`:
@@ -424,6 +583,8 @@ that forces synchronous reflows. See the `vercel-react-best-practices` rule `js-
   `rules/rendering-hoist-jsx.md`, and the rendering section generally.
 - `plugin-transfer` skill → keep transferred plugins on `styled-components`; dependency alignment for
   `styled-components` and `sanity` peers.
+- [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333) — reference migration of
+  `@sanity/vision`: the component-layer (encapsulation) pattern and the `&&` specificity trick.
 - [vanilla-extract](https://vanilla-extract.style) — `style`, `createVar`, `styleVariants`,
   `keyframes`, `globalStyle`; and
   [`@vanilla-extract/dynamic`](https://vanilla-extract.style/documentation/packages/dynamic/) for

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -4,14 +4,28 @@ How to style plugin UI without paying an unnecessary runtime cost or breaking St
 
 ## Priority order
 
-Pick the cheapest option that satisfies the requirement:
+In **greenfield** plugin code, [vanilla-extract](https://vanilla-extract.style) is the styling
+solution for everything you author — both static and dynamic styles. It compiles to a static
+stylesheet at build time (zero per-render and per-instance runtime cost), produces type-safe,
+locally-scoped class names, and lives next to the component in a `.css.ts` file.
+`@sanity/google-maps-input` is the reference implementation (migrated in
+[PR #1417](https://github.com/sanity-io/plugins/pull/1417)).
 
-1. **Static CSS** (preferred) — plain CSS authored or imported once at module scope.
-2. **`styled-components`** — only for styles that must be computed at runtime (theme, props, state).
-3. **Never** raw `<style>` tags or runtime stylesheet injection from a component.
+Decide as follows:
 
-Each step down adds work the browser repeats; only move down when the step above genuinely cannot
-express the requirement.
+1. **vanilla-extract `style()`** — for static styles (the common case).
+2. **vanilla-extract `createVar()` + `assignInlineVars()`** — for styles that must read the live
+   `@sanity/ui` theme, or vary with props or state.
+3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
+   (katex, easymde, react-photo-album).
+4. **`styled-components`** — **brownfield only.** Existing plugins keep it; do not reach for it in
+   new code. See [Brownfield only: styled-components](#brownfield-only-styled-components).
+5. **Never** raw `<style>` tags or runtime stylesheet injection from a component.
+
+> There is essentially no reason to start new code on `styled-components`, even when the plugin is
+> built on `@sanity/ui` (most are). Using `@sanity/ui` does not make `styled-components` a good fit
+> for customizing it or reading its theme: read tokens with the `useTheme()` hook and forward them
+> into vanilla-extract instead (see [Dynamic styling](#dynamic-styling-with-vanilla-extract)).
 
 ---
 
@@ -33,8 +47,7 @@ append a `<style>` / `<link>` element to `document.head` from render or an effec
 - **Specificity and global leakage.** Hand-written selectors easily leak outside the plugin or fight
   the Studio's own styles, leading to brittle `!important` chains.
 - **Injection risk.** Interpolating values into raw CSS text (especially via
-  `dangerouslySetInnerHTML`) is an injection vector and defeats the sanitization styled-components
-  provides.
+  `dangerouslySetInnerHTML`) is an injection vector.
 
 **Incorrect (inline `<style>` tag, re-parsed every render, duplicated per instance):**
 
@@ -79,13 +92,230 @@ function useInjectStyles(css: string) {
 
 ---
 
-## Preferred: static CSS
+## Preferred: vanilla-extract (zero-runtime CSS)
 
-If the styles are known ahead of time, ship them as static CSS. The bundler emits one stylesheet,
-the browser parses it once and caches it, and there is no per-render or per-instance cost.
+Author styles in a colocated `.css.ts` file with `style()` from `@vanilla-extract/css`. Each call
+returns a unique, scoped class-name string; pass it to a component's `className`. The styles are
+extracted to a single static stylesheet at build time, so there is no per-render or per-instance
+cost and no theme or specificity leakage.
 
-Static CSS is also how third-party component CSS is consumed in this repo — import it once at the
-module top:
+```ts
+// plugins/@sanity/google-maps-input/src/input/StaticMapPreview.css.ts
+import {style} from '@vanilla-extract/css'
+
+export const staticMapContainer = style({
+  cursor: 'pointer',
+})
+export const staticMapImage = style({
+  width: '100%',
+  height: 'auto',
+  display: 'block',
+  verticalAlign: 'top',
+})
+```
+
+```tsx
+// plugins/@sanity/google-maps-input/src/input/StaticMapPreview.tsx
+import {StaticMap} from '@vis.gl/react-google-maps'
+
+import {staticMapContainer, staticMapImage} from './StaticMapPreview.css'
+
+export function StaticMapPreview({url}: {url: string}) {
+  return (
+    <div className={staticMapContainer}>
+      <StaticMap className={staticMapImage} url={url} />
+    </div>
+  )
+}
+```
+
+Compose `@sanity/ui` primitives and pass the class through their `className` prop just like a DOM
+element.
+
+### vanilla-extract setup
+
+vanilla-extract needs a build/transform step. Mirror `@sanity/google-maps-input`:
+
+**1. Enable the pkg-utils Rollup integration** so the build extracts a `dist/bundle.css`:
+
+```ts
+// plugins/@sanity/google-maps-input/package.config.ts
+import config from '@repo/package.config'
+import {defineConfig} from '@sanity/pkg-utils'
+
+export default defineConfig({
+  ...config,
+  babel: {reactCompiler: true},
+  reactCompilerOptions: {target: '19'},
+  rollup: {vanillaExtract: true},
+})
+```
+
+**2. Add the `./bundle.css` export and build deps** in `package.json`. The built entry loads the
+stylesheet, so consumers need no changes; the `node` / `default` conditions point at a JS shim so
+SSR/Node imports don't choke on a `.css` file:
+
+```json
+{
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    },
+    "./bundle.css": {
+      "browser": "./dist/bundle.css",
+      "style": "./dist/bundle.css",
+      "node": "./dist/bundle.css.js",
+      "default": "./dist/bundle.css.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "devDependencies": {
+    "@vanilla-extract/css": "catalog:",
+    "@vanilla-extract/vite-plugin": "catalog:"
+  }
+}
+```
+
+Add the matching `./bundle.css` entry under `publishConfig.exports` too. `@vanilla-extract/css` is
+**build-time only** — its `style()` / `createVar()` calls compile away — so it stays a
+`devDependency`, never a runtime `dependency`.
+
+**3. Register the Vite plugin** wherever the plugin's source `.css.ts` is compiled live: the
+plugin's own `vitest.config.ts`, and the test studio (which consumes the plugin's `source` export in
+dev):
+
+```ts
+// plugins/@sanity/google-maps-input/vitest.config.ts
+import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  plugins: [vanillaExtractPlugin()],
+  // ...
+})
+```
+
+```ts
+// dev/test-studio/sanity.cli.ts — add vanillaExtractPlugin() to the studio's Vite plugins
+import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+
+export default defineCliConfig({
+  // ...
+  vite: {
+    plugins: [vanillaExtractPlugin()],
+  },
+})
+```
+
+Finally, the catalog carries the build deps (add them if missing) and knip ignores the
+build-time-only css package:
+
+```yaml
+# pnpm-workspace.yaml
+catalog:
+  '@vanilla-extract/css': ^1.20.1
+  '@vanilla-extract/vite-plugin': ^5.2.2
+```
+
+```jsonc
+// knip.jsonc
+"ignoreDependencies": ["@vanilla-extract/css"]
+```
+
+---
+
+## Dynamic styling with vanilla-extract
+
+When a style must follow the live `@sanity/ui` theme, or change with props or state, you do **not**
+need `styled-components`. Declare a CSS variable with `createVar()`, reference it from a static
+`style()` rule, then assign its value at runtime with `assignInlineVars()` from
+`@vanilla-extract/dynamic` on the element's `style` prop. Read theme tokens with `@sanity/ui`'s
+`useTheme()` hook.
+
+```ts
+// MarkdownInput.css.ts
+import {createVar, style} from '@vanilla-extract/css'
+
+export const fg = createVar()
+export const border = createVar()
+
+export const editor = style({
+  color: fg,
+  borderColor: border,
+  backgroundColor: 'inherit',
+})
+```
+
+```tsx
+// MarkdownInput.tsx
+import {Box, useTheme} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+
+import {border, editor, fg} from './MarkdownInput.css'
+
+export function MarkdownInput() {
+  const theme = useTheme()
+  return (
+    <Box
+      className={editor}
+      style={assignInlineVars({
+        [fg]: theme.sanity.color.card.enabled.fg,
+        [border]: theme.sanity.color.card.enabled.border,
+      })}
+    >
+      ...
+    </Box>
+  )
+}
+```
+
+`assignInlineVars` only emits the variables you pass (a `null` / `undefined` value is omitted), so
+one class can be reused with different runtime values across instances. The variable definitions
+stay in the static stylesheet; only the few changing values ride along as inline custom properties.
+The same applies to prop- or state-driven values — pass them through `assignInlineVars` instead of
+branching on a styled-components prop.
+
+> **Dependency note:** unlike `@vanilla-extract/css`, `@vanilla-extract/dynamic` is a small (~1 kB)
+> **runtime** helper, so a plugin that uses it lists it under `dependencies` (not `devDependencies`)
+> and adds a catalog entry:
+>
+> ```yaml
+> # pnpm-workspace.yaml
+> catalog:
+>   '@vanilla-extract/dynamic': ^2.1.5
+> ```
+
+For the remaining things `styled-components` was used for in this repo:
+
+- **Variants / conditional styles** → `styleVariants({primary: {...}, critical: {...}})`, then pick
+  the class by key. Plain composition is `style([base, extra])`.
+- **Animations** → `keyframes()` from `@vanilla-extract/css` (returns a name you reference in
+  `animationName`), instead of injecting `@keyframes` through a `<style>` tag.
+- **Theming a third-party widget's own classes** (e.g. CodeMirror/EasyMDE) → `globalStyle()` scoped
+  under a local wrapper class so it cannot leak, bridging theme values through a CSS variable:
+
+  ```ts
+  import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+  export const fg = createVar()
+  export const markdownInput = style({})
+
+  globalStyle(`${markdownInput} .CodeMirror`, {
+    color: fg,
+  })
+  ```
+
+  Set `fg` on the wrapper element with `assignInlineVars` exactly as above; the descendant inherits
+  it.
+
+---
+
+## Third-party CSS imports
+
+Prebuilt stylesheets shipped by a dependency are consumed by importing the `.css` once at module
+scope — you are not authoring these, so vanilla-extract does not apply:
 
 ```ts
 // plugins/sanity-plugin-latex-input/src/components/LatexPreview.tsx
@@ -110,21 +340,19 @@ source (this is the existing pattern):
 declare module 'katex/dist/katex.min.css'
 ```
 
-**When to use:** any styling that does not depend on runtime values — layout, spacing, third-party
-widget theming, and most component chrome.
-
-**Trade-off:** static CSS cannot read the live `@sanity/ui` theme. If a rule must follow theme
-tokens or change with props/state, use `styled-components` (below) rather than reaching for a raw
-`<style>` tag.
-
 ---
 
-## Runtime styling: styled-components
+## Brownfield only: styled-components
 
-When a style genuinely must be computed at runtime — it reads the Studio theme, or varies with props
-or state — use `styled-components`. It is the Studio's own styling library and an existing peer
-dependency, so plugins share a single managed stylesheet (one injected `<style>` tag that
-styled-components maintains via the CSSOM, deduplicated across instances) and the same theme.
+`styled-components` is the Studio's own styling library and a `@sanity/ui` peer dependency, so
+existing plugins that use it still work correctly — they share a single managed stylesheet and the
+Studio theme. **Keep working brownfield code on `styled-components`; do not rewrite it
+speculatively.** A migration to vanilla-extract must be done carefully — and usually in its own PR —
+to preserve visual fidelity and avoid regressions. The `plugin-transfer` skill makes this a rule:
+transfers never migrate styling in the initial port.
+
+For **new** code, prefer vanilla-extract (above). The notes below apply only when maintaining a
+plugin that is already on `styled-components`:
 
 **Import named, not default** (`import styled from 'styled-components'` was removed — see the
 `@sanity/code-input` changelog):
@@ -133,35 +361,8 @@ styled-components maintains via the CSSOM, deduplicated across instances) and th
 import {css, keyframes, styled} from 'styled-components'
 ```
 
-**Extend `@sanity/ui` primitives** instead of styling bare DOM elements:
-
-```tsx
-// plugins/sanity-plugin-workflow/src/components/FloatingCard.tsx
-import {Card} from '@sanity/ui'
-import {styled} from 'styled-components'
-
-const StyledFloatingCard = styled(Card)`
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  z-index: 1000;
-`
-```
-
-**Read theme tokens** with the `({theme}) => ...` accessor rather than hardcoding values:
-
-```tsx
-// plugins/sanity-plugin-graph-view/src/tool/GraphViewStyle.tsx
-export const HoverNode = styled.div`
-  font-family: ${({theme}) => theme.fonts.text.family};
-  bottom: ${({theme}) => theme.space[0]}px;
-  border-radius: ${({theme}) => theme.radius[2]}px;
-  padding: ${({theme}) => theme.space[2]}px;
-`
-```
-
-**Use the `css` helper** for conditional or composed style blocks, and to theme third-party widget
-classes from within the plugin's own scoped wrapper:
+**Extend `@sanity/ui` primitives** rather than bare DOM elements, and **read theme tokens** with the
+`({theme}) => ...` accessor:
 
 ```tsx
 // plugins/sanity-plugin-markdown/src/components/MarkdownInput.tsx
@@ -177,19 +378,12 @@ const MarkdownInputStyles = styled(Box)`
 `
 ```
 
-**Use `keyframes`** for animation instead of injecting `@keyframes` through a `<style>` tag (see
-`@sanity/assist` and `sanity-plugin-asset-source-unsplash`).
-
----
-
-## Dependency setup
+### Dependency setup (brownfield)
 
 Declare `styled-components` so the plugin resolves to the workspace override
 (`styled-components: npm:@sanity/styled-components@latest`). This guarantees a **single**
 styled-components instance shared with the Studio — without it, pnpm may install a separate copy and
 theming/SSR break.
-
-In the plugin `package.json`:
 
 ```json
 {
@@ -212,9 +406,11 @@ In the plugin `package.json`:
 ## Inline `style={{}}` props
 
 Inline styles are acceptable for a single, genuinely dynamic value (e.g. a measured `transform` or a
-user-picked color on one element). For anything static or repeated, prefer `@sanity/ui` props, a
-CSS class, or `styled-components` — inline styles are recreated every render and cannot use theme
-tokens, pseudo-classes, or media queries.
+user-picked color on one element). When the value feeds a vanilla-extract variable, set it with
+`assignInlineVars` (typed, and it strips the wrapping `var(...)` for you) rather than hand-writing
+the custom property. For anything static or repeated, prefer `@sanity/ui` props or a vanilla-extract
+class — plain inline styles are recreated every render and cannot use pseudo-classes or media
+queries.
 
 Never interleave inline style writes with layout reads (`offsetWidth`, `getBoundingClientRect()`):
 that forces synchronous reflows. See the `vercel-react-best-practices` rule `js-batch-dom-css`
@@ -226,5 +422,10 @@ that forces synchronous reflows. See the `vercel-react-best-practices` rule `js-
 
 - `vercel-react-best-practices` → `rules/js-batch-dom-css.md` (batch DOM/CSS writes, prefer classes),
   `rules/rendering-hoist-jsx.md`, and the rendering section generally.
-- `plugin-transfer` skill → dependency alignment for `styled-components` and `sanity` peers.
-- [`@sanity/ui`](https://www.sanity.io/ui) for theme tokens and primitives.
+- `plugin-transfer` skill → keep transferred plugins on `styled-components`; dependency alignment for
+  `styled-components` and `sanity` peers.
+- [vanilla-extract](https://vanilla-extract.style) — `style`, `createVar`, `styleVariants`,
+  `keyframes`, `globalStyle`; and
+  [`@vanilla-extract/dynamic`](https://vanilla-extract.style/documentation/packages/dynamic/) for
+  `assignInlineVars`.
+- [`@sanity/ui`](https://www.sanity.io/ui) for theme tokens, the `useTheme()` hook, and primitives.

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -4,12 +4,12 @@ How to style plugin UI without paying an unnecessary runtime cost or breaking St
 
 ## Priority order
 
-In **greenfield** plugin code, [vanilla-extract](https://vanilla-extract.style) is the styling
-solution for everything you author — both static and dynamic styles. It compiles to a static
-stylesheet at build time (zero per-render and per-instance runtime cost), produces type-safe,
-locally-scoped class names, and lives next to the component in a `.css.ts` file.
-`@sanity/google-maps-input` is the reference implementation (migrated in
-[PR #1417](https://github.com/sanity-io/plugins/pull/1417)).
+[vanilla-extract](https://vanilla-extract.style) is the styling solution for everything you author in
+this monorepo — both static and dynamic styles, in new plugins and in existing ones (which are being
+migrated off `styled-components`). It compiles to a static stylesheet at build time (zero per-render
+and per-instance runtime cost), produces type-safe, locally-scoped class names, and lives next to the
+component in a `.css.ts` file. `@sanity/google-maps-input` is the reference implementation (migrated
+in [PR #1417](https://github.com/sanity-io/plugins/pull/1417)).
 
 Decide as follows:
 
@@ -18,14 +18,16 @@ Decide as follows:
    `@sanity/ui` theme, or vary with props or state.
 3. **Import a third-party `.css`** once at module scope — for prebuilt stylesheets you don't author
    (katex, easymde, react-photo-album).
-4. **`styled-components`** — **brownfield only.** Existing plugins keep it; do not reach for it in
-   new code. See [Brownfield only: styled-components](#brownfield-only-styled-components).
-5. **Never** raw `<style>` tags or runtime stylesheet injection from a component.
+4. **Never** raw `<style>` tags or runtime stylesheet injection from a component.
 
-> There is essentially no reason to start new code on `styled-components`, even when the plugin is
-> built on `@sanity/ui` (most are). Using `@sanity/ui` does not make `styled-components` a good fit
-> for customizing it or reading its theme: read tokens with the `useTheme_v2()` hook and forward them
-> into vanilla-extract instead (see [Dynamic styling](#dynamic-styling-with-vanilla-extract)).
+`styled-components` is **not** one of the options above. It is the Studio's legacy styling library —
+still present in some plugins, but on its way out. Never add it to a plugin, and migrate existing
+usage to vanilla-extract (see [Migrating off styled-components](#migrating-off-styled-components)).
+
+> There is no reason to write `styled-components`, even when the plugin is built on `@sanity/ui`
+> (most are). Using `@sanity/ui` does not make `styled-components` a good fit for customizing it or
+> reading its theme: read tokens with the `useTheme_v2()` hook and forward them into vanilla-extract
+> instead (see [Dynamic styling](#dynamic-styling-with-vanilla-extract)).
 
 ---
 
@@ -508,53 +510,66 @@ declare module 'katex/dist/katex.min.css'
 
 ---
 
-## Brownfield only: styled-components
+## Migrating off styled-components
 
-`styled-components` is the Studio's own styling library and a `@sanity/ui` peer dependency, so
-existing plugins that use it still work correctly — they share a single managed stylesheet and the
-Studio theme. **Keep working brownfield code on `styled-components`; do not rewrite it
-speculatively.** A migration to vanilla-extract must be done carefully — and usually in its own PR —
-to preserve visual fidelity and avoid regressions. The `plugin-transfer` skill makes this a rule:
-transfers never migrate styling in the initial port.
+`styled-components` is the Studio's legacy styling library (a `@sanity/ui` peer). It still works, but
+**no new code uses it and existing usage is migrated to vanilla-extract** — this skill is the guide
+for that migration. Don't add `styled-components` to a plugin, and convert a component's styling to
+vanilla-extract when you work on it rather than extending the styled-components code.
 
-> **Locking in a finished migration.** Once a plugin no longer imports `styled-components` at all,
-> ban it via `no-restricted-imports` in `.oxlintrc.json` so it cannot creep back — this is how
-> `@sanity/vision` locked in its migration in
-> [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333).
+The migration is mechanical, reusing the patterns above:
 
-For **new** code, prefer vanilla-extract (above). The notes below apply only when maintaining a
-plugin that is already on `styled-components`:
+- `styled(Primitive)` / `styled.div` → a `style()` rule plus a thin wrapper component that keeps the
+  same name and API, so call sites don't change. See
+  [Keep the component layer](#keep-the-component-layer-encapsulation).
+- Theme reads (`({theme}) => theme.sanity...`) → `useTheme_v2()` + `assignInlineVars` over a
+  `createVar()`. See [Dynamic styling](#dynamic-styling-with-vanilla-extract).
+- `css` variants → `styleVariants`; `keyframes` → vanilla-extract `keyframes`; descendant or
+  third-party selectors → `globalStyle` scoped under a wrapper class.
+- Overriding a primitive's own styles often needs the `selectors: {'&&': {...}}` trick that
+  styled-components got for free via CSSOM ordering (see the `&&` trick section above).
 
-**Import named, not default** (`import styled from 'styled-components'` was removed — see the
-`@sanity/code-input` changelog):
-
-```ts
-import {css, keyframes, styled} from 'styled-components'
-```
-
-**Extend `@sanity/ui` primitives** rather than bare DOM elements, and **read theme tokens** with the
-`({theme}) => ...` accessor:
+For example, the markdown CodeMirror theming moves from a `styled(Box)` template:
 
 ```tsx
-// plugins/sanity-plugin-markdown/src/components/MarkdownInput.tsx
-import {Box} from '@sanity/ui'
-import {styled} from 'styled-components'
-
+// Before — styled-components
 const MarkdownInputStyles = styled(Box)`
   & .CodeMirror.CodeMirror {
     color: ${({theme}) => theme.sanity.color.card.enabled.fg};
-    border-color: ${({theme}) => theme.sanity.color.card.enabled.border};
-    background-color: inherit;
   }
 `
 ```
 
-### Dependency setup (brownfield)
+to a colocated `.css.ts` with `globalStyle` + a variable set from the theme (see
+[Dynamic styling](#dynamic-styling-with-vanilla-extract) for wiring the variable via `useTheme_v2()`):
 
-Declare `styled-components` so the plugin resolves to the workspace override
-(`styled-components: npm:@sanity/styled-components@latest`). This guarantees a **single**
-styled-components instance shared with the Studio — without it, pnpm may install a separate copy and
-theming/SSR break.
+```ts
+// After — MarkdownInput.css.ts
+import {createVar, globalStyle, style} from '@vanilla-extract/css'
+
+export const fg = createVar()
+export const markdownInput = style({})
+
+globalStyle(`${markdownInput} .CodeMirror.CodeMirror`, {
+  color: fg,
+})
+```
+
+**Migrate carefully.** The goal is identical visual output — verify the result against the original
+(theme tokens, spacing, specificity). Where styled-components silently won on source order, you may
+need `&&` to match. During a plugin **transfer/port**, do not migrate styling in the same PR: keep it
+building as-is and do the migration in a dedicated follow-up PR (see the `plugin-transfer` skill).
+
+> **Lock in a finished migration.** Once a plugin no longer imports `styled-components`, ban it via
+> `no-restricted-imports` in `.oxlintrc.json` so it cannot creep back — this is how `@sanity/vision`
+> locked in its migration in
+> [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333).
+
+### While a plugin still has styled-components
+
+Until a plugin is fully migrated, keep its `styled-components` declaration aligned so it resolves to
+the workspace `@sanity/styled-components` override — a **single** instance shared with the Studio,
+without which pnpm may install a separate copy and theming/SSR break:
 
 ```json
 {
@@ -567,10 +582,11 @@ theming/SSR break.
 }
 ```
 
-- It is a **peer dependency** (the host Studio provides it) — never list it under `dependencies`.
-- The `catalog:` devDependency pins the same version the rest of the monorepo uses and keeps the
-  plugin on the shared `sanity` peer variant (see the `plugin-transfer` skill for why duplicate
-  variants break type-aware lint).
+- It is a **peer dependency** (the host Studio provides it) — never under `dependencies`.
+- The `catalog:` devDependency keeps the plugin on the shared `sanity` peer variant (see the
+  `plugin-transfer` skill for why duplicate variants break type-aware lint).
+
+Remove both once the migration is complete.
 
 ---
 
@@ -593,8 +609,8 @@ that forces synchronous reflows. See the `vercel-react-best-practices` rule `js-
 
 - `vercel-react-best-practices` → `rules/js-batch-dom-css.md` (batch DOM/CSS writes, prefer classes),
   `rules/rendering-hoist-jsx.md`, and the rendering section generally.
-- `plugin-transfer` skill → keep transferred plugins on `styled-components`; dependency alignment for
-  `styled-components` and `sanity` peers.
+- `plugin-transfer` skill → don't migrate styling during a transfer (do it in a follow-up PR);
+  dependency alignment for `styled-components` and `sanity` peers.
 - [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333) — reference migration of
   `@sanity/vision`: the component-layer (encapsulation) pattern and the `&&` specificity trick.
 - [vanilla-extract](https://vanilla-extract.style) — `style`, `createVar`, `styleVariants`,

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -226,6 +226,12 @@ catalog:
 "ignoreDependencies": ["@vanilla-extract/css"]
 ```
 
+> **New plugins get this for free.** `pnpm generate "new plugin"` wires all of the above
+> automatically when you opt into styling — the `rollup` option, the `./bundle.css` export, the
+> catalog devDeps, the `vitest.config.ts` plugin, and an example `Tool.css.ts`. The test studio
+> already registers the Vite plugin globally, so generated plugins render in `pnpm dev` with no extra
+> steps.
+
 ---
 
 ## Dynamic styling with vanilla-extract

--- a/turbo/generators/src/config.ts
+++ b/turbo/generators/src/config.ts
@@ -347,16 +347,26 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         default: defaultExport,
       })
 
-      // Step 5: Ask about styled-components
-      const {hasStyledComponents} = await inquirer.prompt<{hasStyledComponents: boolean}>({
+      // Step 5: Ask about styling. New (greenfield) plugins use vanilla-extract — never
+      // styled-components — per the sanity-plugin-best-practices skill.
+      const {hasVanillaExtract} = await inquirer.prompt<{hasVanillaExtract: boolean}>({
         type: 'confirm',
-        name: 'hasStyledComponents',
-        message: 'Will this plugin use styled-components?',
-        default: false,
+        name: 'hasVanillaExtract',
+        message:
+          'Will this plugin include styling? (sets up vanilla-extract; recommended for any UI)',
+        default: true,
       })
 
-      // Version starts at 0.0.1 for new plugins (replaces the OIDC setup package)
-      return {name, description, pluginNamedExport, hasStyledComponents, version: '0.0.1'}
+      // Version starts at 0.0.1 for new plugins (replaces the OIDC setup package).
+      // `hasStyledComponents` is always false for new plugins (greenfield uses vanilla-extract).
+      return {
+        name,
+        description,
+        pluginNamedExport,
+        hasVanillaExtract,
+        hasStyledComponents: false,
+        version: '0.0.1',
+      }
     },
     actions: [
       {
@@ -378,6 +388,14 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         type: 'add',
         path: '{{ turbo.paths.root }}/plugins/{{ name }}/src/components/Tool.tsx',
         templateFile: 'templates/src/components/Tool.tsx.hbs',
+      },
+      {
+        // Only scaffolded when styling was requested; Tool.tsx imports it conditionally
+        type: 'add',
+        path: '{{ turbo.paths.root }}/plugins/{{ name }}/src/components/Tool.css.ts',
+        templateFile: 'templates/src/components/Tool.css.ts.hbs',
+        skip: (data: {hasVanillaExtract?: boolean}) =>
+          data.hasVanillaExtract ? undefined : 'no styling selected; skipping Tool.css.ts',
       },
       {
         type: 'add',
@@ -553,6 +571,9 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
         description,
         pluginNamedExport,
         hasStyledComponents,
+        // Transfers keep their existing styled-components; styling is never migrated to
+        // vanilla-extract during the initial port (see the plugin-transfer skill).
+        hasVanillaExtract: false,
         version,
         isolatedDeclarations,
         originalRepositoryUrl,

--- a/turbo/generators/templates/package.config.ts.hbs
+++ b/turbo/generators/templates/package.config.ts.hbs
@@ -9,4 +9,7 @@ export default defineConfig({
   babel: {reactCompiler: true},
 {{/if}}
   reactCompilerOptions: {target: '19'},
+{{#if hasVanillaExtract}}
+  rollup: {vanillaExtract: true},
+{{/if}}
 })

--- a/turbo/generators/templates/package.json.hbs
+++ b/turbo/generators/templates/package.json.hbs
@@ -28,6 +28,14 @@
       "development": "./src/index.ts",
       "default": "./dist/index.js"
     },
+{{#if hasVanillaExtract}}
+    "./bundle.css": {
+      "browser": "./dist/bundle.css",
+      "style": "./dist/bundle.css",
+      "node": "./dist/bundle.css.js",
+      "default": "./dist/bundle.css.js"
+    },
+{{/if}}
     "./package.json": "./package.json"
   },
   "types": "./dist/index.d.ts",
@@ -51,6 +59,10 @@
     "@sanity/pkg-utils": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+{{#if hasVanillaExtract}}
+    "@vanilla-extract/css": "catalog:",
+    "@vanilla-extract/vite-plugin": "catalog:",
+{{/if}}
     "babel-plugin-react-compiler": "catalog:",
 {{#if hasStyledComponents}}
     "babel-plugin-styled-components": "catalog:",
@@ -72,6 +84,14 @@
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",
+{{#if hasVanillaExtract}}
+      "./bundle.css": {
+        "browser": "./dist/bundle.css",
+        "style": "./dist/bundle.css",
+        "node": "./dist/bundle.css.js",
+        "default": "./dist/bundle.css.js"
+      },
+{{/if}}
       "./package.json": "./package.json"
     }
   }

--- a/turbo/generators/templates/src/components/Tool.css.ts.hbs
+++ b/turbo/generators/templates/src/components/Tool.css.ts.hbs
@@ -1,0 +1,5 @@
+import {style} from '@vanilla-extract/css'
+
+export const layout = style({
+  width: '100%',
+})

--- a/turbo/generators/templates/src/components/Tool.tsx.hbs
+++ b/turbo/generators/templates/src/components/Tool.tsx.hbs
@@ -1,16 +1,15 @@
 import {Flex, Heading} from '@sanity/ui'
-{{#if hasStyledComponents}}
-import {styled} from 'styled-components'
+{{#if hasVanillaExtract}}
 
-const Layout = styled(Flex).attrs({
-  align: 'center',
-  direction: 'column',
-  height: 'fill',
-  justify: 'center',
-})`
-  width: 100%;
-`
+import {layout} from './Tool.css'
 
+function Layout({children}: {children: React.ReactNode}) {
+  return (
+    <Flex align="center" className={layout} direction="column" height="fill" justify="center">
+      {children}
+    </Flex>
+  )
+}
 {{else}}
 
 function Layout({children}: {children: React.ReactNode}) {

--- a/turbo/generators/templates/vitest.config.ts.hbs
+++ b/turbo/generators/templates/vitest.config.ts.hbs
@@ -1,6 +1,12 @@
+{{#if hasVanillaExtract}}
+import {vanillaExtractPlugin} from '@vanilla-extract/vite-plugin'
+{{/if}}
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+{{#if hasVanillaExtract}}
+  plugins: [vanillaExtractPlugin()],
+{{/if}}
   test: {
     server: {
       deps: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes [`@vanilla-extract/css`](https://vanilla-extract.style) the styling solution for **all** plugin code — static and dynamic — frames `styled-components` as **legacy to migrate off** (with one narrow CSS-in-JS escape hatch), and updates the **`new plugin` generator** to scaffold vanilla-extract. Grounded in `@sanity/google-maps-input` (#1417) and the `@sanity/vision` migration in [sanity-io/sanity#13333](https://github.com/sanity-io/sanity/pull/13333).

## Changes

### Skill docs

- **`sanity-plugin-best-practices/references/styling.md`** (largest):
  - Priority order: vanilla-extract `style()` (static) → `createVar()` + `assignInlineVars()` (dynamic) → third-party `.css` imports → never raw `<style>`/`useInsertionEffect`. `styled-components` is **not** a tier — it's legacy, with one last-resort CSS-in-JS escape hatch (arbitrary CSS from runtime data).
  - **Preferred: vanilla-extract** (static) + full **setup**, with a note the generator wires it automatically.
  - **Dynamic styling**: `createVar()` + `assignInlineVars()` (`@vanilla-extract/dynamic`) read via `@sanity/ui`'s `useTheme_v2()` — grounded in `ResultViewWrapper` (sanity#13333); plus `styleVariants` / `keyframes` / `globalStyle`; build-time vs runtime dep split.
  - **Keep the component layer (encapsulation)**: wrap each class in a small component (same export name/API as the old `styled()`); `forwardRef`, `ComponentProps`, boolean→conditional-class.
  - **Overriding `@sanity/ui` styles: the `&&` trick** (CSSOM ordering rationale; real examples).
  - **Anti-pattern: raw `<style>` / `useInsertionEffect`** — hand-rolled CSS insertion is banned; the sole escape hatch (genuinely arbitrary runtime CSS) is `styled-components`, the most performant CSS-in-JS.
  - **Migrating off styled-components**: legacy; mechanical migration guide (before/after), visual-fidelity caveat, transfer-timing exception, dependency alignment "while still present; remove once migrated", lock-in via `no-restricted-imports`; ordinary styling always migrates while the rare arbitrary-runtime-CSS usage may stay.
- **`sanity-plugin-best-practices/SKILL.md`**: one-line rule, table row, principles reframe `styled-components` as legacy-to-migrate with the CSS-in-JS escape hatch; tokens via `useTheme_v2()`; encapsulation + `&&`; bumped to `1.2.0`.
- **`plugin-transfer/SKILL.md`**: a transferred plugin's `styled-components` is left for the initial port and migrated in a follow-up PR.

### `new plugin` generator (`turbo/generators`)

- Replaced the `"Will this plugin use styled-components?"` prompt with a styling prompt that sets up **vanilla-extract** (default yes); new plugins never scaffold styled-components.
- When enabled, templates wire `rollup: {vanillaExtract: true}`, the `./bundle.css` export (+ `publishConfig`), the two catalog devDeps, `vanillaExtractPlugin()` in `vitest.config.ts`, and an example `Tool.css.ts` consumed via an encapsulated `<Layout>` wrapper.
- `copy plugin` leaves styled-components in place for brownfield transfers (migrated later).

## Testing

- ✅ `pnpm format` (idempotent; `.hbs` templates are oxfmt-ignored)
- ✅ `pnpm lint`
- ✅ `pnpm --filter @repo/generators build` (Node 22.22.2) — `config.ts` compiles
- ✅ Handlebars render test of every modified/added template (new / copy / no-styling) — matches the merged `google-maps-input` wiring; generated `package.json` is valid JSON
- ✅ Verified plop's `skip()` data contract (bundled `cli.js` calls `await skip({...data})`)
- ✅ Real `pkg build` proving `dist/bundle.css` is emitted even when the only `.css.ts` is in a **lazy** chunk (probed in `google-maps-input`, then reverted)
- ✅ All intra-doc anchor links resolve

Skill docs are under `.agents/` (not a published package); the generator change touches only scaffolding templates/config. No changeset required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf06cec1-863d-4f62-80c4-1ef0192c224b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf06cec1-863d-4f62-80c4-1ef0192c224b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

