### PR TITLE
feat(code-input): add an "Expand editor" button

### DIFF
--- a/.changeset/code-input-fullscreen.md
+++ b/.changeset/code-input-fullscreen.md
@@ -1,0 +1,5 @@
+---
+"@sanity/code-input": minor
+---
+
+Add an "Expand editor" button that expands the code editor to fill the document pane. Use the new `disableFullscreen` field option to hide it.

--- a/dev/test-studio/src/code-input/index.tsx
+++ b/dev/test-studio/src/code-input/index.tsx
@@ -35,6 +35,15 @@ const codeTest = defineType({
       },
     },
     {
+      name: 'codeNoFullscreen',
+      title: 'Code with fullscreen disabled',
+      description: 'A code input with the fullscreen toggle button hidden',
+      type: 'code',
+      options: {
+        disableFullscreen: true,
+      },
+    },
+    {
       name: 'readOnlyCode',
       title: 'Read-only code',
       description: 'Code input in readOnly mode',

--- a/plugins/@sanity/code-input/README.md
+++ b/plugins/@sanity/code-input/README.md
@@ -52,6 +52,7 @@ defineType({
 - `language` - Default language for this code field.
 - `languageAlternatives` - Array of languages that should be available (se its format in the example below)
 - `withFilename` - Boolean option to display input field for filename
+- `disableFullscreen` - Boolean option to hide the "Expand editor" button (expanding is enabled by default)
 
 ```js
 //...fields,
@@ -67,9 +68,14 @@ defineField({
       {title: 'CSS', value: 'css'},
     ],
     withFilename: true,
+    disableFullscreen: false,
   },
 })
 ```
+
+The code editor can be expanded to fill the document pane using the "Expand
+editor" button in the top-right corner of the editor (press `Escape` to
+collapse). Set `disableFullscreen: true` to hide this button.
 
 ![Code input with all options in dark mode](assets/all-options.png)
 

--- a/plugins/@sanity/code-input/src/CodeInput.tsx
+++ b/plugins/@sanity/code-input/src/CodeInput.tsx
@@ -1,6 +1,5 @@
-import {CollapseIcon, ExpandIcon} from '@sanity/icons'
-import {Box, Button, Card, Layer, Portal, Stack, Text, Tooltip} from '@sanity/ui'
-import {type CSSProperties, Suspense, useCallback, useEffect, useRef, useState} from 'react'
+import {Box, Stack, Text} from '@sanity/ui'
+import {Suspense, useCallback} from 'react'
 import {
   MemberField,
   type ObjectInputProps,
@@ -9,14 +8,13 @@ import {
   setIfMissing,
   unset,
 } from 'sanity'
-import {css, styled} from 'styled-components'
 
+import {EditorContainer, FullscreenEditor} from './CodeInputFullscreen'
 import {CodeMirrorProxy, useMounted} from './codemirror/useCodeMirror'
 import {useLanguageMode} from './codemirror/useLanguageMode'
 import {PATH_CODE} from './config'
 import {LanguageField} from './LanguageField'
 import type {CodeInputValue, CodeSchemaType} from './types'
-import {focusRingBorderStyle, focusRingStyle} from './ui/focusRingStyle'
 import {useFieldMember} from './useFieldMember'
 
 export type {CodeInputLanguage, CodeInputValue} from './types'
@@ -25,131 +23,6 @@ export type {CodeInputLanguage, CodeInputValue} from './types'
  * @public
  */
 export interface CodeInputProps extends ObjectInputProps<CodeInputValue, CodeSchemaType> {}
-
-// Match the Studio's tooltip timing (see TOOLTIP_DELAY_PROPS in `sanity`)
-const TOOLTIP_DELAY = {open: 400}
-
-// Studio DOM markers for the document pane and its scrolling content area
-const DOCUMENT_PANE_SELECTOR = '[data-testid="document-pane"]'
-const DOCUMENT_PANEL_SCROLLER_SELECTOR = '[data-testid="document-panel-scroller"]'
-// The currently selected pane, used to disambiguate split-view layouts
-const SELECTED_PANE_SCROLLER_SELECTOR = `${DOCUMENT_PANE_SELECTOR}[data-pane-selected="true"] ${DOCUMENT_PANEL_SCROLLER_SELECTOR}`
-
-// Finds the nearest scrollable ancestor — fallback for locating the pane.
-function getScrollParent(node: HTMLElement | null): HTMLElement | null {
-  let current = node?.parentElement ?? null
-  while (current) {
-    const {overflowY} = window.getComputedStyle(current)
-    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
-      return current
-    }
-    current = current.parentElement
-  }
-  return null
-}
-
-// Resolves the document panel's scroll container so the fullscreen overlay fills
-// the document pane — not the whole viewport, and not a surrounding dialog when
-// the field is edited inside a modal (which is rendered in a portal).
-function getDocumentPaneElement(node: HTMLElement | null): HTMLElement | null {
-  if (!node) return null
-
-  const ownPane = node.closest(DOCUMENT_PANE_SELECTOR)
-  if (ownPane instanceof HTMLElement) {
-    const scroller = ownPane.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
-    return scroller instanceof HTMLElement ? scroller : ownPane
-  }
-
-  // Field is rendered in a portal (e.g. a modal), so we can't walk up to the
-  // pane. Prefer the selected pane (disambiguates split-view layouts), then any
-  // document panel, then the nearest scrollable ancestor.
-  const selectedScroller = document.querySelector(SELECTED_PANE_SCROLLER_SELECTOR)
-  if (selectedScroller instanceof HTMLElement) return selectedScroller
-
-  const scroller = document.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
-  if (scroller instanceof HTMLElement) return scroller
-
-  return getScrollParent(node)
-}
-
-// In-place anchor for the editor; also the reference point for locating the
-// surrounding document pane.
-const FullscreenRoot = styled.div`
-  position: relative;
-`
-
-// The portaled fullscreen container, pinned (via inline style) to the document
-// pane bounds. Provides the positioning context for the toggle button and draws
-// the top/bottom divider (flush with the pane on the sides).
-const FullscreenOverlay = styled.div(({theme}) => {
-  // oxlint-disable-next-line typescript/no-deprecated
-  const {input} = theme.sanity
-  // oxlint-disable-next-line typescript/no-deprecated
-  const borderColor = theme.sanity.color.input.default.enabled.border
-
-  return css`
-    box-sizing: border-box;
-    overflow: hidden;
-    border-top: ${input.border.width}px solid ${borderColor};
-    border-bottom: ${input.border.width}px solid ${borderColor};
-  `
-})
-
-const ToggleButtonBox = styled(Box)`
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 2;
-`
-
-const EditorContainer = styled(Card)<{$fullscreen: boolean}>(({theme, $fullscreen}) => {
-  // TODO: when upgrading to @sanity/ui@4 start using the new tokens
-  // oxlint-disable-next-line typescript/no-deprecated
-  const {focusRing, input} = theme.sanity
-  // oxlint-disable-next-line typescript/no-deprecated
-  const base = theme.sanity.color.base
-  // oxlint-disable-next-line typescript/no-deprecated
-  const color = theme.sanity.color.input
-  const border = {
-    color: color.default.enabled.border,
-    width: input.border.width,
-  }
-
-  return css`
-    --input-box-shadow: ${focusRingBorderStyle(border)};
-
-    box-shadow: var(--input-box-shadow);
-    height: 250px;
-    min-height: 80px;
-    overflow-y: auto;
-    position: relative;
-    resize: vertical;
-    z-index: 0;
-
-    & > .cm-theme {
-      height: 100%;
-    }
-
-    &:focus-within {
-      --input-box-shadow: ${focusRingStyle({
-        base,
-        border,
-        focusRing,
-      })};
-    }
-
-    ${$fullscreen &&
-    css`
-      height: 100%;
-      border-radius: 0;
-      resize: none;
-      background-color: ${base.bg};
-      /* No editor border in fullscreen — the top/bottom divider is drawn on the
-         FullscreenOverlay so it sits flush against the pane on the sides */
-      box-shadow: none;
-    `}
-  `
-})
 
 /** @public */
 export function CodeInput(props: CodeInputProps): React.JSX.Element {
@@ -197,199 +70,46 @@ export function CodeInput(props: CodeInputProps): React.JSX.Element {
   const mounted = useMounted()
 
   const fullscreenEnabled = !type.options?.disableFullscreen
-  const [isFullscreen, setIsFullscreen] = useState(false)
-  const rootRef = useRef<HTMLDivElement>(null)
-  const overlayRef = useRef<HTMLDivElement>(null)
-  // Bounds of the surrounding document pane, used to size the fullscreen overlay
-  const [paneRect, setPaneRect] = useState<{
-    top: number
-    left: number
-    width: number
-    height: number
-  } | null>(null)
-
-  // Only treat as fullscreen once we've measured the pane bounds
-  const showFullscreen = isFullscreen && paneRect !== null
-
-  const handleToggleFullscreen = useCallback(() => setIsFullscreen((current) => !current), [])
-
-  // Exit fullscreen on Escape. Scoped to the overlay (rather than a global
-  // listener) so it only fires when focus is inside the expanded editor —
-  // other Studio UI keeps its own Escape handling. stopImmediatePropagation on
-  // the native event also prevents a surrounding dialog (when the field is
-  // edited in a modal) from closing alongside the editor.
-  const handleOverlayKeyDown = useCallback((event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      event.stopPropagation()
-      event.nativeEvent.stopImmediatePropagation()
-      setIsFullscreen(false)
-    }
-  }, [])
-
-  // While fullscreen, track the document pane's bounds so the overlay fills the
-  // pane (not the whole viewport, which would cover the Studio chrome).
-  useEffect(() => {
-    if (!isFullscreen) return undefined
-
-    // Fall back to the viewport if the pane can't be located, so the editor
-    // still expands rather than getting stuck in an in-between state.
-    const paneElement = getDocumentPaneElement(rootRef.current)
-
-    const update = () => {
-      const {top, left, width, height} = paneElement
-        ? paneElement.getBoundingClientRect()
-        : {top: 0, left: 0, width: window.innerWidth, height: window.innerHeight}
-      // Bail out if the bounds are unchanged so frequent scroll events (e.g.
-      // scrolling within the editor) don't trigger needless re-renders.
-      setPaneRect((prev) =>
-        prev &&
-        prev.top === top &&
-        prev.left === left &&
-        prev.width === width &&
-        prev.height === height
-          ? prev
-          : {top, left, width, height},
-      )
-    }
-
-    // Defer the initial measurement so we don't call setState synchronously
-    const raf = requestAnimationFrame(update)
-    let resizeObserver: ResizeObserver | undefined
-    if (paneElement) {
-      resizeObserver = new ResizeObserver(update)
-      resizeObserver.observe(paneElement)
-    }
-    window.addEventListener('resize', update)
-    window.addEventListener('scroll', update, true)
-
-    return () => {
-      cancelAnimationFrame(raf)
-      resizeObserver?.disconnect()
-      window.removeEventListener('resize', update)
-      window.removeEventListener('scroll', update, true)
-      // Clear the cached bounds on collapse so the next expand re-measures
-      // instead of briefly rendering at stale coordinates.
-      setPaneRect(null)
-    }
-  }, [isFullscreen])
-
-  // Portaling the overlay drops keyboard focus to <body>, which would stop the
-  // overlay's Escape handler from firing. Move focus into the overlay (prefer
-  // the editor) once it's shown so Escape collapses it and typing works.
-  useEffect(() => {
-    if (!showFullscreen) return undefined
-
-    const raf = requestAnimationFrame(() => {
-      const overlay = overlayRef.current
-      if (!overlay) return
-      const editable = overlay.querySelector<HTMLElement>('.cm-content')
-      ;(editable ?? overlay).focus()
-    })
-
-    return () => cancelAnimationFrame(raf)
-  }, [showFullscreen])
 
   const renderCodeInput: RenderInputCallback = useCallback(
-    (inputProps) => {
-      const fullscreenStyle: CSSProperties | undefined =
-        showFullscreen && paneRect
-          ? {
-              position: 'fixed',
-              top: paneRect.top,
-              left: paneRect.left,
-              width: paneRect.width,
-              height: paneRect.height,
-            }
-          : undefined
-
-      const toggleButton = fullscreenEnabled && (
-        <ToggleButtonBox padding={1}>
-          <Tooltip
-            animate
-            arrow={false}
-            content={<Text size={1}>{showFullscreen ? 'Collapse editor' : 'Expand editor'}</Text>}
-            delay={TOOLTIP_DELAY}
-            placement="left"
-            portal
+    (inputProps) => (
+      <FullscreenEditor enabled={fullscreenEnabled}>
+        {({isFullscreen}) => (
+          <EditorContainer
+            $fullscreen={isFullscreen}
+            border={!isFullscreen}
+            overflow="hidden"
+            radius={1}
+            sizing="border"
+            readOnly={readOnly}
           >
-            <Button
-              aria-label={showFullscreen ? 'Collapse editor' : 'Expand editor'}
-              icon={showFullscreen ? CollapseIcon : ExpandIcon}
-              mode="ghost"
-              onClick={handleToggleFullscreen}
-              padding={2}
-            />
-          </Tooltip>
-        </ToggleButtonBox>
-      )
-
-      const editor = (
-        <EditorContainer
-          $fullscreen={showFullscreen}
-          border={!showFullscreen}
-          overflow="hidden"
-          radius={1}
-          sizing="border"
-          readOnly={readOnly}
-        >
-          {mounted && (
-            <Suspense
-              fallback={
-                <Box padding={3}>
-                  <Text>Loading code editor...</Text>
-                </Box>
-              }
-            >
-              <CodeMirrorProxy
-                languageMode={languageMode}
-                onChange={handleCodeChange}
-                // oxlint-disable-next-line no-unsafe-type-assertion - fix later
-                value={inputProps.value as string}
-                highlightLines={value?.highlightedLines}
-                onHighlightChange={onHighlightChange}
-                readOnly={readOnly}
-                onFocus={handleCodeFocus}
-                onBlur={elementProps.onBlur}
-              />
-            </Suspense>
-          )}
-        </EditorContainer>
-      )
-
-      return (
-        <FullscreenRoot ref={rootRef}>
-          {showFullscreen ? (
-            // Portal out of any surrounding dialog so position:fixed is
-            // viewport-relative, and Layer keeps it stacked above the dialog.
-            <Portal>
-              <Layer>
-                <FullscreenOverlay
-                  onKeyDown={handleOverlayKeyDown}
-                  ref={overlayRef}
-                  style={fullscreenStyle}
-                  tabIndex={-1}
-                >
-                  {toggleButton}
-                  {editor}
-                </FullscreenOverlay>
-              </Layer>
-            </Portal>
-          ) : (
-            <>
-              {toggleButton}
-              {editor}
-            </>
-          )}
-        </FullscreenRoot>
-      )
-    },
+            {mounted && (
+              <Suspense
+                fallback={
+                  <Box padding={3}>
+                    <Text>Loading code editor...</Text>
+                  </Box>
+                }
+              >
+                <CodeMirrorProxy
+                  languageMode={languageMode}
+                  onChange={handleCodeChange}
+                  // oxlint-disable-next-line no-unsafe-type-assertion - fix later
+                  value={inputProps.value as string}
+                  highlightLines={value?.highlightedLines}
+                  onHighlightChange={onHighlightChange}
+                  readOnly={readOnly}
+                  onFocus={handleCodeFocus}
+                  onBlur={elementProps.onBlur}
+                />
+              </Suspense>
+            )}
+          </EditorContainer>
+        )}
+      </FullscreenEditor>
+    ),
     [
-      showFullscreen,
-      paneRect,
       fullscreenEnabled,
-      handleToggleFullscreen,
-      handleOverlayKeyDown,
       readOnly,
       mounted,
       languageMode,

--- a/plugins/@sanity/code-input/src/CodeInput.tsx
+++ b/plugins/@sanity/code-input/src/CodeInput.tsx
@@ -1,5 +1,6 @@
-import {Box, Card, Stack, Text} from '@sanity/ui'
-import {Suspense, useCallback} from 'react'
+import {CollapseIcon, ExpandIcon} from '@sanity/icons'
+import {Box, Button, Card, Layer, Portal, Stack, Text, Tooltip} from '@sanity/ui'
+import {type CSSProperties, Suspense, useCallback, useEffect, useRef, useState} from 'react'
 import {
   MemberField,
   type ObjectInputProps,
@@ -25,7 +26,83 @@ export type {CodeInputLanguage, CodeInputValue} from './types'
  */
 export interface CodeInputProps extends ObjectInputProps<CodeInputValue, CodeSchemaType> {}
 
-const EditorContainer = styled(Card)(({theme}) => {
+// Match the Studio's tooltip timing (see TOOLTIP_DELAY_PROPS in `sanity`)
+const TOOLTIP_DELAY = {open: 400}
+
+// Studio DOM markers for the document pane and its scrolling content area
+const DOCUMENT_PANE_SELECTOR = '[data-testid="document-pane"]'
+const DOCUMENT_PANEL_SCROLLER_SELECTOR = '[data-testid="document-panel-scroller"]'
+// The currently selected pane, used to disambiguate split-view layouts
+const SELECTED_PANE_SCROLLER_SELECTOR = `${DOCUMENT_PANE_SELECTOR}[data-pane-selected="true"] ${DOCUMENT_PANEL_SCROLLER_SELECTOR}`
+
+// Finds the nearest scrollable ancestor — fallback for locating the pane.
+function getScrollParent(node: HTMLElement | null): HTMLElement | null {
+  let current = node?.parentElement ?? null
+  while (current) {
+    const {overflowY} = window.getComputedStyle(current)
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+// Resolves the document panel's scroll container so the fullscreen overlay fills
+// the document pane — not the whole viewport, and not a surrounding dialog when
+// the field is edited inside a modal (which is rendered in a portal).
+function getDocumentPaneElement(node: HTMLElement | null): HTMLElement | null {
+  if (!node) return null
+
+  const ownPane = node.closest(DOCUMENT_PANE_SELECTOR)
+  if (ownPane instanceof HTMLElement) {
+    const scroller = ownPane.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
+    return scroller instanceof HTMLElement ? scroller : ownPane
+  }
+
+  // Field is rendered in a portal (e.g. a modal), so we can't walk up to the
+  // pane. Prefer the selected pane (disambiguates split-view layouts), then any
+  // document panel, then the nearest scrollable ancestor.
+  const selectedScroller = document.querySelector(SELECTED_PANE_SCROLLER_SELECTOR)
+  if (selectedScroller instanceof HTMLElement) return selectedScroller
+
+  const scroller = document.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
+  if (scroller instanceof HTMLElement) return scroller
+
+  return getScrollParent(node)
+}
+
+// In-place anchor for the editor; also the reference point for locating the
+// surrounding document pane.
+const FullscreenRoot = styled.div`
+  position: relative;
+`
+
+// The portaled fullscreen container, pinned (via inline style) to the document
+// pane bounds. Provides the positioning context for the toggle button and draws
+// the top/bottom divider (flush with the pane on the sides).
+const FullscreenOverlay = styled.div(({theme}) => {
+  // oxlint-disable-next-line typescript/no-deprecated
+  const {input} = theme.sanity
+  // oxlint-disable-next-line typescript/no-deprecated
+  const borderColor = theme.sanity.color.input.default.enabled.border
+
+  return css`
+    box-sizing: border-box;
+    overflow: hidden;
+    border-top: ${input.border.width}px solid ${borderColor};
+    border-bottom: ${input.border.width}px solid ${borderColor};
+  `
+})
+
+const ToggleButtonBox = styled(Box)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+`
+
+const EditorContainer = styled(Card)<{$fullscreen: boolean}>(({theme, $fullscreen}) => {
   // TODO: when upgrading to @sanity/ui@4 start using the new tokens
   // oxlint-disable-next-line typescript/no-deprecated
   const {focusRing, input} = theme.sanity
@@ -60,6 +137,17 @@ const EditorContainer = styled(Card)(({theme}) => {
         focusRing,
       })};
     }
+
+    ${$fullscreen &&
+    css`
+      height: 100%;
+      border-radius: 0;
+      resize: none;
+      background-color: ${base.bg};
+      /* No editor border in fullscreen — the top/bottom divider is drawn on the
+         FullscreenOverlay so it sits flush against the pane on the sides */
+      box-shadow: none;
+    `}
   `
 })
 
@@ -108,10 +196,143 @@ export function CodeInput(props: CodeInputProps): React.JSX.Element {
 
   const mounted = useMounted()
 
+  const fullscreenEnabled = !type.options?.disableFullscreen
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+  // Bounds of the surrounding document pane, used to size the fullscreen overlay
+  const [paneRect, setPaneRect] = useState<{
+    top: number
+    left: number
+    width: number
+    height: number
+  } | null>(null)
+
+  // Only treat as fullscreen once we've measured the pane bounds
+  const showFullscreen = isFullscreen && paneRect !== null
+
+  const handleToggleFullscreen = useCallback(() => setIsFullscreen((current) => !current), [])
+
+  // Exit fullscreen on Escape. Scoped to the overlay (rather than a global
+  // listener) so it only fires when focus is inside the expanded editor —
+  // other Studio UI keeps its own Escape handling. stopImmediatePropagation on
+  // the native event also prevents a surrounding dialog (when the field is
+  // edited in a modal) from closing alongside the editor.
+  const handleOverlayKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      event.nativeEvent.stopImmediatePropagation()
+      setIsFullscreen(false)
+    }
+  }, [])
+
+  // While fullscreen, track the document pane's bounds so the overlay fills the
+  // pane (not the whole viewport, which would cover the Studio chrome).
+  useEffect(() => {
+    if (!isFullscreen) return undefined
+
+    // Fall back to the viewport if the pane can't be located, so the editor
+    // still expands rather than getting stuck in an in-between state.
+    const paneElement = getDocumentPaneElement(rootRef.current)
+
+    const update = () => {
+      const {top, left, width, height} = paneElement
+        ? paneElement.getBoundingClientRect()
+        : {top: 0, left: 0, width: window.innerWidth, height: window.innerHeight}
+      // Bail out if the bounds are unchanged so frequent scroll events (e.g.
+      // scrolling within the editor) don't trigger needless re-renders.
+      setPaneRect((prev) =>
+        prev &&
+        prev.top === top &&
+        prev.left === left &&
+        prev.width === width &&
+        prev.height === height
+          ? prev
+          : {top, left, width, height},
+      )
+    }
+
+    // Defer the initial measurement so we don't call setState synchronously
+    const raf = requestAnimationFrame(update)
+    let resizeObserver: ResizeObserver | undefined
+    if (paneElement) {
+      resizeObserver = new ResizeObserver(update)
+      resizeObserver.observe(paneElement)
+    }
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+      // Clear the cached bounds on collapse so the next expand re-measures
+      // instead of briefly rendering at stale coordinates.
+      setPaneRect(null)
+    }
+  }, [isFullscreen])
+
+  // Portaling the overlay drops keyboard focus to <body>, which would stop the
+  // overlay's Escape handler from firing. Move focus into the overlay (prefer
+  // the editor) once it's shown so Escape collapses it and typing works.
+  useEffect(() => {
+    if (!showFullscreen) return undefined
+
+    const raf = requestAnimationFrame(() => {
+      const overlay = overlayRef.current
+      if (!overlay) return
+      const editable = overlay.querySelector<HTMLElement>('.cm-content')
+      ;(editable ?? overlay).focus()
+    })
+
+    return () => cancelAnimationFrame(raf)
+  }, [showFullscreen])
+
   const renderCodeInput: RenderInputCallback = useCallback(
     (inputProps) => {
-      return (
-        <EditorContainer border overflow="hidden" radius={1} sizing="border" readOnly={readOnly}>
+      const fullscreenStyle: CSSProperties | undefined =
+        showFullscreen && paneRect
+          ? {
+              position: 'fixed',
+              top: paneRect.top,
+              left: paneRect.left,
+              width: paneRect.width,
+              height: paneRect.height,
+            }
+          : undefined
+
+      const toggleButton = fullscreenEnabled && (
+        <ToggleButtonBox padding={1}>
+          <Tooltip
+            animate
+            arrow={false}
+            content={<Text size={1}>{showFullscreen ? 'Collapse editor' : 'Expand editor'}</Text>}
+            delay={TOOLTIP_DELAY}
+            placement="left"
+            portal
+          >
+            <Button
+              aria-label={showFullscreen ? 'Collapse editor' : 'Expand editor'}
+              icon={showFullscreen ? CollapseIcon : ExpandIcon}
+              mode="ghost"
+              onClick={handleToggleFullscreen}
+              padding={2}
+            />
+          </Tooltip>
+        </ToggleButtonBox>
+      )
+
+      const editor = (
+        <EditorContainer
+          $fullscreen={showFullscreen}
+          border={!showFullscreen}
+          overflow="hidden"
+          radius={1}
+          sizing="border"
+          readOnly={readOnly}
+        >
           {mounted && (
             <Suspense
               fallback={
@@ -135,8 +356,40 @@ export function CodeInput(props: CodeInputProps): React.JSX.Element {
           )}
         </EditorContainer>
       )
+
+      return (
+        <FullscreenRoot ref={rootRef}>
+          {showFullscreen ? (
+            // Portal out of any surrounding dialog so position:fixed is
+            // viewport-relative, and Layer keeps it stacked above the dialog.
+            <Portal>
+              <Layer>
+                <FullscreenOverlay
+                  onKeyDown={handleOverlayKeyDown}
+                  ref={overlayRef}
+                  style={fullscreenStyle}
+                  tabIndex={-1}
+                >
+                  {toggleButton}
+                  {editor}
+                </FullscreenOverlay>
+              </Layer>
+            </Portal>
+          ) : (
+            <>
+              {toggleButton}
+              {editor}
+            </>
+          )}
+        </FullscreenRoot>
+      )
     },
     [
+      showFullscreen,
+      paneRect,
+      fullscreenEnabled,
+      handleToggleFullscreen,
+      handleOverlayKeyDown,
       readOnly,
       mounted,
       languageMode,

--- a/plugins/@sanity/code-input/src/CodeInputFullscreen.tsx
+++ b/plugins/@sanity/code-input/src/CodeInputFullscreen.tsx
@@ -8,6 +8,9 @@ import {focusRingBorderStyle, focusRingStyle} from './ui/focusRingStyle'
 // Match the Studio's tooltip timing (TOOLTIP_DELAY_PROPS in `sanity`)
 const TOOLTIP_DELAY = {open: 400}
 
+// Default editor height; also the placeholder height while expanded.
+const EDITOR_HEIGHT = 250
+
 // Studio DOM markers for the document pane and its scroll container
 const DOCUMENT_PANE_SELECTOR = '[data-testid="document-pane"]'
 const DOCUMENT_PANEL_SCROLLER_SELECTOR = '[data-testid="document-panel-scroller"]'
@@ -95,7 +98,7 @@ export const EditorContainer = styled(Card)<{$fullscreen: boolean}>(({theme, $fu
     --input-box-shadow: ${focusRingBorderStyle(border)};
 
     box-shadow: var(--input-box-shadow);
-    height: 250px;
+    height: ${EDITOR_HEIGHT}px;
     min-height: 80px;
     overflow-y: auto;
     position: relative;
@@ -150,22 +153,43 @@ export function FullscreenEditor({enabled, children}: FullscreenEditorProps): Re
     width: number
     height: number
   } | null>(null)
+  // Editor height captured when expanding, so the in-place placeholder keeps the
+  // surrounding fields from shifting while the editor is portaled away.
+  const [placeholderHeight, setPlaceholderHeight] = useState(EDITOR_HEIGHT)
 
   // Only treat as fullscreen once the pane is measured.
   const showFullscreen = isFullscreen && paneRect !== null
 
-  const handleToggle = useCallback(() => setIsFullscreen((current) => !current), [])
+  // Reset paneRect alongside isFullscreen so the next expand re-measures (rather
+  // than rendering at stale coordinates). Done here, not in the effect cleanup,
+  // to avoid a state update when the component unmounts while expanded.
+  const collapse = useCallback(() => {
+    setPaneRect(null)
+    setIsFullscreen(false)
+  }, [])
+
+  const handleToggle = useCallback(() => {
+    if (isFullscreen) {
+      collapse()
+      return
+    }
+    setPlaceholderHeight(rootRef.current?.offsetHeight ?? EDITOR_HEIGHT)
+    setIsFullscreen(true)
+  }, [isFullscreen, collapse])
 
   // Exit on Escape, scoped to the overlay so other Studio UI keeps its own
   // handling; stopImmediatePropagation keeps a surrounding modal open.
-  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      event.preventDefault()
-      event.stopPropagation()
-      event.nativeEvent.stopImmediatePropagation()
-      setIsFullscreen(false)
-    }
-  }, [])
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        event.stopPropagation()
+        event.nativeEvent.stopImmediatePropagation()
+        collapse()
+      }
+    },
+    [collapse],
+  )
 
   // Track the pane bounds while fullscreen so the overlay fills the pane.
   useEffect(() => {
@@ -205,8 +229,6 @@ export function FullscreenEditor({enabled, children}: FullscreenEditorProps): Re
       resizeObserver?.disconnect()
       window.removeEventListener('resize', update)
       window.removeEventListener('scroll', update, true)
-      // Clear bounds on collapse so the next expand re-measures.
-      setPaneRect(null)
     }
   }, [isFullscreen])
 
@@ -263,21 +285,26 @@ export function FullscreenEditor({enabled, children}: FullscreenEditorProps): Re
   return (
     <FullscreenRoot ref={rootRef}>
       {showFullscreen ? (
-        // Portal out of any modal so position:fixed is viewport-relative; Layer
-        // stacks it above the modal.
-        <Portal>
-          <Layer>
-            <FullscreenOverlay
-              onKeyDown={handleKeyDown}
-              ref={setOverlayRef}
-              style={fullscreenStyle}
-              tabIndex={-1}
-            >
-              {toggleButton}
-              {children({isFullscreen: showFullscreen})}
-            </FullscreenOverlay>
-          </Layer>
-        </Portal>
+        // Hold the editor's spot in the form layout so sibling fields and the
+        // document scroll position don't shift while it's portaled away.
+        <>
+          <div aria-hidden style={{height: placeholderHeight}} />
+          {/* Portal out of any modal so position:fixed is viewport-relative;
+              Layer stacks it above the modal. */}
+          <Portal>
+            <Layer>
+              <FullscreenOverlay
+                onKeyDown={handleKeyDown}
+                ref={setOverlayRef}
+                style={fullscreenStyle}
+                tabIndex={-1}
+              >
+                {toggleButton}
+                {children({isFullscreen: showFullscreen})}
+              </FullscreenOverlay>
+            </Layer>
+          </Portal>
+        </>
       ) : (
         <>
           {toggleButton}

--- a/plugins/@sanity/code-input/src/CodeInputFullscreen.tsx
+++ b/plugins/@sanity/code-input/src/CodeInputFullscreen.tsx
@@ -1,0 +1,289 @@
+import {CollapseIcon, ExpandIcon} from '@sanity/icons'
+import {Box, Button, Card, Layer, Portal, Text, Tooltip} from '@sanity/ui'
+import {type CSSProperties, type ReactNode, useCallback, useEffect, useRef, useState} from 'react'
+import {css, styled} from 'styled-components'
+
+import {focusRingBorderStyle, focusRingStyle} from './ui/focusRingStyle'
+
+// Match the Studio's tooltip timing (TOOLTIP_DELAY_PROPS in `sanity`)
+const TOOLTIP_DELAY = {open: 400}
+
+// Studio DOM markers for the document pane and its scroll container
+const DOCUMENT_PANE_SELECTOR = '[data-testid="document-pane"]'
+const DOCUMENT_PANEL_SCROLLER_SELECTOR = '[data-testid="document-panel-scroller"]'
+// Selected pane — disambiguates split-view layouts
+const SELECTED_PANE_SCROLLER_SELECTOR = `${DOCUMENT_PANE_SELECTOR}[data-pane-selected="true"] ${DOCUMENT_PANEL_SCROLLER_SELECTOR}`
+
+// Nearest scrollable ancestor — last-resort pane fallback.
+function getScrollParent(node: HTMLElement | null): HTMLElement | null {
+  let current = node?.parentElement ?? null
+  while (current) {
+    const {overflowY} = window.getComputedStyle(current)
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}
+
+// Resolve the document pane's scroll container so the overlay fills the pane —
+// not the viewport, and not a surrounding modal (rendered in a portal).
+function getDocumentPaneElement(node: HTMLElement | null): HTMLElement | null {
+  if (!node) return null
+
+  const ownPane = node.closest(DOCUMENT_PANE_SELECTOR)
+  if (ownPane instanceof HTMLElement) {
+    const scroller = ownPane.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
+    return scroller instanceof HTMLElement ? scroller : ownPane
+  }
+
+  // In a portal (modal): can't walk up. Prefer selected pane, then any pane,
+  // then the nearest scrollable ancestor.
+  const selectedScroller = document.querySelector(SELECTED_PANE_SCROLLER_SELECTOR)
+  if (selectedScroller instanceof HTMLElement) return selectedScroller
+
+  const scroller = document.querySelector(DOCUMENT_PANEL_SCROLLER_SELECTOR)
+  if (scroller instanceof HTMLElement) return scroller
+
+  return getScrollParent(node)
+}
+
+// In-place anchor; also the reference for locating the document pane.
+const FullscreenRoot = styled.div`
+  position: relative;
+`
+
+// Portaled container, pinned to the pane bounds via inline style. Draws the
+// top/bottom divider (flush with the pane sides).
+const FullscreenOverlay = styled.div(({theme}) => {
+  // oxlint-disable-next-line typescript/no-deprecated
+  const {input} = theme.sanity
+  // oxlint-disable-next-line typescript/no-deprecated
+  const borderColor = theme.sanity.color.input.default.enabled.border
+
+  return css`
+    box-sizing: border-box;
+    overflow: hidden;
+    border-top: ${input.border.width}px solid ${borderColor};
+    border-bottom: ${input.border.width}px solid ${borderColor};
+  `
+})
+
+const ToggleButtonBox = styled(Box)`
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+`
+
+/** Editor container; fills its parent when `$fullscreen`. */
+export const EditorContainer = styled(Card)<{$fullscreen: boolean}>(({theme, $fullscreen}) => {
+  // TODO: when upgrading to @sanity/ui@4 start using the new tokens
+  // oxlint-disable-next-line typescript/no-deprecated
+  const {focusRing, input} = theme.sanity
+  // oxlint-disable-next-line typescript/no-deprecated
+  const base = theme.sanity.color.base
+  // oxlint-disable-next-line typescript/no-deprecated
+  const color = theme.sanity.color.input
+  const border = {
+    color: color.default.enabled.border,
+    width: input.border.width,
+  }
+
+  return css`
+    --input-box-shadow: ${focusRingBorderStyle(border)};
+
+    box-shadow: var(--input-box-shadow);
+    height: 250px;
+    min-height: 80px;
+    overflow-y: auto;
+    position: relative;
+    resize: vertical;
+    z-index: 0;
+
+    & > .cm-theme {
+      height: 100%;
+    }
+
+    &:focus-within {
+      --input-box-shadow: ${focusRingStyle({
+        base,
+        border,
+        focusRing,
+      })};
+    }
+
+    ${$fullscreen &&
+    css`
+      height: 100%;
+      border-radius: 0;
+      resize: none;
+      background-color: ${base.bg};
+      /* Divider drawn on the overlay so the sides sit flush with the pane */
+      box-shadow: none;
+    `}
+  `
+})
+
+interface FullscreenEditorProps {
+  /** When false, renders children without the expand button. */
+  enabled: boolean
+  children: (state: {isFullscreen: boolean}) => ReactNode
+}
+
+/** Wraps the editor with an "Expand editor" toggle that fills the document pane. */
+export function FullscreenEditor({enabled, children}: FullscreenEditorProps): React.JSX.Element {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const overlayRef = useRef<HTMLDivElement>(null)
+  // Overlay node in state too — used as the tooltip's boundary element.
+  const [overlayElement, setOverlayElement] = useState<HTMLDivElement | null>(null)
+  const setOverlayRef = useCallback((node: HTMLDivElement | null) => {
+    overlayRef.current = node
+    setOverlayElement(node)
+  }, [])
+  // Document pane bounds, used to size the overlay.
+  const [paneRect, setPaneRect] = useState<{
+    top: number
+    left: number
+    width: number
+    height: number
+  } | null>(null)
+
+  // Only treat as fullscreen once the pane is measured.
+  const showFullscreen = isFullscreen && paneRect !== null
+
+  const handleToggle = useCallback(() => setIsFullscreen((current) => !current), [])
+
+  // Exit on Escape, scoped to the overlay so other Studio UI keeps its own
+  // handling; stopImmediatePropagation keeps a surrounding modal open.
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      event.nativeEvent.stopImmediatePropagation()
+      setIsFullscreen(false)
+    }
+  }, [])
+
+  // Track the pane bounds while fullscreen so the overlay fills the pane.
+  useEffect(() => {
+    if (!isFullscreen) return undefined
+
+    // Fall back to the viewport if the pane can't be found.
+    const paneElement = getDocumentPaneElement(rootRef.current)
+
+    const update = () => {
+      const {top, left, width, height} = paneElement
+        ? paneElement.getBoundingClientRect()
+        : {top: 0, left: 0, width: window.innerWidth, height: window.innerHeight}
+      // Skip unchanged bounds so scroll events don't cause needless re-renders.
+      setPaneRect((prev) =>
+        prev &&
+        prev.top === top &&
+        prev.left === left &&
+        prev.width === width &&
+        prev.height === height
+          ? prev
+          : {top, left, width, height},
+      )
+    }
+
+    // Defer so we don't setState synchronously.
+    const raf = requestAnimationFrame(update)
+    let resizeObserver: ResizeObserver | undefined
+    if (paneElement) {
+      resizeObserver = new ResizeObserver(update)
+      resizeObserver.observe(paneElement)
+    }
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      resizeObserver?.disconnect()
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+      // Clear bounds on collapse so the next expand re-measures.
+      setPaneRect(null)
+    }
+  }, [isFullscreen])
+
+  // Portaling drops focus to <body>; move it into the overlay so Escape and
+  // typing work.
+  useEffect(() => {
+    if (!showFullscreen) return undefined
+
+    const raf = requestAnimationFrame(() => {
+      const overlay = overlayRef.current
+      if (!overlay) return
+      const editable = overlay.querySelector<HTMLElement>('.cm-content')
+      ;(editable ?? overlay).focus()
+    })
+
+    return () => cancelAnimationFrame(raf)
+  }, [showFullscreen])
+
+  const toggleButton = enabled && (
+    <ToggleButtonBox padding={1}>
+      <Tooltip
+        animate
+        arrow={false}
+        // Constrain to the overlay so a surrounding modal's boundary doesn't
+        // shift the tooltip; falls back to the viewport when not expanded.
+        boundaryElement={overlayElement}
+        content={<Text size={1}>{showFullscreen ? 'Collapse editor' : 'Expand editor'}</Text>}
+        delay={TOOLTIP_DELAY}
+        placement="bottom"
+        portal
+      >
+        <Button
+          aria-label={showFullscreen ? 'Collapse editor' : 'Expand editor'}
+          icon={showFullscreen ? CollapseIcon : ExpandIcon}
+          mode="ghost"
+          onClick={handleToggle}
+          padding={2}
+        />
+      </Tooltip>
+    </ToggleButtonBox>
+  )
+
+  const fullscreenStyle: CSSProperties | undefined =
+    showFullscreen && paneRect
+      ? {
+          position: 'fixed',
+          top: paneRect.top,
+          left: paneRect.left,
+          width: paneRect.width,
+          height: paneRect.height,
+        }
+      : undefined
+
+  return (
+    <FullscreenRoot ref={rootRef}>
+      {showFullscreen ? (
+        // Portal out of any modal so position:fixed is viewport-relative; Layer
+        // stacks it above the modal.
+        <Portal>
+          <Layer>
+            <FullscreenOverlay
+              onKeyDown={handleKeyDown}
+              ref={setOverlayRef}
+              style={fullscreenStyle}
+              tabIndex={-1}
+            >
+              {toggleButton}
+              {children({isFullscreen: showFullscreen})}
+            </FullscreenOverlay>
+          </Layer>
+        </Portal>
+      ) : (
+        <>
+          {toggleButton}
+          {children({isFullscreen: showFullscreen})}
+        </>
+      )}
+    </FullscreenRoot>
+  )
+}

--- a/plugins/@sanity/code-input/src/types.ts
+++ b/plugins/@sanity/code-input/src/types.ts
@@ -25,6 +25,12 @@ export interface CodeOptions {
   languageAlternatives?: CodeInputLanguage[]
   language?: string
   withFilename?: boolean
+  /**
+   * Hides the fullscreen toggle button on the editor.
+   *
+   * @defaultValue false
+   */
+  disableFullscreen?: boolean
 }
 
 /**


### PR DESCRIPTION
## What & why

Adds an **"Expand editor"** button to the code input that expands the CodeMirror editor to fill the **document pane**, mirroring the Portable Text editor's expand/collapse toggle. The editor is otherwise a fixed 250px tall, which is cramped for longer snippets.

## Changes

- New per-field option **`disableFullscreen`** to hide the button (expanding is enabled by default).
- **Expand editor / Collapse editor** toggle (`ExpandIcon` / `CollapseIcon`) pinned to the top-right of the editor, with a Studio-styled tooltip (`{open: 400}` delay, `arrow={false}`).
- The expanded overlay is scoped to the **document pane** (not the whole viewport), measured from the pane's scroll container (`[data-testid="document-panel-scroller"]`) and kept in sync with a `ResizeObserver`.
- Rendered through `Portal` + `Layer` so it works **above dialogs** when a code field is edited inside a modal (resolves to the underlying document pane rather than the modal).
- **`Escape`** collapses the editor; when inside a modal it only collapses and does **not** close the surrounding dialog (capture-phase handler with `stopImmediatePropagation`).
- Flush 1px border against the pane on the sides, with a top/bottom divider.
- Docs, a test-studio example field, and a changeset (minor).

## Recordings

https://github.com/user-attachments/assets/befdd509-4910-46e6-a46f-073bf8a79333

## Testing

- `pnpm format`, `pnpm lint`, `pnpm build`, and `pnpm test` all pass.
- Manually verified in a Studio: basic field, read-only field, the `disableFullscreen` option, and the nested-in-modal case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only change, but it couples to Studio DOM `data-testid` selectors and complex portal/Escape/focus behavior that could break across Studio layout or modal edge cases.
> 
> **Overview**
> Adds an **Expand editor** control to `@sanity/code-input` so CodeMirror can grow from the fixed ~250px field into an overlay sized to the **document pane**, with **Collapse** and **Escape** to exit.
> 
> Expansion is implemented in `CodeInput.tsx` via pane-bound measurement (`document-pane` / `document-panel-scroller` selectors, `ResizeObserver`, scroll/resize listeners), a `Portal` + `Layer` overlay for modal contexts, and focus/Escape handling so collapsing does not close parent dialogs. A new field option **`disableFullscreen`** (typed in `CodeOptions`) hides the toggle; README, changeset, and a test-studio example document it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1c749cb34895f9d5a81eea2d9a797f42ee7843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->