### PR TITLE
fix(document-internationalization): enable creating language copies for documents in releases

### DIFF
--- a/.changeset/document-internationalization-releases.md
+++ b/.changeset/document-internationalization-releases.md
@@ -1,0 +1,5 @@
+---
+"@sanity/document-internationalization": patch
+---
+
+Fix the Translations menu being disabled for documents that only exist in a release. When a release is selected, the version document is now used as the source for translations, and new language copies are created in that same release.

--- a/plugins/@sanity/document-internationalization/src/badges/index.test.tsx
+++ b/plugins/@sanity/document-internationalization/src/badges/index.test.tsx
@@ -13,10 +13,12 @@ vi.mock('../components/DocumentInternationalizationContext', () => ({
 function createBadgeProps(opts: {
   draft?: Partial<SanityDocument> | null
   published?: Partial<SanityDocument> | null
+  version?: Partial<SanityDocument> | null
 }): DocumentBadgeProps {
   return {
     draft: opts.draft as SanityDocument | null,
     published: opts.published as SanityDocument | null,
+    version: (opts.version ?? null) as SanityDocument | null,
   } as DocumentBadgeProps
 }
 
@@ -103,6 +105,30 @@ describe('LanguageBadge', () => {
 
     expect(result!.label).toBe('fr')
     expect(result!.title).toBe('French')
+  })
+
+  test('prefers version document over draft and published', () => {
+    const props = createBadgeProps({
+      version: {_id: 'versions.rTestRelease.doc-1', _type: 'article', language: 'es'},
+      draft: {_id: 'drafts.doc-1', _type: 'article', language: 'fr'},
+      published: {_id: 'doc-1', _type: 'article', language: 'en'},
+    })
+    const result = LanguageBadge(props)
+
+    expect(result!.label).toBe('es')
+    expect(result!.title).toBe('Spanish')
+  })
+
+  test('uses version document when document only exists in a release', () => {
+    const props = createBadgeProps({
+      version: {_id: 'versions.rTestRelease.doc-1', _type: 'article', language: 'de'},
+      draft: null,
+      published: null,
+    })
+    const result = LanguageBadge(props)
+
+    expect(result!.label).toBe('de')
+    expect(result!.title).toBe('German')
   })
 
   test('uses published document when no draft exists', () => {

--- a/plugins/@sanity/document-internationalization/src/badges/index.tsx
+++ b/plugins/@sanity/document-internationalization/src/badges/index.tsx
@@ -4,13 +4,13 @@ import {useDocumentInternationalizationContext} from '../components/DocumentInte
 
 /**
  * Document badge that displays the language identifier of a document.
- * Reads the configured `languageField` from the draft or published document,
- * looks up the matching language in `supportedLanguages` to resolve the title,
- * and returns a badge descriptor with `primary` color. Returns `null` when
- * no document exists or the language field is empty/non-string.
+ * Reads the configured `languageField` from the version, draft or published
+ * document, looks up the matching language in `supportedLanguages` to resolve
+ * the title, and returns a badge descriptor with `primary` color. Returns
+ * `null` when no document exists or the language field is empty/non-string.
  */
 export function LanguageBadge(props: DocumentBadgeProps): DocumentBadgeDescription | null {
-  const source = props?.draft || props?.published
+  const source = props?.version || props?.draft || props?.published
   const {languageField, supportedLanguages} = useDocumentInternationalizationContext()
   const languageId = source?.[languageField]
 

--- a/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.test.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.test.tsx
@@ -11,12 +11,14 @@ import {useDocumentInternationalizationContext} from './DocumentInternationaliza
 import {DocumentInternationalizationMenu} from './DocumentInternationalizationMenu'
 
 const mockUseEditState = vi.fn()
+const mockUsePerspective = vi.fn()
 
 vi.mock('sanity', async (importOriginal) => {
   const actual = await importOriginal<typeof import('sanity')>()
   return {
     ...actual,
     useEditState: (...args: unknown[]) => mockUseEditState(...args),
+    usePerspective: () => mockUsePerspective(),
   }
 })
 
@@ -69,7 +71,9 @@ describe('DocumentInternationalizationMenu', () => {
     mockUseEditState.mockReturnValue({
       draft: createMockDocument('drafts.doc-1', 'en'),
       published: null,
+      version: null,
     })
+    mockUsePerspective.mockReturnValue({selectedReleaseId: undefined})
   })
 
   afterEach(() => {
@@ -96,13 +100,43 @@ describe('DocumentInternationalizationMenu', () => {
   })
 
   test('disables translations button when source document does not exist', () => {
-    mockUseEditState.mockReturnValue({draft: null, published: null})
+    mockUseEditState.mockReturnValue({draft: null, published: null, version: null})
 
     render(<DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />, {
       wrapper: ThemeWrapper,
     })
 
     expect(screen.getByRole('button', {name: 'Translations'})).toBeDisabled()
+  })
+
+  test('enables translations button when document only exists as a release version', async () => {
+    mockUsePerspective.mockReturnValue({selectedReleaseId: 'rTestRelease'})
+    mockUseEditState.mockReturnValue({
+      draft: null,
+      published: null,
+      version: createMockDocument('versions.rTestRelease.doc-1', 'en'),
+    })
+    vi.mocked(useTranslationMetadata).mockReturnValue({
+      data: [],
+      loading: false,
+      error: null,
+    })
+
+    render(<DocumentInternationalizationMenu documentId="doc-1" schemaType={articleSchemaType} />, {
+      wrapper: ThemeWrapper,
+    })
+
+    // The selected release is subscribed to in edit state
+    expect(mockUseEditState).toHaveBeenCalledWith('doc-1', 'article', 'default', 'rTestRelease')
+
+    const button = screen.getByRole('button', {name: 'Translations'})
+    expect(button).not.toBeDisabled()
+
+    // Language options are rendered from the version document
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(screen.getAllByTestId('language-option')).toHaveLength(MOCK_LANGUAGES.length)
+    })
   })
 
   test('renders language options when source language is valid', async () => {

--- a/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/DocumentInternationalizationMenu.tsx
@@ -3,7 +3,7 @@ import {Box, Button, Card, Popover, Stack, Text, TextInput, useClickOutsideEvent
 import {uuid} from '@sanity/uuid'
 import type {ChangeEvent} from 'react'
 import {useCallback, useMemo, useRef, useState} from 'react'
-import {useEditState} from 'sanity'
+import {useEditState, usePerspective} from 'sanity'
 import {LANGUAGE_FIELD_NAME} from 'sanity-plugin-internationalized-array'
 
 import {useTranslationMetadata} from '../hooks/useLanguageMetadata'
@@ -56,8 +56,16 @@ export function DocumentInternationalizationMenu(
   }, [loading, metadata?._id])
 
   // Duplicate a new language version from the most recent version of this document
-  const {draft, published} = useEditState(documentId, schemaType.name)
-  const source = draft || published
+  // When a release is selected, the version document is the source, so documents
+  // that only exist in that release can still be translated
+  const {selectedReleaseId} = usePerspective()
+  const {draft, published, version} = useEditState(
+    documentId,
+    schemaType.name,
+    'default',
+    selectedReleaseId,
+  )
+  const source = version || draft || published
 
   // Check for data issues
   const documentIsInOneMetadataDocument = useMemo(() => {

--- a/plugins/@sanity/document-internationalization/src/components/LanguageOption.test.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/LanguageOption.test.tsx
@@ -419,6 +419,38 @@ describe('LanguageOption', () => {
     })
   })
 
+  test('creates translation document in the same release when source is a version document', async () => {
+    mockClient = createMockSanityClient()
+    const transactionMock = mockClient.transaction()
+
+    const source = createMockDocument('versions.rTestRelease.doc-1', 'en')
+    render(
+      <LanguageOption
+        language={mockLanguage}
+        schemaType={mockSchemaType}
+        documentId="doc-1"
+        disabled={false}
+        current={false}
+        source={source}
+        metadataId="meta-1"
+        sourceLanguageId="en"
+      />,
+      {wrapper: ThemeWrapper},
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => {
+      expect(transactionMock.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: 'versions.rTestRelease.mock-uuid-123',
+          _type: 'article',
+          language: 'fr',
+        }),
+      )
+    })
+  })
+
   test('creates metadata document with source reference in transaction', async () => {
     mockClient = createMockSanityClient()
     const transactionMock = mockClient.transaction()

--- a/plugins/@sanity/document-internationalization/src/components/LanguageOption.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/LanguageOption.tsx
@@ -2,7 +2,15 @@ import {AddIcon, CheckmarkIcon, SplitVerticalIcon} from '@sanity/icons'
 import {Badge, Box, Button, Flex, Spinner, Text, Tooltip, useToast} from '@sanity/ui'
 import {uuid} from '@sanity/uuid'
 import {useCallback, useState} from 'react'
-import {type ObjectSchemaType, type SanityDocument, useClient} from 'sanity'
+import {
+  getDraftId,
+  getVersionFromId,
+  getVersionId,
+  isVersionId,
+  type ObjectSchemaType,
+  type SanityDocument,
+  useClient,
+} from 'sanity'
 import {LANGUAGE_FIELD_NAME} from 'sanity-plugin-internationalized-array'
 
 import {METADATA_SCHEMA_NAME} from '../constants'
@@ -77,10 +85,15 @@ export default function LanguageOption(props: LanguageOptionProps) {
     const transaction = client.transaction()
 
     // 1. Duplicate source document
+    // If the source belongs to a release, create the translation
+    // as a version in that same release, otherwise as a draft
     const newTranslationDocumentId = uuid()
+    const sourceReleaseId = isVersionId(source._id) ? getVersionFromId(source._id) : undefined
     let newTranslationDocument = {
       ...source,
-      _id: `drafts.${newTranslationDocumentId}`,
+      _id: sourceReleaseId
+        ? getVersionId(newTranslationDocumentId, sourceReleaseId)
+        : getDraftId(newTranslationDocumentId),
       // 2. Update language of the translation
       [languageField]: language.id,
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When working inside a release ("Create a release and switch to it → create a doc → try to create a language variant"), the **Translations** button was greyed out, so no language copy could be created.

The menu resolved its source document as `draft || published` from `useEditState`. A document that only exists inside a release is a *version* document, so both were `null` and the button was disabled.

## Fix

- `DocumentInternationalizationMenu` now subscribes to the selected release via `usePerspective()` and passes `selectedReleaseId` to `useEditState`, preferring the version document as the source (`version || draft || published`), matching how core Studio resolves the displayed document.
- `LanguageOption` now creates the new language copy **in the same release** when the source is a version document (`versions.<releaseId>.<id>`), and as a draft otherwise — mirroring core Studio's duplicate behavior.

## Testing

- Added unit tests covering the release scenario (menu enabled from a version-only document, translation created with a `versions.<releaseId>.*` ID).
- Manually verified end-to-end in the test studio with a release.
- `pnpm format`, `pnpm lint`, `pnpm build`, `pnpm test run` all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cc81b99-18eb-4a55-b3b4-c07848036d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cc81b99-18eb-4a55-b3b4-c07848036d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

