### PR TITLE
fix(vercel-widget): restore javascript-time-ago locale registration

### DIFF
--- a/.changeset/vercel-widget-locale-fix.md
+++ b/.changeset/vercel-widget-locale-fix.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-vercel": patch
+---
+
+Fix "No locale data has been registered" runtime error in the deployments widget. The side-effect-only `react-time-ago/locale/en` import (added in #1373) was tree-shaken out of the published bundle since it has no bindings; restore the explicit `javascript-time-ago` dependency and `TimeAgo.addDefaultLocale(en)` call so locale registration survives bundling.

--- a/plugins/sanity-plugin-dashboard-widget-vercel/package.json
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/package.json
@@ -51,6 +51,7 @@
     "@sanity/uuid": "catalog:",
     "@tanstack/react-query": "^5.101.1",
     "@xstate/react": "^6.1.0",
+    "javascript-time-ago": "^2.6.4",
     "object-hash": "3.0.0",
     "react-hook-form": "catalog:",
     "react-time-ago": "^7.4.4",

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployment/index.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/components/Deployment/index.tsx
@@ -1,8 +1,6 @@
 import {LinkIcon} from '@sanity/icons'
 import {Box, Flex, Stack, Text} from '@sanity/ui'
 import {useMemo} from 'react'
-// oxlint-disable-next-line import/no-unassigned-import
-import 'react-time-ago/locale/en'
 import ReactTimeAgo from 'react-time-ago'
 
 import {type Vercel} from '../../types'

--- a/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/src/index.ts
@@ -1,6 +1,11 @@
 import {type DashboardWidget, type LayoutConfig} from '@sanity/dashboard'
+// Initialize `javascript-time-ago` locale (required for react-time-ago)
+import TimeAgo from 'javascript-time-ago'
+import en from 'javascript-time-ago/locale/en'
 
 import Widget from './app'
+
+TimeAgo.addDefaultLocale(en)
 
 export function vercelWidget(config: {layout?: LayoutConfig} = {}): DashboardWidget {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2112,6 +2112,9 @@ importers:
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.2)
+      javascript-time-ago:
+        specifier: ^2.6.4
+        version: 2.6.4
       object-hash:
         specifier: 3.0.0
         version: 3.0.0


### PR DESCRIPTION
## Summary

`sanity-plugin-dashboard-widget-vercel` has been broken since `4.0.6` (the release after #1373 merged) — the deployments widget throws at render time:

```
No locale data has been registered for any of the locales: en-US, en, en
```

## Root cause

#1373 replaced the explicit locale registration in `src/index.ts`:

```ts
import TimeAgo from 'javascript-time-ago'
import en from 'javascript-time-ago/locale/en'
TimeAgo.addDefaultLocale(en)
```

with a bare side-effect import in `src/components/Deployment/index.tsx`:

```ts
// oxlint-disable-next-line import/no-unassigned-import
import 'react-time-ago/locale/en'
```

That import has no bindings, and it targets an *external* package subpath, so the plugin's own bundler (rolldown, via `pkg build`) tree-shakes it out of the published bundle entirely. I confirmed this by diffing the actual published `dist/index.js` for `4.0.5` vs `4.0.8`: the working `4.0.5` bundle contains the `javascript-time-ago` import and the `TimeAgo.addDefaultLocale(en)` call; the broken `4.0.8` bundle contains neither. `<ReactTimeAgo locale="en-US" .../>` then renders with no locale ever registered, and `javascript-time-ago` throws.

## Fix

Revert to the explicit-call pattern, which survives tree-shaking because it's a real call expression rather than a binding-less import:

- Re-add `javascript-time-ago` as a direct dependency
- Restore `import TimeAgo from 'javascript-time-ago'` / `import en from 'javascript-time-ago/locale/en'` / `TimeAgo.addDefaultLocale(en)` in `src/index.ts`
- Remove the now-redundant side-effect import from `src/components/Deployment/index.tsx`

I verified the fix by rebuilding the plugin and confirming the built `dist/index.js` now contains the `javascript-time-ago` import and `TimeAgo.addDefaultLocale(en)` call again (same technique used to diagnose the regression).

## Testing

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm build --filter sanity-plugin-dashboard-widget-vercel`
- [x] `pnpm test run` (full suite, 889 tests passing)
- [x] Manually diffed built `dist/index.js` before/after to confirm the locale registration call is present in the output
- [x] Added a changeset

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted bundling/locale-init fix in a dashboard widget with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a **runtime crash** in the Vercel deployments widget (“No locale data has been registered…”) introduced when locale setup was switched to a side-effect-only `react-time-ago/locale/en` import that **rolldown tree-shakes out** of the published `dist` bundle.
> 
> The PR **re-adds** `javascript-time-ago` as a direct dependency and registers English in `src/index.ts` via `TimeAgo.addDefaultLocale(en)`, and **drops** the redundant locale import from the Deployment row component so registration survives bundling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ab38a52d09faf21ae0cf2fce535793aaaba011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->