### PR TITLE
refactor(test-studio): merge Kitchen Sink into Home workspace

### DIFF
--- a/.agents/skills/test-studio-script-runner/SKILL.md
+++ b/.agents/skills/test-studio-script-runner/SKILL.md
@@ -20,10 +20,10 @@ Read `README.md` and `types.ts` before changing the runner or adding scripts.
 
 ## What The Tool Does
 
-The runner is a Sanity Studio custom tool registered in the `kitchen-sink` workspace.
+The runner is a Sanity Studio custom tool registered in the `home` workspace.
 
-- Home route: `<studio>/kitchen-sink/scripts`
-- Script route: `<studio>/kitchen-sink/scripts/<script-name>`
+- Home route: `<studio>/home/scripts`
+- Script route: `<studio>/home/scripts/<script-name>`
 
 Scripts are browser-side TypeScript modules discovered at build time with Vite `import.meta.glob`.
 They run inside Sanity Studio with the logged-in user's permissions and receive the Studio client.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,16 +481,16 @@ The test studio connects to Sanity Cloud (project `ppsg7ml5`, dataset `plugins` 
 Navigate to the studio with the token in the URL hash (Sanity consumes it on load and removes it from the address bar):
 
 ```
-http://localhost:3333/kitchen-sink#token=<STUDIO_AUTH_TOKEN>
+http://localhost:3333/home#token=<STUDIO_AUTH_TOKEN>
 ```
 
 Build the URL from the secret:
 
 ```bash
-node -e "const t=process.env.STUDIO_AUTH_TOKEN; console.log('http://localhost:3333/kitchen-sink#token=' + encodeURIComponent(t))"
+node -e "const t=process.env.STUDIO_AUTH_TOKEN; console.log('http://localhost:3333/home#token=' + encodeURIComponent(t))"
 ```
 
-Open that URL in the browser to authenticate and land directly in the Kitchen Sink workspace. Without a token, workspaces show as "Signed out".
+Open that URL in the browser to authenticate and land directly in the Home workspace (the merged "kitchen sink"). Without a token, workspaces show as "Signed out".
 
 ### Node.js version notes
 

--- a/dev/test-studio/package.json
+++ b/dev/test-studio/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "sanity build -y",
     "dev": "sanity dev --no-auto-updates",
-    "typegen": "sanity schema extract --enforce-required-fields --workspace kitchen-sink && sanity typegen generate"
+    "typegen": "sanity schema extract --enforce-required-fields --workspace home && sanity typegen generate"
   },
   "dependencies": {
     "@sanity/assist": "workspace:*",

--- a/dev/test-studio/sanity.config.ts
+++ b/dev/test-studio/sanity.config.ts
@@ -1,9 +1,10 @@
 import {debugSecrets} from '@sanity/debug-preview-url-secret-plugin'
+import {HomeIcon} from '@sanity/icons'
 import {vercelProtectionBypassTool} from '@sanity/vercel-protection-bypass'
 import {visionTool} from '@sanity/vision'
 import {defineConfig, type WorkspaceOptions} from 'sanity'
 import {contentGraphView} from 'sanity-plugin-graph-view'
-import {workspaceHomeConfig} from 'sanity-plugin-workspace-home'
+import {workspaceHome} from 'sanity-plugin-workspace-home'
 import {structureTool} from 'sanity/structure'
 
 import {aprimoExample} from '#aprimo'
@@ -24,10 +25,8 @@ import {embeddingsIndexUiExample} from '#embeddings-index-ui'
 import {formToolkitExample} from '#form-toolkit'
 import {googleMapsInputExample} from '#google-maps-input'
 import {googleTranslateExample} from '#google-translate'
-import {
-  hierarchicalDocumentListExample,
-  hierarchicalDocumentListExampleStructure,
-} from '#hierarchical-document-list'
+import {hierarchicalDocumentListExample} from '#hierarchical-document-list'
+import {homeDefaultDocumentNode, homeStructure} from '#home'
 import {hotspotArrayExample} from '#hotspot-array'
 import {i18nArrayTranslationExample} from '#i18n-array-translation'
 import {iframePaneExample} from '#iframe-pane'
@@ -40,10 +39,7 @@ import {markdownExample} from '#markdown'
 import {mediaExample} from '#media'
 import {muxInputExample} from '#mux-input'
 import {netlifyWidgetExample} from '#netlify-widget'
-import {
-  orderableDocumentListExample,
-  orderableDocumentListExampleStructure,
-} from '#orderable-document-list'
+import {orderableDocumentListExample} from '#orderable-document-list'
 import {personalizationExample} from '#personalization'
 import {presetsWorkspace} from '#presets'
 import {richDateInputExample} from '#rich-date-input'
@@ -76,73 +72,25 @@ function createWorkspace(
 }
 
 export default defineConfig([
-  workspaceHomeConfig({projectId, dataset}),
+  // The default "Home" workspace is the merged kitchen sink. It must stay first
+  // so the Workspaces Home launcher (which lists every *other* workspace) works.
+  // It hosts every plugin that can coexist in one dataset/schema; the workspaces
+  // below only exist because they require a different dataset or register a
+  // conflicting plugin/schema configuration that cannot live alongside Home.
   createWorkspace({
-    name: 'naive-html-serializer-example',
-    title: 'Naive HTML Serializer',
-    plugins: [sanityNaiveHtmlSerializerExample()],
-  }),
-  createWorkspace({name: 'content-graph-view', plugins: [contentGraphView()]}),
-  createWorkspace({name: 'utils-example', title: 'Utils Example', plugins: [utilsExample()]}),
-  createWorkspace({name: 'iframe-pane-example', plugins: [iframePaneExample()]}),
-  createWorkspace({name: 'transifex-example', title: 'Transifex', plugins: [transifexExample()]}),
-  createWorkspace({name: 'smartling-example', title: 'Smartling', plugins: [smartlingExample()]}),
-  createWorkspace({name: 'documents-pane-example', plugins: [documentsPaneExample()]}),
-  createWorkspace({
-    name: 'translations-tab-example',
-    title: 'Translations Tab',
-    plugins: [translationsTabExample()],
-  }),
-  createWorkspace({
-    name: 'i18n-array-translation-example',
-    title: 'i18n Array Translation',
-    plugins: [i18nArrayTranslationExample()],
-  }),
-  createWorkspace({
-    name: 'doc-i18n-translation-example',
-    title: 'Doc i18n + Translations',
-    plugins: [documentInternationalizationTranslationExample()],
-  }),
-  createWorkspace({name: 'workflow-example', plugins: [structureTool(), workflowExample()]}),
-  createWorkspace({
-    name: 'orderable-document-list-example',
-    title: 'Orderable Document List',
-    plugins: [orderableDocumentListExample(), orderableDocumentListExampleStructure()],
-  }),
-  createWorkspace({
-    name: 'hierarchical-document-list-example',
-    title: 'Hierarchical Document List',
-    plugins: [hierarchicalDocumentListExample(), hierarchicalDocumentListExampleStructure()],
-  }),
-  createWorkspace({
-    name: 'presets-studio',
-    title: 'Presets Studio',
-    plugins: [structureTool(), presetsWorkspace()],
-  }),
-  createWorkspace({
-    name: 'sfcc-example',
-    title: 'Salesforce Commerce Cloud',
-    plugins: [sfccExample()],
-  }),
-  createWorkspace({
-    name: 'dashboard-example',
-    title: 'Dashboard',
+    name: 'home',
+    title: 'Home',
+    icon: HomeIcon,
     plugins: [
-      structureTool(),
-      dashboardToolExample(),
-      documentListWidgetExample(),
-      netlifyWidgetExample(),
-      vercelWidgetExample(),
-    ],
-  }),
-  createWorkspace({
-    name: 'kitchen-sink',
-    plugins: [
-      structureTool(),
+      // Order matters for the top navigation: Workspaces Home, Structure, then
+      // the most-used plugin tools first.
+      workspaceHome(),
+      structureTool({structure: homeStructure, defaultDocumentNode: homeDefaultDocumentNode}),
+      mediaExample(),
+      muxInputExample(),
+      // Inputs, asset sources, panes and tools (no particular order beyond the above).
       assistExample(),
       googleTranslateExample(),
-      mediaExample(),
-      // add new plugins here
       embeddingsIndexUiExample(),
       formToolkitExample(),
       googleMapsInputExample(),
@@ -151,7 +99,6 @@ export default defineConfig([
       shopifyAssetsExample(),
       personalizationExample(),
       cloudinaryExample(),
-      muxInputExample(),
       asyncListExample(),
       tableExample(),
       hotspotArrayExample(),
@@ -167,24 +114,67 @@ export default defineConfig([
       bynderExample(),
       colorExample(),
       markdownExample(),
-      debugSecrets(),
       unsplashExample(),
+      presetsWorkspace(),
+      sanityNaiveHtmlSerializerExample(),
+      utilsExample(),
+      iframePaneExample(),
+      documentsPaneExample(),
+      transifexExample(),
+      smartlingExample(),
+      translationsTabExample(),
+      dashboardToolExample(),
+      documentListWidgetExample(),
+      netlifyWidgetExample(),
+      vercelWidgetExample(),
+      contentGraphView(),
       scriptRunnerTool(),
+      debugSecrets(),
       vercelProtectionBypassTool(),
       visionTool(),
     ],
   }),
+  // Re-registers `internationalizedArray` with async languages loaded from
+  // documents, which cannot coexist with Home's static language config.
   createWorkspace({
     name: 'internationalized-array-async-languages',
+    title: 'internationalized-array: Async Languages',
     plugins: [internationalizedArrayAsyncLanguages()],
   }),
+  // Demos the translations tab at the internationalized-array level, with its own
+  // `internationalizedArray` language set (en/de/no_nb/is) — conflicts with Home.
+  createWorkspace({
+    name: 'i18n-array-translation',
+    title: 'sanity-translations-tab: i18n Array',
+    plugins: [i18nArrayTranslationExample()],
+  }),
+  // A second `documentInternationalization` registration (for docI18nLocalizedPage)
+  // that cannot coexist with Home's `lesson` configuration.
+  createWorkspace({
+    name: 'doc-i18n-translation',
+    title: 'document-internationalization: Translations',
+    plugins: [documentInternationalizationTranslationExample()],
+  }),
+  // Registers its own `internationalizedArray` (en_US/fr) and `product`/`category`
+  // types (`product` collides with the workflow workspace).
+  createWorkspace({
+    name: 'sfcc',
+    title: 'sfcc: Salesforce Commerce Cloud',
+    plugins: [sfccExample()],
+  }),
+  // Defines `product`/`article`; `product` collides with the sfcc workspace.
+  createWorkspace({
+    name: 'workflow',
+    title: 'workflow: Document Workflow',
+    plugins: [structureTool(), workflowExample()],
+  }),
   // Destination workspace for @sanity/cross-dataset-duplicator: uses a
-  // different dataset so it can be picked as a duplication target
+  // different dataset so it can be picked as a duplication target.
   {
     projectId,
     dataset: 'test',
     name: 'cross-dataset-duplicator-target',
-    title: 'Cross Dataset Duplicator Target',
+    title: 'cross-dataset-duplicator: Target',
     basePath: '/cross-dataset-duplicator-target',
     plugins: [structureTool(), crossDatasetDuplicatorExample()],
   },

--- a/dev/test-studio/sanity.types.ts
+++ b/dev/test-studio/sanity.types.ts
@@ -24,6 +24,27 @@ export type Rendition = {
   publicuri?: string
 }
 
+export type CorePresetsTestReference = {
+  _ref: string
+  _type: 'reference'
+  _weak?: boolean
+  [internalGroqTypeReferenceTo]?: 'corePresetsTest'
+}
+
+export type Link = {
+  linkType?: 'internal' | 'external'
+  reference?: CorePresetsTestReference
+  url?: string
+  openInNewTab?: boolean
+}
+
+export type CtaLink = {
+  linkType?: 'internal' | 'external'
+  reference?: CorePresetsTestReference
+  url?: string
+  openInNewTab?: boolean
+}
+
 export type SanityVercelProtectionBypass = {
   _id: string
   _type: 'sanity.vercelProtectionBypass'
@@ -33,6 +54,169 @@ export type SanityVercelProtectionBypass = {
   secret?: string
 }
 
+export type SanityPreviewUrlSecret = {
+  _id: string
+  _type: 'sanity.previewUrlSecret'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  secret?: string
+  source?: string
+  studioUrl?: string
+  userId?: string
+}
+
+export type DocumentListDemo = {
+  _id: string
+  _type: 'documentListDemo'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+}
+
+export type Translatable = {
+  _id: string
+  _type: 'translatable'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  content?: string
+}
+
+export type SmartlingTest = {
+  _id: string
+  _type: 'smartlingTest'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  greeting?: SmartlingLocalizedString
+  description?: SmartlingLocalizedString
+}
+
+export type SmartlingLocalizedString = {
+  _type: 'smartlingLocalizedString'
+  en?: string
+  es?: string
+  fr?: string
+}
+
+export type TransifexTest = {
+  _id: string
+  _type: 'transifexTest'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  greeting?: TransifexLocalizedString
+  description?: TransifexLocalizedString
+}
+
+export type TransifexLocalizedString = {
+  _type: 'transifexLocalizedString'
+  en?: string
+  es?: string
+  fr?: string
+}
+
+export type DocumentsPaneArticleReference = {
+  _ref: string
+  _type: 'reference'
+  _weak?: boolean
+  [internalGroqTypeReferenceTo]?: 'documentsPaneArticle'
+}
+
+export type DocumentsPaneArticle = {
+  _id: string
+  _type: 'documentsPaneArticle'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  references?: Array<
+    {
+      _key: string
+    } & DocumentsPaneArticleReference
+  >
+}
+
+export type IframeExample = {
+  _id: string
+  _type: 'iframeExample'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  slug?: Slug
+}
+
+export type Slug = {
+  _type: 'slug'
+  current: string
+  source?: string
+}
+
+export type UtilsDemoDocument = {
+  _id: string
+  _type: 'utilsDemoDocument'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+}
+
+export type NaiveHtmlSerializerArticle = {
+  _id: string
+  _type: 'naiveHtmlSerializerArticle'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  snippet?: string
+  content?: Array<{
+    children?: Array<{
+      marks?: Array<string>
+      text?: string
+      _type: 'span'
+      _key: string
+    }>
+    style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
+    listItem?: 'bullet' | 'number'
+    markDefs?: Array<{
+      href?: string
+      _type: 'link'
+      _key: string
+    }>
+    level?: number
+    _type: 'block'
+    _key: string
+  }>
+}
+
+export type Blockquote = {
+  _type: 'blockquote'
+  quote?: string
+  author?: string
+  link?: Link
+}
+
+export type RichTextMinimal = Array<{
+  children?: Array<{
+    marks?: Array<string>
+    text?: string
+    _type: 'span'
+    _key: string
+  }>
+  style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
+  listItem?: 'bullet' | 'number'
+  markDefs?: null
+  level?: number
+  _type: 'block'
+  _key: string
+}>
+
 export type SanityImageAssetReference = {
   _ref: string
   _type: 'reference'
@@ -40,20 +224,139 @@ export type SanityImageAssetReference = {
   [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
 }
 
-export type UnsplashPost = {
+export type RichTextDefaults = Array<
+  | {
+      children?: Array<
+        | {
+            marks?: Array<string>
+            text?: string
+            _type: 'span'
+            _key: string
+          }
+        | {
+            link?: CtaLink
+            level?: 1 | 2 | 3
+            _type: 'cta'
+            _key: string
+          }
+      >
+      style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
+      listItem?: 'bullet' | 'number'
+      markDefs?: Array<{
+        linkType?: 'internal' | 'external'
+        reference?: CorePresetsTestReference
+        url?: string
+        openInNewTab?: boolean
+        _type: 'link'
+        _key: string
+      }>
+      level?: number
+      _type: 'block'
+      _key: string
+    }
+  | {
+      asset?: SanityImageAssetReference
+      media?: unknown
+      hotspot?: SanityImageHotspot
+      crop?: SanityImageCrop
+      altText?: string
+      caption?: string
+      _type: 'richTextImage'
+      _key: string
+    }
+>
+
+export type CorePresetsTest = {
   _id: string
-  _type: 'unsplashPost'
+  _type: 'corePresetsTest'
   _createdAt: string
   _updatedAt: string
   _rev: string
-  title?: string
-  image?: {
+  type?: 'landingPage' | 'marketingPage' | 'documentationPage'
+  name: string
+  slug?: Slug
+  content?: Array<
+    | ({
+        _key: string
+      } & Blockquote)
+    | {
+        asset?: SanityImageAssetReference
+        media?: unknown
+        hotspot?: SanityImageHotspot
+        crop?: SanityImageCrop
+        altText?: string
+        caption?: string
+        _type: 'imageBlock'
+        _key: string
+      }
+    | {
+        content?: Array<
+          | {
+              children?: Array<
+                | {
+                    marks?: Array<string>
+                    text?: string
+                    _type: 'span'
+                    _key: string
+                  }
+                | {
+                    link?: CtaLink
+                    level?: 1 | 2 | 3
+                    _type: 'cta'
+                    _key: string
+                  }
+              >
+              style?: 'normal' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'blockquote'
+              listItem?: 'bullet' | 'number'
+              markDefs?: Array<{
+                linkType?: 'internal' | 'external'
+                reference?: CorePresetsTestReference
+                url?: string
+                openInNewTab?: boolean
+                _type: 'link'
+                _key: string
+              }>
+              level?: number
+              _type: 'block'
+              _key: string
+            }
+          | {
+              asset?: SanityImageAssetReference
+              media?: unknown
+              hotspot?: SanityImageHotspot
+              crop?: SanityImageCrop
+              altText?: string
+              caption?: string
+              _type: 'richTextImage'
+              _key: string
+            }
+        >
+        _type: 'richTextDefaults'
+        _key: string
+      }
+  >
+  seo?: {
+    title?: string
+    description?: string
+    ogImage?: {
+      asset?: SanityImageAssetReference
+      media?: unknown
+      hotspot?: SanityImageHotspot
+      crop?: SanityImageCrop
+      _type: 'image'
+    }
+  }
+  headerImage?: {
     asset?: SanityImageAssetReference
     media?: unknown
     hotspot?: SanityImageHotspot
     crop?: SanityImageCrop
+    altText?: string
+    caption?: string
     _type: 'image'
   }
+  canonicalUrl?: string
+  body?: RichTextDefaults
 }
 
 export type SanityImageCrop = {
@@ -72,16 +375,20 @@ export type SanityImageHotspot = {
   width: number
 }
 
-export type SanityPreviewUrlSecret = {
+export type UnsplashPost = {
   _id: string
-  _type: 'sanity.previewUrlSecret'
+  _type: 'unsplashPost'
   _createdAt: string
   _updatedAt: string
   _rev: string
-  secret?: string
-  source?: string
-  studioUrl?: string
-  userId?: string
+  title?: string
+  image?: {
+    asset?: SanityImageAssetReference
+    media?: unknown
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    _type: 'image'
+  }
 }
 
 export type MarkdownTest = {
@@ -96,12 +403,6 @@ export type MarkdownTest = {
 }
 
 export type Markdown = string
-
-export type Slug = {
-  _type: 'slug'
-  current: string
-  source?: string
-}
 
 export type ColorTest = {
   _id: string
@@ -583,126 +884,6 @@ export type DisneyCharacter = string
 
 export type Pokemon = string
 
-export type MuxTrailer = {
-  _id: string
-  _type: 'muxTrailer'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  title?: string
-  video?: MuxVideo
-}
-
-export type MuxVideoAssetReference = {
-  _ref: string
-  _type: 'reference'
-  _weak?: boolean
-  [internalGroqTypeReferenceTo]?: 'mux.videoAsset'
-}
-
-export type MuxVideo = {
-  _type: 'mux.video'
-  asset?: MuxVideoAssetReference
-}
-
-export type MuxVideoAsset = {
-  _id: string
-  _type: 'mux.videoAsset'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  status?: string
-  assetId?: string
-  playbackId?: string
-  filename?: string
-  thumbTime?: number
-  data?: MuxAssetData
-}
-
-export type MuxAssetData = {
-  _type: 'mux.assetData'
-  resolution_tier?: string
-  upload_id?: string
-  created_at?: string
-  id?: string
-  status?: string
-  max_stored_resolution?: string
-  passthrough?: string
-  encoding_tier?: string
-  video_quality?: string
-  master_access?: string
-  aspect_ratio?: string
-  duration?: number
-  max_stored_frame_rate?: number
-  mp4_support?: string
-  max_resolution_tier?: string
-  tracks?: Array<
-    {
-      _key: string
-    } & MuxTrack
-  >
-  playback_ids?: Array<
-    {
-      _key: string
-    } & MuxPlaybackId
-  >
-  static_renditions?: MuxStaticRenditions
-  master?: MuxMasterFile
-}
-
-export type MuxMasterFile = {
-  _type: 'mux.masterFile'
-  status?: string
-  url?: string
-}
-
-export type MuxStaticRenditions = {
-  _type: 'mux.staticRenditions'
-  status?: string
-  files?: Array<
-    {
-      _key: string
-    } & MuxStaticRenditionFile
-  >
-}
-
-export type MuxStaticRenditionFile = {
-  _type: 'mux.staticRenditionFile'
-  name?: string
-  ext?: string
-  height?: number
-  width?: number
-  bitrate?: number
-  filesize?: string
-  type?: string
-  status?: string
-  resolution_tier?: string
-  resolution?: string
-  id?: string
-  passthrough?: string
-}
-
-export type MuxPlaybackId = {
-  _type: 'mux.playbackId'
-  id?: string
-  policy?: string
-}
-
-export type MuxTrack = {
-  _type: 'mux.track'
-  id?: string
-  type?: string
-  max_width?: number
-  max_frame_rate?: number
-  duration?: number
-  max_height?: number
-  language_code?: string
-  name?: string
-  status?: string
-  text_source?: string
-  text_type?: string
-}
-
 export type CloudinaryTest = {
   _id: string
   _type: 'cloudinaryTest'
@@ -1024,43 +1205,6 @@ export type EmbeddingsArticle = {
   relatedDefaultPlugin?: EmbeddingsArticleReference
 }
 
-export type SanityFileAssetReference = {
-  _ref: string
-  _type: 'reference'
-  _weak?: boolean
-  [internalGroqTypeReferenceTo]?: 'sanity.fileAsset'
-}
-
-export type MediaProduct = {
-  _id: string
-  _type: 'mediaProduct'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  name?: string
-  image?: {
-    asset?: SanityImageAssetReference
-    media?: unknown
-    hotspot?: SanityImageHotspot
-    crop?: SanityImageCrop
-    _type: 'image'
-  }
-  attachment?: {
-    asset?: SanityFileAssetReference
-    media?: unknown
-    _type: 'file'
-  }
-}
-
-export type MediaTag = {
-  _id: string
-  _type: 'media.tag'
-  _createdAt: string
-  _updatedAt: string
-  _rev: string
-  name?: Slug
-}
-
 export type GoogleTranslateTest = {
   _id: string
   _type: 'googleTranslateTest'
@@ -1216,6 +1360,163 @@ export type SanityAssistSchemaTypeField = {
   >
 }
 
+export type MuxTrailer = {
+  _id: string
+  _type: 'muxTrailer'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  video?: MuxVideo
+}
+
+export type MuxVideoAssetReference = {
+  _ref: string
+  _type: 'reference'
+  _weak?: boolean
+  [internalGroqTypeReferenceTo]?: 'mux.videoAsset'
+}
+
+export type MuxVideo = {
+  _type: 'mux.video'
+  asset?: MuxVideoAssetReference
+}
+
+export type MuxVideoAsset = {
+  _id: string
+  _type: 'mux.videoAsset'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  status?: string
+  assetId?: string
+  playbackId?: string
+  filename?: string
+  thumbTime?: number
+  data?: MuxAssetData
+}
+
+export type MuxAssetData = {
+  _type: 'mux.assetData'
+  resolution_tier?: string
+  upload_id?: string
+  created_at?: string
+  id?: string
+  status?: string
+  max_stored_resolution?: string
+  passthrough?: string
+  encoding_tier?: string
+  video_quality?: string
+  master_access?: string
+  aspect_ratio?: string
+  duration?: number
+  max_stored_frame_rate?: number
+  mp4_support?: string
+  max_resolution_tier?: string
+  tracks?: Array<
+    {
+      _key: string
+    } & MuxTrack
+  >
+  playback_ids?: Array<
+    {
+      _key: string
+    } & MuxPlaybackId
+  >
+  static_renditions?: MuxStaticRenditions
+  master?: MuxMasterFile
+}
+
+export type MuxMasterFile = {
+  _type: 'mux.masterFile'
+  status?: string
+  url?: string
+}
+
+export type MuxStaticRenditions = {
+  _type: 'mux.staticRenditions'
+  status?: string
+  files?: Array<
+    {
+      _key: string
+    } & MuxStaticRenditionFile
+  >
+}
+
+export type MuxStaticRenditionFile = {
+  _type: 'mux.staticRenditionFile'
+  name?: string
+  ext?: string
+  height?: number
+  width?: number
+  bitrate?: number
+  filesize?: string
+  type?: string
+  status?: string
+  resolution_tier?: string
+  resolution?: string
+  id?: string
+  passthrough?: string
+}
+
+export type MuxPlaybackId = {
+  _type: 'mux.playbackId'
+  id?: string
+  policy?: string
+}
+
+export type MuxTrack = {
+  _type: 'mux.track'
+  id?: string
+  type?: string
+  max_width?: number
+  max_frame_rate?: number
+  duration?: number
+  max_height?: number
+  language_code?: string
+  name?: string
+  status?: string
+  text_source?: string
+  text_type?: string
+}
+
+export type SanityFileAssetReference = {
+  _ref: string
+  _type: 'reference'
+  _weak?: boolean
+  [internalGroqTypeReferenceTo]?: 'sanity.fileAsset'
+}
+
+export type MediaProduct = {
+  _id: string
+  _type: 'mediaProduct'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  name?: string
+  image?: {
+    asset?: SanityImageAssetReference
+    media?: unknown
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    _type: 'image'
+  }
+  attachment?: {
+    asset?: SanityFileAssetReference
+    media?: unknown
+    _type: 'file'
+  }
+}
+
+export type MediaTag = {
+  _id: string
+  _type: 'media.tag'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  name?: Slug
+}
+
 export type SanityImagePaletteSwatch = {
   _type: 'sanity.imagePaletteSwatch'
   background?: string
@@ -1309,15 +1610,33 @@ export type SanityImageAsset = {
 export type AllSanitySchemaTypes =
   | Options
   | Rendition
+  | CorePresetsTestReference
+  | Link
+  | CtaLink
   | SanityVercelProtectionBypass
+  | SanityPreviewUrlSecret
+  | DocumentListDemo
+  | Translatable
+  | SmartlingTest
+  | SmartlingLocalizedString
+  | TransifexTest
+  | TransifexLocalizedString
+  | DocumentsPaneArticleReference
+  | DocumentsPaneArticle
+  | IframeExample
+  | Slug
+  | UtilsDemoDocument
+  | NaiveHtmlSerializerArticle
+  | Blockquote
+  | RichTextMinimal
   | SanityImageAssetReference
-  | UnsplashPost
+  | RichTextDefaults
+  | CorePresetsTest
   | SanityImageCrop
   | SanityImageHotspot
-  | SanityPreviewUrlSecret
+  | UnsplashPost
   | MarkdownTest
   | Markdown
-  | Slug
   | ColorTest
   | Color
   | RgbaColor
@@ -1362,16 +1681,6 @@ export type AllSanitySchemaTypes =
   | AsyncListTest
   | DisneyCharacter
   | Pokemon
-  | MuxTrailer
-  | MuxVideoAssetReference
-  | MuxVideo
-  | MuxVideoAsset
-  | MuxAssetData
-  | MuxMasterFile
-  | MuxStaticRenditions
-  | MuxStaticRenditionFile
-  | MuxPlaybackId
-  | MuxTrack
   | CloudinaryTest
   | CloudinaryAsset
   | CloudinaryAssetContextCustom
@@ -1399,9 +1708,6 @@ export type AllSanitySchemaTypes =
   | Form
   | EmbeddingsArticleReference
   | EmbeddingsArticle
-  | SanityFileAssetReference
-  | MediaProduct
-  | MediaTag
   | GoogleTranslateTest
   | LocalizedString
   | SanityAssistInstructionTask
@@ -1417,6 +1723,19 @@ export type AllSanitySchemaTypes =
   | SanityAssistInstructionFieldRef
   | SanityAssistInstruction
   | SanityAssistSchemaTypeField
+  | MuxTrailer
+  | MuxVideoAssetReference
+  | MuxVideo
+  | MuxVideoAsset
+  | MuxAssetData
+  | MuxMasterFile
+  | MuxStaticRenditions
+  | MuxStaticRenditionFile
+  | MuxPlaybackId
+  | MuxTrack
+  | SanityFileAssetReference
+  | MediaProduct
+  | MediaTag
   | SanityImagePaletteSwatch
   | SanityImagePalette
   | SanityImageDimensions

--- a/dev/test-studio/schema.json
+++ b/dev/test-studio/schema.json
@@ -39,6 +39,132 @@
     }
   },
   {
+    "type": "type",
+    "name": "corePresetsTest.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "corePresetsTest"
+    }
+  },
+  {
+    "type": "type",
+    "name": "link",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "linkType": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "union",
+            "of": [
+              {
+                "type": "string",
+                "value": "internal"
+              },
+              {
+                "type": "string",
+                "value": "external"
+              }
+            ]
+          },
+          "optional": true
+        },
+        "reference": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "corePresetsTest.reference"
+          },
+          "optional": true
+        },
+        "url": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "openInNewTab": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "type": "type",
+    "name": "cta.link",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "linkType": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "union",
+            "of": [
+              {
+                "type": "string",
+                "value": "internal"
+              },
+              {
+                "type": "string",
+                "value": "external"
+              }
+            ]
+          },
+          "optional": true
+        },
+        "reference": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "corePresetsTest.reference"
+          },
+          "optional": true
+        },
+        "url": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "openInNewTab": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
     "name": "sanity.vercelProtectionBypass",
     "type": "document",
     "attributes": {
@@ -83,6 +209,999 @@
     }
   },
   {
+    "name": "sanity.previewUrlSecret",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "sanity.previewUrlSecret"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "secret": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "source": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "studioUrl": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "userId": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "documentListDemo",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "documentListDemo"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "translatable",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "translatable"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "content": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "smartlingTest",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "smartlingTest"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "greeting": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "smartlingLocalizedString"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "smartlingLocalizedString"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "smartlingLocalizedString",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "smartlingLocalizedString"
+          }
+        },
+        "en": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "es": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "fr": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "transifexTest",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "transifexTest"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "greeting": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "transifexLocalizedString"
+        },
+        "optional": true
+      },
+      "description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "transifexLocalizedString"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "transifexLocalizedString",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "transifexLocalizedString"
+          }
+        },
+        "en": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "es": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "fr": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "type": "type",
+    "name": "documentsPaneArticle.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "documentsPaneArticle"
+    }
+  },
+  {
+    "name": "documentsPaneArticle",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "documentsPaneArticle"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "references": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "_key": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "rest": {
+              "type": "inline",
+              "name": "documentsPaneArticle.reference"
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "iframeExample",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "iframeExample"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "slug",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "slug"
+          }
+        },
+        "current": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": false
+        },
+        "source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "utilsDemoDocument",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "utilsDemoDocument"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "naiveHtmlSerializerArticle",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "naiveHtmlSerializerArticle"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "snippet": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "content": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "children": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "marks": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "array",
+                          "of": {
+                            "type": "string"
+                          }
+                        },
+                        "optional": true
+                      },
+                      "text": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "span"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "style": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "normal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h1"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h2"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h3"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h4"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h5"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h6"
+                    },
+                    {
+                      "type": "string",
+                      "value": "blockquote"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "listItem": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "bullet"
+                    },
+                    {
+                      "type": "string",
+                      "value": "number"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "markDefs": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "href": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "link"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "level": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "block"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "blockquote",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "blockquote"
+          }
+        },
+        "quote": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "author": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "link": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "link"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "richTextMinimal",
+    "type": "type",
+    "value": {
+      "type": "array",
+      "of": {
+        "type": "object",
+        "attributes": {
+          "children": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "array",
+              "of": {
+                "type": "object",
+                "attributes": {
+                  "marks": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "string"
+                      }
+                    },
+                    "optional": true
+                  },
+                  "text": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "span"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "optional": true
+          },
+          "style": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "union",
+              "of": [
+                {
+                  "type": "string",
+                  "value": "normal"
+                },
+                {
+                  "type": "string",
+                  "value": "h1"
+                },
+                {
+                  "type": "string",
+                  "value": "h2"
+                },
+                {
+                  "type": "string",
+                  "value": "h3"
+                },
+                {
+                  "type": "string",
+                  "value": "h4"
+                },
+                {
+                  "type": "string",
+                  "value": "h5"
+                },
+                {
+                  "type": "string",
+                  "value": "h6"
+                },
+                {
+                  "type": "string",
+                  "value": "blockquote"
+                }
+              ]
+            },
+            "optional": true
+          },
+          "listItem": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "union",
+              "of": [
+                {
+                  "type": "string",
+                  "value": "bullet"
+                },
+                {
+                  "type": "string",
+                  "value": "number"
+                }
+              ]
+            },
+            "optional": true
+          },
+          "markDefs": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "null"
+            },
+            "optional": true
+          },
+          "level": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "number"
+            },
+            "optional": true
+          },
+          "_type": {
+            "type": "objectAttribute",
+            "value": {
+              "type": "string",
+              "value": "block"
+            }
+          }
+        },
+        "rest": {
+          "type": "object",
+          "attributes": {
+            "_key": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  {
     "type": "type",
     "name": "sanity.imageAsset.reference",
     "value": {
@@ -113,7 +1232,348 @@
     }
   },
   {
-    "name": "unsplashPost",
+    "name": "richTextDefaults",
+    "type": "type",
+    "value": {
+      "type": "array",
+      "of": {
+        "type": "union",
+        "of": [
+          {
+            "type": "object",
+            "attributes": {
+              "children": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "union",
+                    "of": [
+                      {
+                        "type": "object",
+                        "attributes": {
+                          "marks": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "array",
+                              "of": {
+                                "type": "string"
+                              }
+                            },
+                            "optional": true
+                          },
+                          "text": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string"
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "span"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "attributes": {
+                          "link": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "inline",
+                              "name": "cta.link"
+                            },
+                            "optional": true
+                          },
+                          "level": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "union",
+                              "of": [
+                                {
+                                  "type": "number",
+                                  "value": 1
+                                },
+                                {
+                                  "type": "number",
+                                  "value": 2
+                                },
+                                {
+                                  "type": "number",
+                                  "value": 3
+                                }
+                              ]
+                            },
+                            "optional": true
+                          },
+                          "_type": {
+                            "type": "objectAttribute",
+                            "value": {
+                              "type": "string",
+                              "value": "cta"
+                            }
+                          }
+                        },
+                        "rest": {
+                          "type": "object",
+                          "attributes": {
+                            "_key": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "optional": true
+              },
+              "style": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "normal"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h1"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h2"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h3"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h4"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h5"
+                    },
+                    {
+                      "type": "string",
+                      "value": "h6"
+                    },
+                    {
+                      "type": "string",
+                      "value": "blockquote"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "listItem": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "union",
+                  "of": [
+                    {
+                      "type": "string",
+                      "value": "bullet"
+                    },
+                    {
+                      "type": "string",
+                      "value": "number"
+                    }
+                  ]
+                },
+                "optional": true
+              },
+              "markDefs": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "linkType": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "union",
+                          "of": [
+                            {
+                              "type": "string",
+                              "value": "internal"
+                            },
+                            {
+                              "type": "string",
+                              "value": "external"
+                            }
+                          ]
+                        },
+                        "optional": true
+                      },
+                      "reference": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "inline",
+                          "name": "corePresetsTest.reference"
+                        },
+                        "optional": true
+                      },
+                      "url": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        },
+                        "optional": true
+                      },
+                      "openInNewTab": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "boolean"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "link"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              },
+              "level": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "block"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageAsset.reference"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "altText": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "caption": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "richTextImage"
+                }
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "corePresetsTest",
     "type": "document",
     "attributes": {
       "_id": {
@@ -126,7 +1586,7 @@
         "type": "objectAttribute",
         "value": {
           "type": "string",
-          "value": "unsplashPost"
+          "value": "corePresetsTest"
         }
       },
       "_createdAt": {
@@ -147,14 +1607,572 @@
           "type": "string"
         }
       },
-      "title": {
+      "type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "union",
+          "of": [
+            {
+              "type": "string",
+              "value": "landingPage"
+            },
+            {
+              "type": "string",
+              "value": "marketingPage"
+            },
+            {
+              "type": "string",
+              "value": "documentationPage"
+            }
+          ]
+        },
+        "optional": true
+      },
+      "name": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
+        "optional": false
+      },
+      "slug": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
         "optional": true
       },
-      "image": {
+      "content": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "union",
+            "of": [
+              {
+                "type": "object",
+                "attributes": {
+                  "_key": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "inline",
+                  "name": "blockquote"
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageAsset.reference"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "altText": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    },
+                    "optional": true
+                  },
+                  "caption": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "imageBlock"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "attributes": {
+                  "content": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "array",
+                      "of": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "children": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "array",
+                                  "of": {
+                                    "type": "union",
+                                    "of": [
+                                      {
+                                        "type": "object",
+                                        "attributes": {
+                                          "marks": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "array",
+                                              "of": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "optional": true
+                                          },
+                                          "text": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "string"
+                                            },
+                                            "optional": true
+                                          },
+                                          "_type": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "string",
+                                              "value": "span"
+                                            }
+                                          }
+                                        },
+                                        "rest": {
+                                          "type": "object",
+                                          "attributes": {
+                                            "_key": {
+                                              "type": "objectAttribute",
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "attributes": {
+                                          "link": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "inline",
+                                              "name": "cta.link"
+                                            },
+                                            "optional": true
+                                          },
+                                          "level": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "union",
+                                              "of": [
+                                                {
+                                                  "type": "number",
+                                                  "value": 1
+                                                },
+                                                {
+                                                  "type": "number",
+                                                  "value": 2
+                                                },
+                                                {
+                                                  "type": "number",
+                                                  "value": 3
+                                                }
+                                              ]
+                                            },
+                                            "optional": true
+                                          },
+                                          "_type": {
+                                            "type": "objectAttribute",
+                                            "value": {
+                                              "type": "string",
+                                              "value": "cta"
+                                            }
+                                          }
+                                        },
+                                        "rest": {
+                                          "type": "object",
+                                          "attributes": {
+                                            "_key": {
+                                              "type": "objectAttribute",
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "optional": true
+                              },
+                              "style": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "union",
+                                  "of": [
+                                    {
+                                      "type": "string",
+                                      "value": "normal"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h1"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h2"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h3"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h4"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h5"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "h6"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "blockquote"
+                                    }
+                                  ]
+                                },
+                                "optional": true
+                              },
+                              "listItem": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "union",
+                                  "of": [
+                                    {
+                                      "type": "string",
+                                      "value": "bullet"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "value": "number"
+                                    }
+                                  ]
+                                },
+                                "optional": true
+                              },
+                              "markDefs": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "array",
+                                  "of": {
+                                    "type": "object",
+                                    "attributes": {
+                                      "linkType": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                          "type": "union",
+                                          "of": [
+                                            {
+                                              "type": "string",
+                                              "value": "internal"
+                                            },
+                                            {
+                                              "type": "string",
+                                              "value": "external"
+                                            }
+                                          ]
+                                        },
+                                        "optional": true
+                                      },
+                                      "reference": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                          "type": "inline",
+                                          "name": "corePresetsTest.reference"
+                                        },
+                                        "optional": true
+                                      },
+                                      "url": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "optional": true
+                                      },
+                                      "openInNewTab": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                          "type": "boolean"
+                                        },
+                                        "optional": true
+                                      },
+                                      "_type": {
+                                        "type": "objectAttribute",
+                                        "value": {
+                                          "type": "string",
+                                          "value": "link"
+                                        }
+                                      }
+                                    },
+                                    "rest": {
+                                      "type": "object",
+                                      "attributes": {
+                                        "_key": {
+                                          "type": "objectAttribute",
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "optional": true
+                              },
+                              "level": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "number"
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "block"
+                                }
+                              }
+                            },
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "attributes": {
+                              "asset": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "inline",
+                                  "name": "sanity.imageAsset.reference"
+                                },
+                                "optional": true
+                              },
+                              "media": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "unknown"
+                                },
+                                "optional": true
+                              },
+                              "hotspot": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "inline",
+                                  "name": "sanity.imageHotspot"
+                                },
+                                "optional": true
+                              },
+                              "crop": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "inline",
+                                  "name": "sanity.imageCrop"
+                                },
+                                "optional": true
+                              },
+                              "altText": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                },
+                                "optional": true
+                              },
+                              "caption": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                },
+                                "optional": true
+                              },
+                              "_type": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string",
+                                  "value": "richTextImage"
+                                }
+                              }
+                            },
+                            "rest": {
+                              "type": "object",
+                              "attributes": {
+                                "_key": {
+                                  "type": "objectAttribute",
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "richTextDefaults"
+                    }
+                  }
+                },
+                "rest": {
+                  "type": "object",
+                  "attributes": {
+                    "_key": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "optional": true
+      },
+      "seo": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "title": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "description": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "ogImage": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageAsset.reference"
+                    },
+                    "optional": true
+                  },
+                  "media": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "unknown"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                }
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
+      },
+      "headerImage": {
         "type": "objectAttribute",
         "value": {
           "type": "object",
@@ -190,6 +2208,20 @@
               },
               "optional": true
             },
+            "altText": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "caption": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
             "_type": {
               "type": "objectAttribute",
               "value": {
@@ -198,6 +2230,21 @@
               }
             }
           }
+        },
+        "optional": true
+      },
+      "canonicalUrl": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "body": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "richTextDefaults"
         },
         "optional": true
       }
@@ -292,7 +2339,7 @@
     }
   },
   {
-    "name": "sanity.previewUrlSecret",
+    "name": "unsplashPost",
     "type": "document",
     "attributes": {
       "_id": {
@@ -305,7 +2352,7 @@
         "type": "objectAttribute",
         "value": {
           "type": "string",
-          "value": "sanity.previewUrlSecret"
+          "value": "unsplashPost"
         }
       },
       "_createdAt": {
@@ -326,31 +2373,57 @@
           "type": "string"
         }
       },
-      "secret": {
+      "title": {
         "type": "objectAttribute",
         "value": {
           "type": "string"
         },
         "optional": true
       },
-      "source": {
+      "image": {
         "type": "objectAttribute",
         "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "studioUrl": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "userId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageAsset.reference"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
         },
         "optional": true
       }
@@ -421,36 +2494,6 @@
     "type": "type",
     "value": {
       "type": "string"
-    }
-  },
-  {
-    "name": "slug",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "slug"
-          }
-        },
-        "current": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": false
-        },
-        "source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
     }
   },
   {
@@ -3137,671 +5180,6 @@
     }
   },
   {
-    "name": "muxTrailer",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "muxTrailer"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "video": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "mux.video"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "type": "type",
-    "name": "mux.videoAsset.reference",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_ref": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          }
-        },
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "reference"
-          }
-        },
-        "_weak": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        }
-      },
-      "dereferencesTo": "mux.videoAsset"
-    }
-  },
-  {
-    "name": "mux.video",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.video"
-          }
-        },
-        "asset": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "mux.videoAsset.reference"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.videoAsset",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "mux.videoAsset"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "status": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "assetId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "playbackId": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "filename": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "thumbTime": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "data": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "mux.assetData"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "mux.assetData",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.assetData"
-          }
-        },
-        "resolution_tier": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "upload_id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "created_at": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "status": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "max_stored_resolution": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "passthrough": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "encoding_tier": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "video_quality": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "master_access": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "aspect_ratio": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "duration": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "max_stored_frame_rate": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "mp4_support": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "max_resolution_tier": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "tracks": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "rest": {
-                "type": "inline",
-                "name": "mux.track"
-              }
-            }
-          },
-          "optional": true
-        },
-        "playback_ids": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "rest": {
-                "type": "inline",
-                "name": "mux.playbackId"
-              }
-            }
-          },
-          "optional": true
-        },
-        "static_renditions": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "mux.staticRenditions"
-          },
-          "optional": true
-        },
-        "master": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "inline",
-            "name": "mux.masterFile"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.masterFile",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.masterFile"
-          }
-        },
-        "status": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "url": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.staticRenditions",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.staticRenditions"
-          }
-        },
-        "status": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "files": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "array",
-            "of": {
-              "type": "object",
-              "attributes": {
-                "_key": {
-                  "type": "objectAttribute",
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "rest": {
-                "type": "inline",
-                "name": "mux.staticRenditionFile"
-              }
-            }
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.staticRenditionFile",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.staticRenditionFile"
-          }
-        },
-        "name": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "ext": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "bitrate": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "filesize": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "status": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "resolution_tier": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "resolution": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "passthrough": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.playbackId",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.playbackId"
-          }
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "policy": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
-    "name": "mux.track",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "mux.track"
-          }
-        },
-        "id": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "max_width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "max_frame_rate": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "duration": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "max_height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": true
-        },
-        "language_code": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "name": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "status": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "text_source": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        },
-        "text_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          },
-          "optional": true
-        }
-      }
-    }
-  },
-  {
     "name": "cloudinaryTest",
     "type": "document",
     "attributes": {
@@ -5499,203 +6877,6 @@
     }
   },
   {
-    "type": "type",
-    "name": "sanity.fileAsset.reference",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_ref": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string"
-          }
-        },
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "reference"
-          }
-        },
-        "_weak": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
-          },
-          "optional": true
-        }
-      },
-      "dereferencesTo": "sanity.fileAsset"
-    }
-  },
-  {
-    "name": "mediaProduct",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "mediaProduct"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": true
-      },
-      "image": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageAsset.reference"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": true
-      },
-      "attachment": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.fileAsset.reference"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "file"
-              }
-            }
-          }
-        },
-        "optional": true
-      }
-    }
-  },
-  {
-    "name": "media.tag",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "media.tag"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "name": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "slug"
-        },
-        "optional": true
-      }
-    }
-  },
-  {
     "name": "googleTranslateTest",
     "type": "document",
     "attributes": {
@@ -6533,6 +7714,868 @@
           },
           "optional": true
         }
+      }
+    }
+  },
+  {
+    "name": "muxTrailer",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "muxTrailer"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "video": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "mux.video"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "type": "type",
+    "name": "mux.videoAsset.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "mux.videoAsset"
+    }
+  },
+  {
+    "name": "mux.video",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.video"
+          }
+        },
+        "asset": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "mux.videoAsset.reference"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.videoAsset",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "mux.videoAsset"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "status": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "assetId": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "playbackId": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "filename": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "thumbTime": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "data": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "mux.assetData"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "mux.assetData",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.assetData"
+          }
+        },
+        "resolution_tier": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "upload_id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "created_at": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "status": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "max_stored_resolution": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "passthrough": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "encoding_tier": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "video_quality": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "master_access": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "aspect_ratio": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "duration": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "max_stored_frame_rate": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "mp4_support": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "max_resolution_tier": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "tracks": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "rest": {
+                "type": "inline",
+                "name": "mux.track"
+              }
+            }
+          },
+          "optional": true
+        },
+        "playback_ids": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "rest": {
+                "type": "inline",
+                "name": "mux.playbackId"
+              }
+            }
+          },
+          "optional": true
+        },
+        "static_renditions": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "mux.staticRenditions"
+          },
+          "optional": true
+        },
+        "master": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "inline",
+            "name": "mux.masterFile"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.masterFile",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.masterFile"
+          }
+        },
+        "status": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "url": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.staticRenditions",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.staticRenditions"
+          }
+        },
+        "status": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "files": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "array",
+            "of": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "rest": {
+                "type": "inline",
+                "name": "mux.staticRenditionFile"
+              }
+            }
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.staticRenditionFile",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.staticRenditionFile"
+          }
+        },
+        "name": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "ext": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "width": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "bitrate": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "filesize": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "status": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "resolution_tier": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "resolution": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "passthrough": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.playbackId",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.playbackId"
+          }
+        },
+        "id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "policy": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "name": "mux.track",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "mux.track"
+          }
+        },
+        "id": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "max_width": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "max_frame_rate": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "duration": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "max_height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": true
+        },
+        "language_code": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "name": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "status": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "text_source": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        },
+        "text_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": true
+        }
+      }
+    }
+  },
+  {
+    "type": "type",
+    "name": "sanity.fileAsset.reference",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_ref": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          }
+        },
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "reference"
+          }
+        },
+        "_weak": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "boolean"
+          },
+          "optional": true
+        }
+      },
+      "dereferencesTo": "sanity.fileAsset"
+    }
+  },
+  {
+    "name": "mediaProduct",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "mediaProduct"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "image": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageAsset.reference"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "attachment": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.fileAsset.reference"
+              },
+              "optional": true
+            },
+            "media": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "unknown"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "file"
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "media.tag",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "media.tag"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "slug"
+        },
+        "optional": true
       }
     }
   },

--- a/dev/test-studio/src/documents-pane/index.tsx
+++ b/dev/test-studio/src/documents-pane/index.tsx
@@ -1,7 +1,7 @@
 import {DocumentsIcon} from '@sanity/icons'
 import {definePlugin, defineType} from 'sanity'
 import DocumentsPane from 'sanity-plugin-documents-pane'
-import {structureTool, type DefaultDocumentNodeResolver} from 'sanity/structure'
+import type {DefaultDocumentNodeResolver} from 'sanity/structure'
 
 const documentsPaneArticle = defineType({
   name: 'documentsPaneArticle',
@@ -28,7 +28,7 @@ const documentsPaneArticle = defineType({
   ],
 })
 
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const documentsPaneDefaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
   if (schemaType === 'documentsPaneArticle') {
     return S.document().views([
       S.view.form(),
@@ -44,15 +44,10 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
     ])
   }
 
-  return S.document().views([S.view.form()])
+  return null
 }
 
 export const documentsPaneExample = definePlugin(() => ({
   name: 'documents-pane-example',
   schema: {types: [documentsPaneArticle]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
 }))

--- a/dev/test-studio/src/hierarchical-document-list/index.tsx
+++ b/dev/test-studio/src/hierarchical-document-list/index.tsx
@@ -4,8 +4,8 @@ import {
   hierarchyTree,
 } from '@sanity/hierarchical-document-list'
 import {BookIcon, UserIcon} from '@sanity/icons'
-import {definePlugin, defineType} from 'sanity'
-import {structureTool} from 'sanity/structure'
+import {definePlugin, defineType, type ConfigContext} from 'sanity'
+import type {StructureBuilder} from 'sanity/structure'
 
 const hierarchyAuthor = defineType({
   name: 'hierarchyAuthor',
@@ -46,25 +46,20 @@ export const hierarchicalDocumentListExample = definePlugin(() => ({
   plugins: [hierarchicalDocumentList()],
 }))
 
-export const hierarchicalDocumentListExampleStructure = definePlugin(() => ({
-  plugins: [
-    structureTool({
-      structure: (S, context) =>
-        S.list()
-          .title('Content')
-          .items([
-            S.documentTypeListItem('hierarchyAuthor'),
-            S.documentTypeListItem('hierarchyBook'),
-            S.divider(),
-            createDeskHierarchy({
-              S,
-              context,
-              title: 'Main table of contents',
-              documentId: 'main-table-of-contents',
-              referenceTo: ['hierarchyAuthor', 'hierarchyBook'],
-              maxDepth: 3,
-            }),
-          ]),
+// Desk items for the hierarchical-document-list plugin, composed into the
+// home workspace's structure (rather than living in a dedicated workspace).
+export function hierarchicalDocumentListDeskItems(S: StructureBuilder, context: ConfigContext) {
+  return [
+    S.documentTypeListItem('hierarchyAuthor'),
+    S.documentTypeListItem('hierarchyBook'),
+    S.divider(),
+    createDeskHierarchy({
+      S,
+      context,
+      title: 'Main table of contents',
+      documentId: 'main-table-of-contents',
+      referenceTo: ['hierarchyAuthor', 'hierarchyBook'],
+      maxDepth: 3,
     }),
-  ],
-}))
+  ]
+}

--- a/dev/test-studio/src/home/index.tsx
+++ b/dev/test-studio/src/home/index.tsx
@@ -1,0 +1,155 @@
+import type {DefaultDocumentNodeResolver, StructureResolver} from 'sanity/structure'
+
+import {documentsPaneDefaultDocumentNode} from '#documents-pane'
+import {hierarchicalDocumentListDeskItems} from '#hierarchical-document-list'
+import {iframePaneDefaultDocumentNode} from '#iframe-pane'
+import {orderableDocumentListDeskItems} from '#orderable-document-list'
+import {sanityNaiveHtmlSerializerDefaultDocumentNode} from '#sanity-naive-html-serializer'
+import {smartlingDefaultDocumentNode} from '#smartling'
+import {transifexDefaultDocumentNode} from '#transifex'
+import {translationsTabDefaultDocumentNode} from '#translations-tab'
+
+// Document types grouped by the Studio API the plugin implements. Items inside
+// each group are ordered alphabetically by their plugin/document title. Any
+// document type not listed here falls through to the catch-all at the bottom of
+// the structure, so nothing ever disappears from the studio.
+
+const INPUT_PLUGIN_TYPES = [
+  'asyncListTest', // @sanity/sanity-plugin-async-list
+  'codeTest', // @sanity/code-input
+  'colorTest', // @sanity/color-input
+  'embeddingsArticle', // @sanity/embeddings-index-ui
+  'form', // @sanity/form-toolkit
+  'googleMapsTest', // @sanity/google-maps-input
+  'hotspotArrayDemo', // sanity-plugin-hotspot-array
+  'latexTest', // sanity-plugin-latex-input
+  'markdownTest', // sanity-plugin-markdown
+  'personalizationTest', // @sanity/personalization-plugin
+  'corePresetsTest', // @sanity/presets
+  'richDateTest', // @sanity/rich-date-input
+  'tableTest', // @sanity/table
+]
+
+const ASSET_SOURCE_TYPES = [
+  'aprimoTest', // sanity-plugin-aprimo
+  'bynderTest', // sanity-plugin-bynder-input
+  'cloudinaryTest', // sanity-plugin-cloudinary
+  'mediaProduct', // sanity-plugin-media
+  'muxTrailer', // sanity-plugin-mux-input
+  'shopifyAssetsTest', // sanity-plugin-shopify-assets
+  'unsplashPost', // sanity-plugin-asset-source-unsplash
+]
+
+const CUSTOM_PANE_TYPES = [
+  'documentsPaneArticle', // sanity-plugin-documents-pane
+  'iframeExample', // sanity-plugin-iframe-pane
+  'naiveHtmlSerializerArticle', // sanity-naive-html-serializer
+]
+
+const INTERNATIONALIZATION_TYPES = [
+  'lesson', // @sanity/document-internationalization
+  'translation.metadata', // @sanity/document-internationalization
+  'googleTranslateTest', // sanity-plugin-google-translate
+  'internationalizedPost', // sanity-plugin-internationalized-array
+  'i18nArrayPerformanceTest', // sanity-plugin-internationalized-array
+  'i18nArrayCircularSchemaRepro', // sanity-plugin-internationalized-array
+  'movieDocument', // sanity-plugin-internationalized-array
+  'issue520Repro', // sanity-plugin-internationalized-array
+  'smartlingTest', // sanity-plugin-studio-smartling
+  'transifexTest', // sanity-plugin-transifex
+  'translatable', // sanity-translations-tab
+]
+
+// Explicitly placed in the (untitled) catch-all section, ahead of the leftovers.
+const MISC_NAMED_TYPES = [
+  'assist.instruction.context', // @sanity/assist (AI context)
+  'media.tag', // sanity-plugin-media (Media Tag)
+]
+
+// Surfaced through the "Document list builders" folder via desk-item helpers,
+// so they should not also appear in the catch-all.
+const DESK_BUILDER_TYPES = [
+  'hierarchyAuthor', // @sanity/hierarchical-document-list
+  'hierarchyBook', // @sanity/hierarchical-document-list
+  'hierarchyTree', // @sanity/hierarchical-document-list
+  'orderableCategory', // @sanity/orderable-document-list
+  'orderableProject', // @sanity/orderable-document-list
+]
+
+/**
+ * Structure for the `home` workspace: a single Structure tool that organizes the
+ * merged "kitchen sink" of plugins into sections by the Studio API they
+ * implement (input plugins, asset sources, custom panes, document-list builders,
+ * internationalization), with a catch-all for everything else.
+ */
+export const homeStructure: StructureResolver = (S, context) => {
+  const exists = (type: string) => Boolean(context.schema.get(type))
+  const itemsFor = (types: string[]) =>
+    types.filter(exists).map((type) => S.documentTypeListItem(type))
+
+  const folder = (id: string, title: string, types: string[]) =>
+    S.listItem()
+      .id(id)
+      .title(title)
+      .child(S.list().title(title).items(itemsFor(types)))
+
+  const placed = new Set<string>([
+    ...INPUT_PLUGIN_TYPES,
+    ...ASSET_SOURCE_TYPES,
+    ...CUSTOM_PANE_TYPES,
+    ...INTERNATIONALIZATION_TYPES,
+    ...MISC_NAMED_TYPES,
+    ...DESK_BUILDER_TYPES,
+  ])
+
+  const leftovers = S.documentTypeListItems().filter((item) => {
+    const id = item.getId()
+    return id ? !placed.has(id) : false
+  })
+
+  return S.list()
+    .title('Content')
+    .items([
+      S.divider().title('Plugins'),
+      folder('input-plugins', 'Input plugins', INPUT_PLUGIN_TYPES),
+      folder('asset-source-plugins', 'Asset source plugins', ASSET_SOURCE_TYPES),
+      folder('custom-panes', 'Custom panes', CUSTOM_PANE_TYPES),
+      S.listItem()
+        .id('document-list-builders')
+        .title('Document list builders')
+        .child(
+          S.list()
+            .title('Document list builders')
+            .items([
+              ...hierarchicalDocumentListDeskItems(S, context),
+              S.divider(),
+              ...orderableDocumentListDeskItems(S, context),
+            ]),
+        ),
+      S.divider().title('Internationalization'),
+      ...itemsFor(INTERNATIONALIZATION_TYPES),
+      S.divider(),
+      ...itemsFor(MISC_NAMED_TYPES),
+      ...leftovers,
+    ])
+}
+
+// Per-type document views contributed by the folded "custom pane" plugins. Each
+// fragment returns a document node for the types it owns, or `null` otherwise,
+// so the first match wins and everything else uses the default form view.
+const documentNodeFragments: DefaultDocumentNodeResolver[] = [
+  documentsPaneDefaultDocumentNode,
+  iframePaneDefaultDocumentNode,
+  sanityNaiveHtmlSerializerDefaultDocumentNode,
+  smartlingDefaultDocumentNode,
+  transifexDefaultDocumentNode,
+  translationsTabDefaultDocumentNode,
+]
+
+export const homeDefaultDocumentNode: DefaultDocumentNodeResolver = (S, context) => {
+  for (const fragment of documentNodeFragments) {
+    const node = fragment(S, context)
+    if (node) return node
+  }
+  return undefined
+}

--- a/dev/test-studio/src/iframe-pane/index.tsx
+++ b/dev/test-studio/src/iframe-pane/index.tsx
@@ -2,7 +2,6 @@ import {LinkIcon} from '@sanity/icons'
 import {definePlugin, defineType} from 'sanity'
 import {Iframe} from 'sanity-plugin-iframe-pane'
 import type {DefaultDocumentNodeResolver} from 'sanity/structure'
-import {structureTool} from 'sanity/structure'
 
 // Example document type for demonstrating the iframe pane
 const iframeDocument = defineType({
@@ -28,7 +27,7 @@ const iframeDocument = defineType({
 })
 
 // Example default document node that uses the Iframe component
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const iframePaneDefaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
   if (schemaType === 'iframeExample') {
     return S.document().views([
       S.view.form(),
@@ -43,15 +42,10 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
         .title('Preview'),
     ])
   }
-  return S.document().views([S.view.form()])
+  return null
 }
 
 export const iframePaneExample = definePlugin(() => ({
   name: 'iframe-pane-example',
   schema: {types: [iframeDocument]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
 }))

--- a/dev/test-studio/src/internationalized-array/issue-520-repro.ts
+++ b/dev/test-studio/src/internationalized-array/issue-520-repro.ts
@@ -14,7 +14,7 @@ import {defineField, defineType} from 'sanity'
  * Seed the misordered document with:
  *   pnpm --filter test-studio seed:issue-520
  *
- * Then open it in the `kitchen-sink` workspace and switch the perspective
+ * Then open it in the `home` workspace and switch the perspective
  * to the published version.
  */
 export const issue520Repro = defineType({

--- a/dev/test-studio/src/mux-input/index.tsx
+++ b/dev/test-studio/src/mux-input/index.tsx
@@ -15,6 +15,8 @@ export const muxInputExample = definePlugin(() => ({
   schema: {types: [muxTrailer]},
   plugins: [
     muxInput({
+      // Make the studio tool clearly attributable to the plugin in the nav.
+      tool: {title: 'mux-input: Videos'},
       video_quality: 'plus',
       max_resolution_tier: '2160p',
       static_renditions: ['highest'],

--- a/dev/test-studio/src/orderable-document-list/index.tsx
+++ b/dev/test-studio/src/orderable-document-list/index.tsx
@@ -5,7 +5,7 @@ import {
   orderRankOrdering,
 } from '@sanity/orderable-document-list'
 import {definePlugin, defineType, type ConfigContext} from 'sanity'
-import {structureTool, type StructureBuilder} from 'sanity/structure'
+import type {StructureBuilder} from 'sanity/structure'
 
 type StructureListItem = Parameters<ReturnType<StructureBuilder['list']>['items']>[0][number]
 
@@ -62,17 +62,14 @@ export const orderableDocumentListExample = definePlugin(() => ({
   schema: {types: [orderableCategory, orderableProject]},
 }))
 
-export const orderableDocumentListExampleStructure = definePlugin(() => ({
-  plugins: [
-    structureTool({
-      structure: (S, context) => {
-        return S.list()
-          .title('Content')
-          .items([
-            orderableDeskItem({type: 'orderableCategory', title: 'Categories'}, S, context),
-            orderableDeskItem({type: 'orderableProject', title: 'Projects'}, S, context),
-          ])
-      },
-    }),
-  ],
-}))
+// Desk items for the orderable-document-list plugin, composed into the home
+// workspace's structure (rather than living in a dedicated workspace).
+export function orderableDocumentListDeskItems(
+  S: StructureBuilder,
+  context: ConfigContext,
+): StructureListItem[] {
+  return [
+    orderableDeskItem({type: 'orderableCategory', title: 'Categories'}, S, context),
+    orderableDeskItem({type: 'orderableProject', title: 'Projects'}, S, context),
+  ]
+}

--- a/dev/test-studio/src/sanity-naive-html-serializer/index.tsx
+++ b/dev/test-studio/src/sanity-naive-html-serializer/index.tsx
@@ -3,11 +3,7 @@ import {Box, Button, Card, Code, Flex, Stack, Text, Tooltip, useToast} from '@sa
 import {useCallback, useMemo} from 'react'
 import type {SanityDocument} from 'sanity'
 import {definePlugin, defineType, useSchema} from 'sanity'
-import {
-  structureTool,
-  type DefaultDocumentNodeResolver,
-  type UserViewComponent,
-} from 'sanity/structure'
+import type {DefaultDocumentNodeResolver, UserViewComponent} from 'sanity/structure'
 
 import {formatHtml} from './formatHtml'
 import {serializeDocumentToHtml} from './serializeDocumentToHtml'
@@ -132,7 +128,10 @@ const HtmlSerializeView: UserViewComponent = ({document}) => {
   )
 }
 
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const sanityNaiveHtmlSerializerDefaultDocumentNode: DefaultDocumentNodeResolver = (
+  S,
+  {schemaType},
+) => {
   if (schemaType === 'naiveHtmlSerializerArticle') {
     return S.document().views([
       S.view.form(),
@@ -140,15 +139,10 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
     ])
   }
 
-  return S.document().views([S.view.form()])
+  return null
 }
 
 export const sanityNaiveHtmlSerializerExample = definePlugin(() => ({
   name: 'sanity-naive-html-serializer-example',
   schema: {types: [naiveHtmlSerializerArticle]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
 }))

--- a/dev/test-studio/src/script-runner/README.md
+++ b/dev/test-studio/src/script-runner/README.md
@@ -1,12 +1,12 @@
 # Test Studio Script Runner
 
-The script runner adds a `Scripts` tool to the `kitchen-sink` test studio workspace. It lists
+The script runner adds a `Scripts` tool to the `home` test studio workspace. It lists
 browser-side scripts and lets agents run them with the current Studio client.
 
 ## Routes
 
-- `<studio>/kitchen-sink/scripts` shows all registered scripts.
-- `<studio>/kitchen-sink/scripts/<script-name>` opens a script run screen.
+- `<studio>/home/scripts` shows all registered scripts.
+- `<studio>/home/scripts/<script-name>` opens a script run screen.
 
 The route segment comes from the script's `name`.
 

--- a/dev/test-studio/src/script-runner/scripts/seed-issue-520/REPRO.md
+++ b/dev/test-studio/src/script-runner/scripts/seed-issue-520/REPRO.md
@@ -24,20 +24,20 @@ test-studio instead.
 
 ## End-to-end repro in the dev test-studio
 
-For a live repro inside the test-studio's `kitchen-sink` workspace:
+For a live repro inside the test-studio's `home` workspace:
 
 ### 1. Schema
 
 A dedicated document type `issue520Repro` is added in
 `dev/test-studio/src/internationalized-array/issue-520-repro.ts` and wired
-into the `kitchen-sink` workspace via the existing
+into the `home` workspace via the existing
 `internationalizedArrayExample` plugin export.
 
 ### 2. Studio runner script
 
 Use the Studio Script Runner entrypoint at
 `dev/test-studio/src/script-runner/scripts/seed-issue-520/index.ts`. It runs
-inside the `kitchen-sink` Studio workspace with the logged-in user's Studio
+inside the `home` Studio workspace with the logged-in user's Studio
 client and:
 
 1. Create an asap release.
@@ -59,9 +59,9 @@ pnpm --filter test-studio dev
 
 Then run the Studio script:
 
-1. Open the studio at `http://localhost:3333/kitchen-sink`.
+1. Open the studio at `http://localhost:3333/home`.
 2. Open the `Scripts` tool from the Studio tools menu.
-3. Open `Seed issue #520 repro` at `/kitchen-sink/scripts/seed-issue-520`.
+3. Open `Seed issue #520 repro` at `/home/scripts/seed-issue-520`.
 4. Set `Published document ID` to the document id you want to reproduce with
    (defaults to `issue-520-repro`).
 5. Click `Run script`.

--- a/dev/test-studio/src/script-runner/scripts/seed-issue-520/index.ts
+++ b/dev/test-studio/src/script-runner/scripts/seed-issue-520/index.ts
@@ -49,7 +49,7 @@ const seedIssue520: StudioScript = {
     log.info('Publishing the release...')
     await client.releases.publish({releaseId})
 
-    log.success(`Done. Open "${publishedId}" in the kitchen-sink workspace.`)
+    log.success(`Done. Open "${publishedId}" in the home workspace.`)
     log.info('The Localized field should crash with "Attempted to patch a read-only document".')
   },
 }

--- a/dev/test-studio/src/smartling/index.tsx
+++ b/dev/test-studio/src/smartling/index.tsx
@@ -2,7 +2,6 @@ import {EarthGlobeIcon} from '@sanity/icons'
 import {defineField, definePlugin, defineType} from 'sanity'
 import {defaultFieldLevelConfig, TranslationsTab} from 'sanity-plugin-studio-smartling'
 import type {DefaultDocumentNodeResolver} from 'sanity/structure'
-import {structureTool} from 'sanity/structure'
 
 const languages = [
   {id: 'en', title: 'English', isDefault: true},
@@ -50,7 +49,7 @@ const smartlingTest = defineType({
   ],
 })
 
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const smartlingDefaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
   if (schemaType === 'smartlingTest') {
     return S.document().views([
       S.view.form(),
@@ -58,15 +57,10 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
     ])
   }
 
-  return S.document().views([S.view.form()])
+  return null
 }
 
 export const smartlingExample = definePlugin(() => ({
   name: 'smartling-example',
   schema: {types: [localizedString, smartlingTest]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
 }))

--- a/dev/test-studio/src/transifex/index.tsx
+++ b/dev/test-studio/src/transifex/index.tsx
@@ -2,7 +2,6 @@ import {EarthGlobeIcon} from '@sanity/icons'
 import {defineField, definePlugin, defineType} from 'sanity'
 import {defaultFieldLevelConfig, TranslationsTab} from 'sanity-plugin-transifex'
 import type {DefaultDocumentNodeResolver} from 'sanity/structure'
-import {structureTool} from 'sanity/structure'
 
 const languages = [
   {id: 'en', title: 'English', isDefault: true},
@@ -50,7 +49,7 @@ const transifexTest = defineType({
   ],
 })
 
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const transifexDefaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
   if (schemaType === 'transifexTest') {
     return S.document().views([
       S.view.form(),
@@ -58,15 +57,10 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
     ])
   }
 
-  return S.document().views([S.view.form()])
+  return null
 }
 
 export const transifexExample = definePlugin(() => ({
   name: 'transifex-example',
   schema: {types: [localizedString, transifexTest]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
 }))

--- a/dev/test-studio/src/translations-tab/index.tsx
+++ b/dev/test-studio/src/translations-tab/index.tsx
@@ -8,7 +8,6 @@ import {
   type ImportTranslation,
 } from 'sanity-translations-tab'
 import type {DefaultDocumentNodeResolver} from 'sanity/structure'
-import {structureTool} from 'sanity/structure'
 
 const SECRETS_DOCUMENT_ID = 'translationService.secrets'
 
@@ -43,7 +42,10 @@ const importTranslation: ImportTranslation = async () => {
   return undefined
 }
 
-const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
+export const translationsTabDefaultDocumentNode: DefaultDocumentNodeResolver = (
+  S,
+  {schemaType},
+) => {
   if (schemaType === 'translatable') {
     return S.document().views([
       S.view.form(),
@@ -67,7 +69,7 @@ const defaultDocumentNode: DefaultDocumentNodeResolver = (S, {schemaType}) => {
     ])
   }
 
-  return S.document().views([S.view.form()])
+  return null
 }
 
 function SeedTranslationSecrets() {
@@ -92,11 +94,6 @@ function SeedTranslationSecrets() {
 export const translationsTabExample = definePlugin(() => ({
   name: 'translations-tab-example',
   schema: {types: [translatableDocument]},
-  plugins: [
-    structureTool({
-      defaultDocumentNode,
-    }),
-  ],
   studio: {
     components: {
       layout: (props) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The `dev/test-studio` workspace list had grown to ~22 workspaces, most of which existed only because each example bundled its own `structureTool`. This merges the `kitchen-sink` workspace into the default `home` workspace and keeps only the workspaces that are *technically* required.

## Changes

- **`home` is now the merged "kitchen sink"** (and stays first so the Workspaces Home launcher still works). It hosts every plugin that can coexist in one dataset/schema.
- **`home`'s Structure tool is organized into sections** using titled dividers (`S.divider().title(...)`) and folders, grouped by the Studio API each plugin implements:
  - `Plugins` → Input plugins, Asset source plugins, Custom panes, Document list builders
  - `Internationalization` → translation/i18n document types
  - an untitled catch-all (AI context, Media Tag, and any leftover types) so nothing disappears
- **Foldable examples refactored** (`documents-pane`, `iframe-pane`, `transifex`, `smartling`, `translations-tab`, `naive-html-serializer`, `hierarchical-document-list`, `orderable-document-list`) to export schema + a `defaultDocumentNode`/desk-item fragment, which `home` composes into a single Structure tool and `defaultDocumentNode`.
- **Only conflict/dataset-driven workspaces remain**, each prefixed with the plugin name:
  - `internationalized-array: Async Languages` (alternate async `internationalizedArray` config)
  - `sanity-translations-tab: i18n Array` (own `internationalizedArray` language set)
  - `document-internationalization: Translations` (second `documentInternationalization` config)
  - `sfcc: Salesforce Commerce Cloud` (own `internationalizedArray` + `product`/`category`)
  - `workflow: Document Workflow` (`product` collides with sfcc)
  - `cross-dataset-duplicator: Target` (locked to dataset `test`)
- **Tool naming:** the Mux studio tool is renamed to `mux-input: Videos` via the plugin's own `tool.title` option, so it's attributable to its plugin in the nav. Home tool order is `Workspaces Home → Structure → Media → mux-input: Videos → …`.
- **Refs:** typegen script and all `/kitchen-sink` references (AGENTS.md, script-runner docs/skill, seed-issue-520, issue-520 repro) updated to `/home`; `sanity.types.ts`/`schema.json` regenerated.

No changeset: `dev/test-studio` is private and all changes are studio-side (the Mux rename uses an existing plugin option).

## Testing

- `pnpm build` — 50/50 tasks succeed (validates the merged schema/config)
- `pnpm lint` — passes
- `pnpm --filter test-studio typegen` — regenerates types (135 schema types in `home`)
- Manual GUI verification of the sectioned Structure, renamed Mux tool, and each isolated workspace (see walkthrough in the agent summary).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-537647d9-6a48-41af-aceb-b01532266ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-537647d9-6a48-41af-aceb-b01532266ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

