### PR TITLE
Upgrade oxlint-tsgolint to ^0.24.0 and fix new lint findings

### DIFF
--- a/.changeset/tsgolint-024-asset-source-unsplash.md
+++ b/.changeset/tsgolint-024-asset-source-unsplash.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-asset-source-unsplash": patch
+---
+
+Document intentional use of the asset source `title` property (internal change only)

--- a/.changeset/tsgolint-024-assist.md
+++ b/.changeset/tsgolint-024-assist.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Remove type assertions made redundant by improved type inference (internal refactor, no API change)

--- a/.changeset/tsgolint-024-cloudinary.md
+++ b/.changeset/tsgolint-024-cloudinary.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-cloudinary": patch
+---
+
+Document intentional use of the asset source `title` property (internal change only)

--- a/.changeset/tsgolint-024-dashboard.md
+++ b/.changeset/tsgolint-024-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@sanity/dashboard": patch
+---
+
+Remove a redundant type assertion in the tutorials widget (internal refactor, no API change)

--- a/.changeset/tsgolint-024-document-internationalization.md
+++ b/.changeset/tsgolint-024-document-internationalization.md
@@ -1,0 +1,5 @@
+---
+"@sanity/document-internationalization": patch
+---
+
+Remove redundant `ButtonTone` type assertions in delete actions (internal refactor, no API change)

--- a/.changeset/tsgolint-024-iframe-pane.md
+++ b/.changeset/tsgolint-024-iframe-pane.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-iframe-pane": patch
+---
+
+Use the `previewMode` option instead of the deprecated `draftMode` option when resolving preview URLs with `@sanity/preview-url-secret` (no behavior change)

--- a/.changeset/tsgolint-024-media.md
+++ b/.changeset/tsgolint-024-media.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Replace redundant type assertions with `satisfies` checks and return type annotations (internal refactor, no API change)

--- a/.changeset/tsgolint-024-mux-input.md
+++ b/.changeset/tsgolint-024-mux-input.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-mux-input": patch
+---
+
+Remove redundant type assertions in the uploader components (internal refactor, no API change)

--- a/.changeset/tsgolint-024-naive-html-serializer.md
+++ b/.changeset/tsgolint-024-naive-html-serializer.md
@@ -1,0 +1,5 @@
+---
+"sanity-naive-html-serializer": patch
+---
+
+Remove redundant type assertions in block deserialization (internal refactor, no API change)

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -226,10 +226,12 @@
       }
     },
     {
-      // XState v5's canonical typing pattern relies on `{} as Context` style assertions
+      // XState v5's canonical typing pattern relies on `{} as Context` style assertions,
+      // which drive the machine's generic type inference and are never truly unnecessary
       "files": ["plugins/sanity-plugin-dashboard-widget-vercel/src/machines/*.ts"],
       "rules": {
-        "no-unsafe-type-assertion": "off"
+        "no-unsafe-type-assertion": "off",
+        "no-unnecessary-type-assertion": "off"
       }
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,13 @@ pnpm format
 # 2. Run linters (oxlint)
 pnpm lint
 
-# 3. Build all packages
+# 3. Check for unused files, dependencies and exports (knip)
+pnpm knip
+
+# 4. Build all packages
 pnpm build
 
-# 4. Run tests
+# 5. Run tests
 pnpm test
 ```
 
@@ -194,7 +197,10 @@ The CI pipeline runs on every PR:
 | --------- | ------------------------------------------------------ |
 | **build** | `pnpm build` - All packages compile successfully       |
 | **lint**  | `pnpm lint --format github` - Code passes oxlint       |
+| **knip**  | `pnpm knip` - No unused files, dependencies or exports |
 | **test**  | `pnpm test` - All tests pass (runs after build + lint) |
+
+Note on **knip**: in-file usage keeps an exported type "used" (`ignoreExportsUsedInFile`), so removing a type assertion or annotation that was the last reference to an exported type will make knip start flagging that export. Run `pnpm knip` after refactors that remove type references.
 
 ### Lint Specifics
 

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -28,7 +28,6 @@ export default defineCliConfig({
       return tsRE.test(filename)
     },
   },
-  studioHost: 'plugins',
   typegen: {formatGeneratedCode: false},
   vite: {
     plugins: [vanillaExtractPlugin(), ...(isViteDevToolsEnabled ? [DevTools()] : [])],

--- a/dev/test-studio/src/orderable-document-list/index.tsx
+++ b/dev/test-studio/src/orderable-document-list/index.tsx
@@ -14,13 +14,7 @@ function orderableDeskItem(
   S: StructureBuilder,
   context: ConfigContext,
 ): StructureListItem {
-  /* oxlint-disable no-unsafe-type-assertion -- workspace packages can resolve duplicate sanity instances under pnpm */
-  return orderableDocumentListDeskItem({
-    ...config,
-    S: S as unknown as OrderableListConfig['S'],
-    context: context as unknown as OrderableListConfig['context'],
-  }) as unknown as StructureListItem
-  /* oxlint-enable no-unsafe-type-assertion */
+  return orderableDocumentListDeskItem({...config, S, context})
 }
 
 const orderableCategory = defineType({

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "^16.4.0",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
-    "oxlint-tsgolint": "^0.23.0",
+    "oxlint-tsgolint": "^0.24.0",
     "setup-npm-trusted-publish": "^1.3.1",
     "turbo": "2.10.0",
     "typescript": "catalog:",

--- a/plugins/@sanity/assist/src/assistDocument/components/instruction/InstructionOutputInput.tsx
+++ b/plugins/@sanity/assist/src/assistDocument/components/instruction/InstructionOutputInput.tsx
@@ -110,8 +110,7 @@ function ObjectOutputInput({
             <Selectable
               value={field.name}
               title={field.type.title ?? field.name}
-              // oxlint-disable-next-line no-unsafe-type-assertion
-              arrayValue={value as OutputFieldItem[]}
+              arrayValue={value}
               onChange={onSelectChange}
             />
           </Flex>
@@ -172,8 +171,7 @@ function ArrayOutputInput({
             <Selectable
               value={itemType.name}
               title={isType(itemType, 'block') ? 'Text' : (itemType.title ?? itemType.name)}
-              // oxlint-disable-next-line no-unsafe-type-assertion
-              arrayValue={value as OutputTypeItem[] | undefined}
+              arrayValue={value}
               onChange={onSelectChange}
             />
           </Flex>

--- a/plugins/@sanity/assist/src/assistFormComponents/AssistField.tsx
+++ b/plugins/@sanity/assist/src/assistFormComponents/AssistField.tsx
@@ -57,6 +57,7 @@ function AssistField(props: FieldProps) {
     actions: props.actions,
 
     // Render presence in the internal slot (between presence and the field actions)
+    // oxlint-disable-next-line no-deprecated -- the slot is deprecated for external use but exists specifically for this plugin
     __internal_slot: actions,
   })
 }

--- a/plugins/@sanity/assist/src/assistInspector/helpers.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.ts
@@ -211,8 +211,5 @@ export type AiPaneRouter = Omit<PaneRouterContextValue, 'setParams' | 'params'> 
 export function useAiPaneRouter() {
   const paneRouter = usePaneRouter()
 
-  return useMemo(
-    () => ({...paneRouter, params: paneRouter.params ?? {}}) as AiPaneRouter,
-    [paneRouter],
-  )
+  return useMemo(() => ({...paneRouter, params: paneRouter.params ?? {}}), [paneRouter])
 }

--- a/plugins/@sanity/assist/src/assistInspector/helpers.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.ts
@@ -208,7 +208,7 @@ export type AiPaneRouter = Omit<PaneRouterContextValue, 'setParams' | 'params'> 
   setParams: (p: Record<keyof AssistInspectorRouteParams, string | undefined>) => void
 }
 
-export function useAiPaneRouter() {
+export function useAiPaneRouter(): AiPaneRouter {
   const paneRouter = usePaneRouter()
 
   return useMemo(() => ({...paneRouter, params: paneRouter.params ?? {}}), [paneRouter])

--- a/plugins/@sanity/assist/src/schemas/serialize/serializeSchema.test.ts
+++ b/plugins/@sanity/assist/src/schemas/serialize/serializeSchema.test.ts
@@ -157,7 +157,6 @@ describe('serializeSchema', () => {
               name: 'crossDatasetReference',
               to: [{type: 'excluded'}],
               dataset: 'x',
-              projectId: 'y',
             }),
           ],
         },

--- a/plugins/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.tsx
+++ b/plugins/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.tsx
@@ -2,7 +2,7 @@ import {Flex} from '@sanity/ui'
 import {useEffect, useState} from 'react'
 
 import {DashboardWidgetContainer} from '../../components/DashboardWidgetContainer'
-import {type FeedItem, type Guide, useDataAdapter} from './dataAdapter'
+import {type FeedItem, useDataAdapter} from './dataAdapter'
 import {Tutorial} from './Tutorial'
 
 function createUrl(slug: {current: string}, type?: string) {
@@ -44,7 +44,7 @@ export function SanityTutorials(props: SanityTutorialsProps) {
           }
           const presenter = feedItem.presenter || feedItem.guideOrTutorial?.presenter || {}
           const subtitle = feedItem.category
-          const {guideOrTutorial = {} as Guide} = feedItem
+          const {guideOrTutorial = {}} = feedItem
           const href =
             (guideOrTutorial.slug
               ? createUrl(guideOrTutorial.slug, guideOrTutorial._type)

--- a/plugins/@sanity/document-internationalization/src/actions/DeleteMetadataAction.tsx
+++ b/plugins/@sanity/document-internationalization/src/actions/DeleteMetadataAction.tsx
@@ -1,5 +1,5 @@
 import {TrashIcon} from '@sanity/icons/Trash'
-import {type ButtonTone, useToast} from '@sanity/ui'
+import {useToast} from '@sanity/ui'
 import {useCallback, useMemo, useState} from 'react'
 import {
   type DocumentActionDescription,
@@ -82,7 +82,7 @@ export const useDeleteMetadataAction = (props: DocumentActionProps): DocumentAct
     label: `Delete all translations`,
     disabled: !doc || !translations.length,
     icon: TrashIcon,
-    tone: 'critical' as ButtonTone,
+    tone: 'critical',
     onHandle: () => {
       setDialogOpen(true)
     },
@@ -93,7 +93,7 @@ export const useDeleteMetadataAction = (props: DocumentActionProps): DocumentAct
         onProceed()
         onClose()
       },
-      tone: 'critical' as ButtonTone,
+      tone: 'critical',
       message:
         translations.length === 1
           ? `Delete 1 translation and this document`

--- a/plugins/@sanity/document-internationalization/src/actions/DeleteTranslationAction.tsx
+++ b/plugins/@sanity/document-internationalization/src/actions/DeleteTranslationAction.tsx
@@ -1,5 +1,5 @@
 import {TrashIcon} from '@sanity/icons/Trash'
-import {type ButtonTone, useToast} from '@sanity/ui'
+import {useToast} from '@sanity/ui'
 import {useCallback, useState} from 'react'
 import {useClient, type DocumentActionDescription, type DocumentActionProps} from 'sanity'
 import {LANGUAGE_FIELD_NAME} from 'sanity-plugin-internationalized-array'
@@ -94,7 +94,7 @@ export const useDeleteTranslationAction = (
     label: `Delete translation...`,
     disabled: !doc || !documentLanguage,
     icon: TrashIcon,
-    tone: 'critical' as ButtonTone,
+    tone: 'critical',
     onHandle: () => {
       setDialogOpen(true)
     },

--- a/plugins/@sanity/language-filter/src/filterField.test.ts
+++ b/plugins/@sanity/language-filter/src/filterField.test.ts
@@ -9,12 +9,10 @@ describe('filterField', () => {
       name: 'some-doc',
       jsonType: 'object',
       fields: [],
-      __experimental_search: [],
       type: {
         name: 'document',
         jsonType: 'object',
         fields: [],
-        __experimental_search: [],
       },
     }
     it('should be enabled when documentTypes is missing', () => {
@@ -52,7 +50,6 @@ describe('filterField', () => {
       name: 'locale_parent',
       jsonType: 'object',
       fields: [],
-      __experimental_search: [],
     }
     const member: FieldMember = {
       name: 'nb',

--- a/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
+++ b/plugins/@sanity/presets/src/presets/rich-text-type/rich-text-type.test.ts
@@ -33,8 +33,7 @@ function getOf(typeDef: SchemaTypeDefinition): Member[] {
   if (!('of' in typeDef) || !typeDef.of) {
     throw new Error('Expected an array type definition with an of array')
   }
-  // oxlint-disable-next-line no-unsafe-type-assertion -- test helper narrows to stub shape
-  return typeDef.of as unknown as Member[]
+  return typeDef.of
 }
 
 function getBlock(typeDef: SchemaTypeDefinition): BlockMember {
@@ -42,8 +41,7 @@ function getBlock(typeDef: SchemaTypeDefinition): BlockMember {
   if (!block) {
     throw new Error('Expected a block member in the array')
   }
-  // oxlint-disable-next-line no-unsafe-type-assertion -- test helper narrows to stub shape
-  return block as unknown as BlockMember
+  return block
 }
 
 describe('richTextType', () => {

--- a/plugins/sanity-naive-html-serializer/src/BaseSerializationConfig.ts
+++ b/plugins/sanity-naive-html-serializer/src/BaseSerializationConfig.ts
@@ -133,11 +133,11 @@ export const customBlockDeserializers: Array<any> = [
             ...block,
             ...newBlock,
             style: customStyle ?? (newBlock as PortableTextTextBlock).style,
-          } as PortableTextTextBlock
+          }
 
           //next(childNodes) plays poorly with custom styles, issue to be filed.
           if (customStyle) {
-            return block as PortableTextTextBlock
+            return block
           }
         }
       }

--- a/plugins/sanity-plugin-asset-source-unsplash/src/index.ts
+++ b/plugins/sanity-plugin-asset-source-unsplash/src/index.ts
@@ -10,6 +10,7 @@ export type {Asset, AssetDocument, UnsplashPhoto} from './types'
  */
 export const unsplashAssetSource: AssetSource = {
   name: 'unsplash',
+  // oxlint-disable-next-line no-deprecated -- `i18nKey` requires a locale bundle; a plain title is intentional here
   title: 'Unsplash',
   component: UnsplashAssetSource,
   icon: UnsplashIcon,

--- a/plugins/sanity-plugin-cloudinary/src/index.ts
+++ b/plugins/sanity-plugin-cloudinary/src/index.ts
@@ -50,6 +50,7 @@ export const cloudinarySchemaPlugin = definePlugin({
 
 export const cloudinaryImageSource: AssetSource = {
   name: 'cloudinary-image',
+  // oxlint-disable-next-line no-deprecated -- `i18nKey` requires a locale bundle; a plain title is intentional here
   title: 'Cloudinary',
   icon: CloudinaryIcon,
   component: CloudinaryAssetSource,

--- a/plugins/sanity-plugin-iframe-pane/src/Iframe.tsx
+++ b/plugins/sanity-plugin-iframe-pane/src/Iframe.tsx
@@ -159,7 +159,7 @@ export function Iframe(props: IframeProps): React.JSX.Element {
         const resolvePreviewUrl = definePreviewUrl({
           origin: urlProp.origin === 'same-origin' ? location.origin : urlProp.origin,
           preview,
-          draftMode: {
+          previewMode: {
             enable: urlProp.draftMode,
           },
         })

--- a/plugins/sanity-plugin-media/src/__tests__/fixtures/rootState.ts
+++ b/plugins/sanity-plugin-media/src/__tests__/fixtures/rootState.ts
@@ -23,5 +23,5 @@ export function createTestRootState(overrides: Partial<RootReducerState> = {}): 
     uploads: {allIds: [], byIds: {}},
   }
 
-  return {...base, ...overrides} as RootReducerState
+  return {...base, ...overrides}
 }

--- a/plugins/sanity-plugin-media/src/components/CardAsset/CardAsset.test.tsx
+++ b/plugins/sanity-plugin-media/src/components/CardAsset/CardAsset.test.tsx
@@ -20,12 +20,11 @@ function setShiftPressed(on: boolean) {
 }
 
 vi.mock('../../hooks/useKeyPress', () => ({
-  default: (): RefObject<boolean> =>
-    ({
-      get current() {
-        return Boolean((globalThis as unknown as Record<string, unknown>)[SHIFT_FLAG])
-      },
-    }) as RefObject<boolean>,
+  default: (): RefObject<boolean> => ({
+    get current() {
+      return Boolean((globalThis as unknown as Record<string, unknown>)[SHIFT_FLAG])
+    },
+  }),
 }))
 
 vi.mock('../Image', () => ({

--- a/plugins/sanity-plugin-media/src/modules/assets/reducer.test.ts
+++ b/plugins/sanity-plugin-media/src/modules/assets/reducer.test.ts
@@ -50,9 +50,12 @@ describe('assets slice', () => {
   })
 
   it('fetchComplete merges assets', () => {
-    let state = assetsReducer({...initialState, assetTypes: ['image'] as AssetType[]}, {
-      type: '@@INIT',
-    } as never)
+    let state = assetsReducer(
+      {...initialState, assetTypes: ['image'] as AssetType[]},
+      {
+        type: '@@INIT',
+      },
+    )
     state = assetsReducer(state, assetsActions.fetchComplete({assets: [minimalImage]}))
     expect(state.allIds).toContain('img-1')
     expect(state.fetching).toBe(false)

--- a/plugins/sanity-plugin-media/src/modules/notifications/epics.test.ts
+++ b/plugins/sanity-plugin-media/src/modules/notifications/epics.test.ts
@@ -285,7 +285,7 @@ describe('notificationsGenericErrorEpic', () => {
         fetchCount: -1,
         fetching: false,
         panelVisible: true,
-      } as any,
+      },
     })
     store.dispatch(
       tagsActions.createError({

--- a/plugins/sanity-plugin-media/src/modules/search/index.test.ts
+++ b/plugins/sanity-plugin-media/src/modules/search/index.test.ts
@@ -7,7 +7,7 @@ import searchReducer, {searchActions} from './index'
 
 describe('search slice', () => {
   it('facetsAdd assigns an id and appends facet', () => {
-    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    let state = searchReducer(undefined, {type: '@@INIT'})
     state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
     expect(state.facets).toHaveLength(1)
     expect(state.facets[0]!.name).toBe('title')
@@ -15,20 +15,20 @@ describe('search slice', () => {
   })
 
   it('querySet updates search string', () => {
-    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    let state = searchReducer(undefined, {type: '@@INIT'})
     state = searchReducer(state, searchActions.querySet({searchQuery: 'cats'}))
     expect(state.query).toBe('cats')
   })
 
   it('facetsClear removes all facets', () => {
-    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    let state = searchReducer(undefined, {type: '@@INIT'})
     state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
     state = searchReducer(state, searchActions.facetsClear())
     expect(state.facets).toHaveLength(0)
   })
 
   it('facetsRemoveByName filters facets', () => {
-    let state = searchReducer(undefined, {type: '@@INIT'} as never)
+    let state = searchReducer(undefined, {type: '@@INIT'})
     state = searchReducer(state, searchActions.facetsAdd({facet: {...inputs.title}}))
     state = searchReducer(state, searchActions.facetsRemoveByName({facetName: 'title'}))
     expect(state.facets).toHaveLength(0)

--- a/plugins/sanity-plugin-media/src/modules/selectors.ts
+++ b/plugins/sanity-plugin-media/src/modules/selectors.ts
@@ -9,8 +9,8 @@ export const selectCombinedItems = createSelector(
     (state: RootReducerState) => state.uploads.allIds,
   ],
   (assetIds, uploadIds) => {
-    const assetItems = assetIds.map((id) => ({id, type: 'asset'}) as CardAssetData)
-    const uploadItems = uploadIds.map((id) => ({id, type: 'upload'}) as CardUploadData)
+    const assetItems = assetIds.map((id): CardAssetData => ({id, type: 'asset'}))
+    const uploadItems = uploadIds.map((id): CardUploadData => ({id, type: 'upload'}))
     const combinedItems: (CardAssetData | CardUploadData)[] = [...uploadItems, ...assetItems]
     return combinedItems
   },

--- a/plugins/sanity-plugin-media/src/modules/tags/index.test.ts
+++ b/plugins/sanity-plugin-media/src/modules/tags/index.test.ts
@@ -16,7 +16,7 @@ const sampleTag: Tag = {
 
 describe('tags slice', () => {
   it('createComplete adds tag', () => {
-    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    let state = tagsReducer(undefined, {type: '@@INIT'})
     state = tagsReducer(state, tagsActions.createComplete({tag: sampleTag}))
     expect(state.allIds).toContain('tag-1')
     expect(state.byIds['tag-1']!.tag).toEqual(sampleTag)
@@ -24,7 +24,7 @@ describe('tags slice', () => {
   })
 
   it('deleteComplete removes tag', () => {
-    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    let state = tagsReducer(undefined, {type: '@@INIT'})
     state = tagsReducer(state, tagsActions.createComplete({tag: sampleTag}))
     state = tagsReducer(state, tagsActions.deleteComplete({tagId: 'tag-1'}))
     expect(state.allIds).not.toContain('tag-1')
@@ -32,7 +32,7 @@ describe('tags slice', () => {
   })
 
   it('fetchComplete hydrates tag list', () => {
-    let state = tagsReducer(undefined, {type: '@@INIT'} as never)
+    let state = tagsReducer(undefined, {type: '@@INIT'})
     state = tagsReducer(state, tagsActions.fetchRequest())
     expect(state.fetching).toBe(true)
     state = tagsReducer(state, tagsActions.fetchComplete({tags: [sampleTag]}))

--- a/plugins/sanity-plugin-media/src/modules/uploads/index.test.ts
+++ b/plugins/sanity-plugin-media/src/modules/uploads/index.test.ts
@@ -7,7 +7,7 @@ import uploadsReducer, {uploadsActions} from './index'
 
 describe('uploads slice', () => {
   it('uploadStart adds item to queue', () => {
-    let state = uploadsReducer(undefined, {type: '@@INIT'} as never)
+    let state = uploadsReducer(undefined, {type: '@@INIT'})
     const uploadItem = {
       _type: 'upload',
       assetType: 'image',
@@ -30,7 +30,7 @@ describe('uploads slice', () => {
   })
 
   it('uploadProgress updates percent and status', () => {
-    let state = uploadsReducer(undefined, {type: '@@INIT'} as never)
+    let state = uploadsReducer(undefined, {type: '@@INIT'})
     const uploadItem = {
       _type: 'upload',
       assetType: 'image',

--- a/plugins/sanity-plugin-media/src/operators/checkTagName.ts
+++ b/plugins/sanity-plugin-media/src/operators/checkTagName.ts
@@ -21,7 +21,7 @@ const checkTagName = (client: SanityClient, name: string) => {
           return throwError({
             message: 'Tag already exists',
             statusCode: 409,
-          } as HttpError)
+          } satisfies HttpError)
         }
 
         return of(true)

--- a/plugins/sanity-plugin-media/src/utils/imageDprUrl.test.ts
+++ b/plugins/sanity-plugin-media/src/utils/imageDprUrl.test.ts
@@ -37,7 +37,7 @@ describe('imageDprUrl', () => {
 
   it('uses multiplier 1 when devicePixelRatio is missing', () => {
     Object.defineProperty(window, 'devicePixelRatio', {
-      value: undefined as unknown as number,
+      value: undefined,
       configurable: true,
     })
     const url = imageDprUrl(asset, {width: 100})

--- a/plugins/sanity-plugin-media/src/utils/uploadSanityAsset.ts
+++ b/plugins/sanity-plugin-media/src/utils/uploadSanityAsset.ts
@@ -66,7 +66,7 @@ const uploadSanityAsset$ = (
         return throwError({
           message: 'Asset already exists',
           statusCode: 409,
-        } as HttpError)
+        } satisfies HttpError)
       }
 
       return of(null)

--- a/plugins/sanity-plugin-mux-input/src/components/UploadConfiguration.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/UploadConfiguration.tsx
@@ -530,7 +530,7 @@ function formatUploadConfig(
       inputs.push({
         url: config.watermark.imageUrl,
         overlay_settings: overlaySettings,
-      } as NonNullable<MuxNewAssetSettings['input']>[number])
+      })
     }
   }
 
@@ -546,9 +546,7 @@ function formatUploadConfig(
       video_quality: config.video_quality,
       normalize_audio: config.normalize_audio,
     },
-    watermark: config.watermark?.imageUrl
-      ? ({...config.watermark, enabled: true} as WatermarkConfig)
-      : undefined,
+    watermark: config.watermark?.imageUrl ? {...config.watermark, enabled: true} : undefined,
   }
 }
 

--- a/plugins/sanity-plugin-mux-input/src/components/Uploader.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/Uploader.tsx
@@ -87,7 +87,7 @@ export default function Uploader(props: Props) {
       const events$ = new Subject()
       return {
         observable: events$.asObservable(),
-        handleClick: ((event) => events$.next(event)) as React.MouseEventHandler<HTMLButtonElement>,
+        handleClick: (event: React.MouseEvent<HTMLButtonElement>) => events$.next(event),
       }
     })(),
   ).current

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,10 +201,10 @@ importers:
         version: 0.57.0
       oxlint:
         specifier: ^1.72.0
-        version: 1.72.0(oxlint-tsgolint@0.23.0)
+        version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       setup-npm-trusted-publish:
         specifier: ^1.3.1
         version: 1.3.1
@@ -5404,33 +5404,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
-    resolution: {integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==}
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
-    resolution: {integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==}
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
-    resolution: {integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==}
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
-    resolution: {integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==}
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    resolution: {integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
-    resolution: {integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==}
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
-    resolution: {integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==}
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    resolution: {integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==}
     cpu: [x64]
     os: [win32]
 
@@ -9881,8 +9881,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
-    resolution: {integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==}
+  oxlint-tsgolint@0.24.0:
+    resolution: {integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==}
     hasBin: true
 
   oxlint@1.72.0:
@@ -14395,22 +14395,22 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.57.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.23.0':
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.23.0':
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.23.0':
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.23.0':
+  '@oxlint-tsgolint/linux-x64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.23.0':
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.23.0':
+  '@oxlint-tsgolint/win32-x64@0.24.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
@@ -19585,16 +19585,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.57.0
       '@oxfmt/binding-win32-x64-msvc': 0.57.0
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.23.0
-      '@oxlint-tsgolint/darwin-x64': 0.23.0
-      '@oxlint-tsgolint/linux-arm64': 0.23.0
-      '@oxlint-tsgolint/linux-x64': 0.23.0
-      '@oxlint-tsgolint/win32-arm64': 0.23.0
-      '@oxlint-tsgolint/win32-x64': 0.23.0
+      '@oxlint-tsgolint/darwin-arm64': 0.24.0
+      '@oxlint-tsgolint/darwin-x64': 0.24.0
+      '@oxlint-tsgolint/linux-arm64': 0.24.0
+      '@oxlint-tsgolint/linux-x64': 0.24.0
+      '@oxlint-tsgolint/win32-arm64': 0.24.0
+      '@oxlint-tsgolint/win32-x64': 0.24.0
 
-  oxlint@1.72.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -19615,7 +19615,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.72.0
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
-      oxlint-tsgolint: 0.23.0
+      oxlint-tsgolint: 0.24.0
 
   p-any@3.0.0:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Upgrades `oxlint-tsgolint` from `^0.23.0` to `^0.24.0` ([release notes](https://github.com/oxc-project/tsgolint/releases/tag/v0.24.0)) and fixes the 45 new findings it reports, favoring real code fixes over blanket rule suppressions (unlike the config-only approach on the stale renovate PR #1465).

### What the new version detects

tsgolint 0.24.0 substantially improved `no-unnecessary-type-assertion` coverage (upstream test-parity work, e.g. oxc-project/tsgolint#998, #1001) and `no-deprecated` now reports contextual object literal properties (oxc-project/tsgolint#944).

### Fixes

**Unnecessary type assertions removed** (verified by type-aware lint + full build + tests):
- `@sanity/assist`: `InstructionOutputInput.tsx`, `helpers.ts` (plus now-unused `oxlint-disable no-unsafe-type-assertion` directives). In `helpers.ts` the removed `as AiPaneRouter` cast was the exported type's only reference, which tripped CI's knip job — fixed by declaring it as `useAiPaneRouter()`'s return type, preserving the narrowed `params` contract
- `@sanity/dashboard`: `SanityTutorials.tsx` (plus now-unused `Guide` import)
- `@sanity/document-internationalization`: `'critical' as ButtonTone` casts and the `ButtonTone` imports in both delete actions
- `sanity-naive-html-serializer`: `BaseSerializationConfig.ts`
- `sanity-plugin-media`: swapped object literal casts for `satisfies HttpError` checks and `(id): CardAssetData =>` return type annotations so type safety is kept without assertions; test files cleaned up
- `sanity-plugin-mux-input`: `UploadConfiguration.tsx`; `Uploader.tsx` types the `handleClick` parameter instead of casting the whole handler
- `@sanity/presets`, `dev/test-studio` (orderable-document-list): assertions plus their now-unused disable directives

**New `no-deprecated` findings fixed properly:**
- `sanity-plugin-iframe-pane`: passes `previewMode` instead of the deprecated `draftMode` option to `@sanity/preview-url-secret`'s `definePreviewUrl` (same shape, no behavior change; the plugin's own `url.draftMode` option is untouched)
- `dev/test-studio/sanity.cli.ts`: drops `studioHost: 'plugins'` — it is superseded by `deployment.appId` (sanity-io/sanity#10425), which this config already sets, and deploy/undeploy prefer `appId` when present
- `@sanity/language-filter` tests: drop `__experimental_search` (optional + "Unused" per its deprecation)
- `@sanity/assist` serialize test: drop deprecated `projectId` from the cross-dataset reference fixture (unused by the serializer)

**Intentional deprecated usage suppressed with justification:**
- `@sanity/assist` `AssistField.tsx`: `__internal_slot` is deprecated as "ONLY USED BY AI ASSIST PLUGIN" — this is that plugin
- `sanity-plugin-asset-source-unsplash` / `sanity-plugin-cloudinary`: `AssetSource.title` — `i18nKey` requires shipping a locale bundle; sanity core's own dataset asset sources still use `title` the same way

**Config / docs:**
- `.oxlintrc.json`: `no-unnecessary-type-assertion` off for the vercel dashboard widget's XState machines only — the `{} as Context` casts there drive `setup()` generic inference and removing them breaks the build (verified), so the rule's "receiver accepts the original type" heuristic is a false positive for this pattern
- `AGENTS.md`: documents the knip CI job (it was missing from the CI checks table and the pre-PR checklist), per the guide's self-improvement note

### Changesets

Patch changesets added for all 9 published plugins with `src/` changes. Test-only changes (`@sanity/language-filter`, `@sanity/presets`) follow the no-changeset precedent of #1355.

## Verification

- ✅ `pnpm format`
- ✅ `pnpm lint` (zero findings; was 45 errors after the bump)
- ✅ `pnpm knip` (zero findings; reproduced and fixed the CI failure locally)
- ✅ `pnpm build` (50/50 tasks)
- ✅ `pnpm test run` (167 files, 889 tests passed; assist project re-run after the knip fix: 5 files, 33 tests passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df9d691d-9d58-4b4c-8185-34dc6aa6ffa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df9d691d-9d58-4b4c-8185-34dc6aa6ffa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

