### PR TITLE
fix(assist): keep field group selection while editing AI Assist inputs

### DIFF
--- a/.changeset/assist-field-group-reset.md
+++ b/.changeset/assist-field-group-reset.md
@@ -1,0 +1,5 @@
+---
+'@sanity/assist': patch
+---
+
+Keep the document's selected field group from resetting while editing AI Assist instructions. The instruction inspector no longer overwrites the host document pane's `path` param, so working with AI Assist inputs preserves the active field group tab.

--- a/dev/test-studio/src/assist/index.tsx
+++ b/dev/test-studio/src/assist/index.tsx
@@ -1,7 +1,34 @@
 import {assist} from '@sanity/assist'
-import {definePlugin} from 'sanity'
+import {defineField, definePlugin, defineType} from 'sanity'
+
+// Fixture for manually testing AI Assist together with field groups (tabs).
+// Reproduces SAPP-3970: opening / editing AI Assist instructions used to reset
+// the selected field group in the host document.
+const assistFieldGroupsRepro = defineType({
+  name: 'assistFieldGroupsRepro',
+  title: 'AI Assist: Field groups',
+  type: 'document',
+  groups: [
+    {name: 'content', title: 'Content', default: true},
+    {name: 'seo', title: 'SEO'},
+  ],
+  fields: [
+    defineField({name: 'title', title: 'Title', type: 'string', group: 'content'}),
+    defineField({name: 'body', title: 'Body', type: 'text', group: 'content'}),
+    defineField({name: 'metaTitle', title: 'Meta title', type: 'string', group: 'seo'}),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta description',
+      type: 'text',
+      group: 'seo',
+    }),
+  ],
+})
 
 export const assistExample = definePlugin(() => ({
+  schema: {
+    types: [assistFieldGroupsRepro],
+  },
   plugins: [
     assist({
       translate: {

--- a/plugins/@sanity/assist/src/assistInspector/AssistInspector.tsx
+++ b/plugins/@sanity/assist/src/assistInspector/AssistInspector.tsx
@@ -1,6 +1,6 @@
 import {ArrowRightIcon, CloseIcon, PlayIcon, RetryIcon} from '@sanity/icons'
 import {Box, Button, Card, Flex, Spinner, Stack, Text} from '@sanity/ui'
-import {useCallback, useMemo, useRef} from 'react'
+import {type PropsWithChildren, useCallback, useMemo, useRef, useState} from 'react'
 import {
   type DocumentInspectorProps,
   PerspectiveProvider,
@@ -11,7 +11,10 @@ import {
   DocumentInspectorHeader,
   type DocumentPaneNode,
   DocumentPaneProvider,
+  PaneRouterContext,
+  type PaneRouterContextValue,
   useDocumentPane,
+  usePaneRouter,
 } from 'sanity/structure'
 import {styled} from 'styled-components'
 
@@ -36,6 +39,9 @@ import {
   useTypePath,
 } from './helpers'
 import {InstructionTaskHistoryButton} from './InstructionTaskHistoryButton'
+import {isolatePathParams} from './isolatePathParams'
+
+const EMPTY_PANE_PARAMS: Record<string, string | undefined> = {}
 
 const CardWithShadowBelow = styled(Card)`
   position: relative;
@@ -327,14 +333,16 @@ function AssistInspector(props: DocumentInspectorProps) {
                       containerElement={boundary}
                     >
                       <PerspectiveProvider selectedPerspectiveName={undefined}>
-                        <DocumentPaneProvider
-                          paneKey={documentPane.paneKey}
-                          index={documentPane.index}
-                          itemId="ai"
-                          pane={paneNode}
-                        >
-                          <DocumentForm />
-                        </DocumentPaneProvider>
+                        <IsolatedPathPaneRouterProvider>
+                          <DocumentPaneProvider
+                            paneKey={documentPane.paneKey}
+                            index={documentPane.index}
+                            itemId="ai"
+                            pane={paneNode}
+                          >
+                            <DocumentForm />
+                          </DocumentPaneProvider>
+                        </IsolatedPathPaneRouterProvider>
                       </PerspectiveProvider>
                     </VirtualizerScrollInstanceProvider>
                   </AssistTypeContext.Provider>
@@ -384,6 +392,47 @@ function AssistInspector(props: DocumentInspectorProps) {
       </CardWithShadowAbove>
     </Flex>
   )
+}
+
+/**
+ * The instruction editor below renders a nested document form that reuses the
+ * host document's pane router. Sanity's document pane mirrors the router `path`
+ * param to programmatic focus, and focus drives the selected field group. So
+ * without isolation, navigating the instruction form overwrites the host `path`
+ * and resets the host document's field group selection (SAPP-3970).
+ *
+ * This provider keeps the nested form's `path` navigation in local state while
+ * still forwarding every other param (e.g. the selected instruction) to the
+ * host pane router.
+ */
+function IsolatedPathPaneRouterProvider(props: PropsWithChildren) {
+  const parentRouter = usePaneRouter()
+  const parentParams = parentRouter.params ?? EMPTY_PANE_PARAMS
+  const parentSetParams = parentRouter.setParams
+
+  const [localPath, setLocalPath] = useState<string | undefined>(undefined)
+
+  const setParams = useCallback<PaneRouterContextValue['setParams']>(
+    (nextParams, stickyParams) => {
+      const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, parentParams)
+      setLocalPath(nextLocalPath)
+      if (forwardParams) {
+        parentSetParams(forwardParams, stickyParams)
+      }
+    },
+    [parentParams, parentSetParams],
+  )
+
+  const value = useMemo<PaneRouterContextValue>(
+    () => ({
+      ...parentRouter,
+      params: {...parentParams, path: localPath},
+      setParams,
+    }),
+    [parentRouter, parentParams, localPath, setParams],
+  )
+
+  return <PaneRouterContext.Provider value={value}>{props.children}</PaneRouterContext.Provider>
 }
 
 function AiInspectorHeader(props: {fieldTitle: string; field?: FieldRef; onClose: () => void}) {

--- a/plugins/@sanity/assist/src/assistInspector/isolatePathParams.test.ts
+++ b/plugins/@sanity/assist/src/assistInspector/isolatePathParams.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, test} from 'vitest'
+
+import {isolatePathParams} from './isolatePathParams'
+
+describe('isolatePathParams', () => {
+  test('keeps path local and does not forward when only path changed', () => {
+    const hostParams = {inspect: 'sanity-assist', pathKey: 'title', path: 'title'}
+    // The nested form spreads the current (isolated) params, then overrides path
+    const nextParams = {...hostParams, path: 'fields[_key=="title"].instructions'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('fields[_key=="title"].instructions')
+    expect(forwardParams).toBeNull()
+  })
+
+  test('forwards non-path param changes while preserving the host path', () => {
+    const hostParams = {inspect: 'sanity-assist', pathKey: 'title', path: 'title'}
+    const nextParams = {...hostParams, instruction: 'abc123', path: 'fields[_key=="title"]'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('fields[_key=="title"]')
+    expect(forwardParams).toEqual({
+      inspect: 'sanity-assist',
+      pathKey: 'title',
+      instruction: 'abc123',
+      path: 'title',
+    })
+  })
+
+  test('preserves an undefined host path when forwarding', () => {
+    const hostParams = {inspect: 'sanity-assist', pathKey: 'title'}
+    const nextParams = {...hostParams, instruction: 'abc123', path: 'fields[_key=="title"]'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('fields[_key=="title"]')
+    expect(forwardParams).toEqual({
+      inspect: 'sanity-assist',
+      pathKey: 'title',
+      instruction: 'abc123',
+      path: undefined,
+    })
+  })
+
+  test('forwards cleared params (e.g. closing the inspector) without touching host path', () => {
+    const hostParams = {
+      inspect: 'sanity-assist',
+      pathKey: 'title',
+      instruction: 'abc',
+      path: 'title',
+    }
+    const nextParams = {...hostParams, instruction: undefined, path: 'title'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('title')
+    expect(forwardParams).toEqual({
+      inspect: 'sanity-assist',
+      pathKey: 'title',
+      instruction: undefined,
+      path: 'title',
+    })
+  })
+
+  test('treats missing path the same as undefined path (no false forwards)', () => {
+    const hostParams = {pathKey: 'title'}
+    const nextParams = {pathKey: 'title', path: 'fields[_key=="title"]'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('fields[_key=="title"]')
+    expect(forwardParams).toBeNull()
+  })
+})

--- a/plugins/@sanity/assist/src/assistInspector/isolatePathParams.test.ts
+++ b/plugins/@sanity/assist/src/assistInspector/isolatePathParams.test.ts
@@ -73,4 +73,17 @@ describe('isolatePathParams', () => {
     expect(nextLocalPath).toBe('fields[_key=="title"]')
     expect(forwardParams).toBeNull()
   })
+
+  test('forwards when only the name of an undefined param differs (same key count)', () => {
+    // Regression: a naive shallow compare that only checks `a[key] === b[key]`
+    // treats {instruction: undefined} and {pathKey: undefined} as equal (both
+    // read back as undefined) and would incorrectly skip forwarding.
+    const hostParams = {inspect: 'sanity-assist', instruction: undefined, path: 'title'}
+    const nextParams = {inspect: 'sanity-assist', pathKey: undefined, path: 'title'}
+
+    const {nextLocalPath, forwardParams} = isolatePathParams(nextParams, hostParams)
+
+    expect(nextLocalPath).toBe('title')
+    expect(forwardParams).toEqual({inspect: 'sanity-assist', pathKey: undefined, path: 'title'})
+  })
 })

--- a/plugins/@sanity/assist/src/assistInspector/isolatePathParams.ts
+++ b/plugins/@sanity/assist/src/assistInspector/isolatePathParams.ts
@@ -1,0 +1,46 @@
+type PaneParams = Record<string, string | undefined>
+
+function shallowEqualParams(a: PaneParams, b: PaneParams): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => a[key] === b[key])
+}
+
+export interface IsolatedPathParams {
+  /** The `path` value to keep in the nested pane's local state. */
+  nextLocalPath: string | undefined
+  /**
+   * Params to forward to the host pane router, or `null` when only `path`
+   * changed — in which case the host router (and therefore the host document's
+   * focus and selected field group) is left untouched.
+   */
+  forwardParams: PaneParams | null
+}
+
+/**
+ * The AI Assist inspector renders a nested document form for the instruction
+ * document, but it reuses the host document's pane router. Sanity's document
+ * pane mirrors the router `path` param to programmatic focus, and focus drives
+ * the selected field group. So when the nested form writes `path`, the host
+ * document re-focuses and its field group selection resets (SAPP-3970).
+ *
+ * This keeps the nested form's `path` navigation local, while still forwarding
+ * every other param (e.g. the selected `instruction`) to the host router and
+ * preserving the host document's own `path`.
+ */
+export function isolatePathParams(
+  nextParams: PaneParams,
+  hostParams: PaneParams,
+): IsolatedPathParams {
+  const {path: nextLocalPath, ...restNext} = nextParams
+  const {path: hostPath, ...restHost} = hostParams
+
+  if (shallowEqualParams(restNext, restHost)) {
+    return {nextLocalPath, forwardParams: null}
+  }
+
+  return {nextLocalPath, forwardParams: {...restNext, path: hostPath}}
+}

--- a/plugins/@sanity/assist/src/assistInspector/isolatePathParams.ts
+++ b/plugins/@sanity/assist/src/assistInspector/isolatePathParams.ts
@@ -1,13 +1,6 @@
-type PaneParams = Record<string, string | undefined>
+import isEqual from 'react-fast-compare'
 
-function shallowEqualParams(a: PaneParams, b: PaneParams): boolean {
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
-  if (aKeys.length !== bKeys.length) {
-    return false
-  }
-  return aKeys.every((key) => a[key] === b[key])
-}
+type PaneParams = Record<string, string | undefined>
 
 export interface IsolatedPathParams {
   /** The `path` value to keep in the nested pane's local state. */
@@ -38,7 +31,7 @@ export function isolatePathParams(
   const {path: nextLocalPath, ...restNext} = nextParams
   const {path: hostPath, ...restHost} = hostParams
 
-  if (shallowEqualParams(restNext, restHost)) {
+  if (isEqual(restNext, restHost)) {
     return {nextLocalPath, forwardParams: null}
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When editing AI Assist inputs in a document that uses field groups, the selected field group tab kept resetting during common AI Assist actions (opening the instruction inspector, selecting/editing an instruction, etc.), adding a frustrating extra navigation step.

## Root cause

The AI Assist instruction inspector renders a **nested** `DocumentPaneProvider` for the instruction document, but it reused the **host** document's pane router (`usePaneRouter()`).

Sanity's structure document pane mirrors the router `path` param to programmatic focus, and focus drives the selected field group. So whenever the nested instruction form wrote `path` (which happens when it opens the active field/instruction path — a very common action), the host document picked up the changed `path`, re-focused itself, and reset its field group selection to the group containing the newly focused path.

## Fix

Wrap the nested `DocumentPaneProvider` in a small `PaneRouterContext` provider that isolates the `path` param: the instruction form's `path` navigation is kept in local state, while every other param (e.g. the selected `instruction`, `inspect`) is still forwarded to the host pane router. This decouples the instruction form's navigation from the host document's focus/field-group state.

The param-splitting logic is extracted into a pure, unit-tested helper (`isolatePathParams`). Param equality uses `react-fast-compare` (already a plugin dependency) rather than a hand-rolled check.

## Before / after

Both recordings use the same steps: create a doc, select the **SEO** group tab, then open AI Assist on the SEO field "Meta title".

Bug (before) — the group tab jumps back to "Content" the moment the AI Assist inspector opens:
[bug_field_group_resets_on_ai_assist_open.mp4](https://cursor.com/agents/bc-c86cbf56-09f8-4600-828b-420dfb4e7241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_field_group_resets_on_ai_assist_open.mp4)
[Bug: group reset to Content](https://cursor.com/agents/bc-c86cbf56-09f8-4600-828b-420dfb4e7241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_group_reset_to_content.webp)

Fix (after) — the group tab stays on "SEO" while opening the inspector and adding/editing an instruction:
[fix_field_group_stays_selected_with_ai_assist.mp4](https://cursor.com/agents/bc-c86cbf56-09f8-4600-828b-420dfb4e7241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffix_field_group_stays_selected_with_ai_assist.mp4)
[Fix: group stays on SEO](https://cursor.com/agents/bc-c86cbf56-09f8-4600-828b-420dfb4e7241/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffix_group_stays_seo.webp)

## Changes

- `plugins/@sanity/assist/src/assistInspector/isolatePathParams.ts` — pure helper that keeps `path` local and forwards other params (preserving the host `path`); uses `react-fast-compare` for param equality.
- `plugins/@sanity/assist/src/assistInspector/AssistInspector.tsx` — new `IsolatedPathPaneRouterProvider` wrapping the nested instruction form's `DocumentPaneProvider`.
- `plugins/@sanity/assist/src/assistInspector/isolatePathParams.test.ts` — unit tests (incl. a regression test for the equality edge case raised in review).
- `dev/test-studio/src/assist/index.tsx` — adds an "AI Assist: Field groups" fixture (Content/SEO tabs) for manual testing.
- Changeset (`@sanity/assist`: patch).

## Review notes

Addresses Copilot's review: the initial `shallowEqualParams` helper could return a false positive when two param objects had the same key count but different keys whose values were `undefined` (it never verified the key existed on the other object). Replaced it with `react-fast-compare` (already used elsewhere in the plugin) and added a regression test.

## Testing

- `pnpm build` — all packages build (`@sanity/assist` with `--strict --check`).
- `pnpm lint` — passes.
- `pnpm test run` — passes, incl. the `isolatePathParams` unit tests (6 cases).
- Manual verification in the test studio (AI Assist enabled): confirmed the bug before the fix and that the field group stays selected after the fix (see videos above).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c86cbf56-09f8-4600-828b-420dfb4e7241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c86cbf56-09f8-4600-828b-420dfb4e7241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

