### PR TITLE
Add changesets for plugins affected by pkg-utils styled-components tree-shaking upgrade

### DIFF
--- a/.changeset/asset-source-unsplash-styled-components-treeshaking.md
+++ b/.changeset/asset-source-unsplash-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-asset-source-unsplash": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/assist-styled-components-treeshaking.md
+++ b/.changeset/assist-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/async-list-styled-components-treeshaking.md
+++ b/.changeset/async-list-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/sanity-plugin-async-list": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/cloudinary-styled-components-treeshaking.md
+++ b/.changeset/cloudinary-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-cloudinary": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/code-input-styled-components-treeshaking.md
+++ b/.changeset/code-input-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/code-input": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/color-input-styled-components-treeshaking.md
+++ b/.changeset/color-input-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/color-input": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/cross-dataset-duplicator-styled-components-treeshaking.md
+++ b/.changeset/cross-dataset-duplicator-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/cross-dataset-duplicator": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/dashboard-styled-components-treeshaking.md
+++ b/.changeset/dashboard-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/dashboard": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/dashboard-widget-netlify-styled-components-treeshaking.md
+++ b/.changeset/dashboard-widget-netlify-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-netlify": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/dashboard-widget-vercel-styled-components-treeshaking.md
+++ b/.changeset/dashboard-widget-vercel-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-vercel": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/debug-live-sync-tags-styled-components-treeshaking.md
+++ b/.changeset/debug-live-sync-tags-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/debug-live-sync-tags": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/documents-pane-styled-components-treeshaking.md
+++ b/.changeset/documents-pane-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-documents-pane": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/embeddings-index-ui-styled-components-treeshaking.md
+++ b/.changeset/embeddings-index-ui-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/embeddings-index-ui": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/google-translate-styled-components-treeshaking.md
+++ b/.changeset/google-translate-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-google-translate": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/graph-view-styled-components-treeshaking.md
+++ b/.changeset/graph-view-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-graph-view": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/hierarchical-document-list-styled-components-treeshaking.md
+++ b/.changeset/hierarchical-document-list-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/hierarchical-document-list": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/iframe-pane-styled-components-treeshaking.md
+++ b/.changeset/iframe-pane-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-iframe-pane": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/markdown-styled-components-treeshaking.md
+++ b/.changeset/markdown-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-markdown": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/media-styled-components-treeshaking.md
+++ b/.changeset/media-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/mux-input-styled-components-treeshaking.md
+++ b/.changeset/mux-input-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-mux-input": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/orderable-document-list-styled-components-treeshaking.md
+++ b/.changeset/orderable-document-list-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/orderable-document-list": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/sfcc-styled-components-treeshaking.md
+++ b/.changeset/sfcc-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"@sanity/sfcc": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/shopify-assets-styled-components-treeshaking.md
+++ b/.changeset/shopify-assets-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-shopify-assets": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/transifex-styled-components-treeshaking.md
+++ b/.changeset/transifex-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-transifex": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/translations-tab-styled-components-treeshaking.md
+++ b/.changeset/translations-tab-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-translations-tab": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/utils-styled-components-treeshaking.md
+++ b/.changeset/utils-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-utils": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/workflow-styled-components-treeshaking.md
+++ b/.changeset/workflow-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-workflow": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.

--- a/.changeset/workspace-home-styled-components-treeshaking.md
+++ b/.changeset/workspace-home-styled-components-treeshaking.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-workspace-home": patch
+---
+
+Upgrade `@sanity/pkg-utils` to `^10.9.0`, enabling tree-shaking of unused `styled-components` in the published bundle. Tagged template literals are now transpiled to plain call expressions during build, so bundlers can drop styled components this plugin exports but the app doesn't use, reducing bundle size.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds one changeset per plugin that sets `styledComponents: true` in its `package.config.ts`, related to #1478 (bump `@sanity/pkg-utils` `^10.8.2` → `^10.9.0`).

That upgrade enables `transpileTemplateLiterals` by default in the `babel.styledComponents` transform, so tagged template literals (`` styled.button`...` ``) are transpiled to plain call expressions (`styled.button([...])`). This lets bundlers tree-shake unused styled components out of published bundles, which they previously couldn't due to `/*#__PURE__*/` annotations being dropped from an unsupported position.

Affected plugins (found via `styledComponents: true` in `package.config.ts`):
- `sanity-plugin-media`
- `sanity-plugin-markdown`
- `sanity-plugin-iframe-pane`
- `sanity-plugin-graph-view`
- `@sanity/orderable-document-list`
- `@sanity/hierarchical-document-list`
- `sanity-translations-tab`
- `@sanity/embeddings-index-ui`
- `@sanity/assist`
- `sanity-plugin-workspace-home`
- `sanity-plugin-workflow`
- `sanity-plugin-utils`
- `sanity-plugin-documents-pane`
- `sanity-plugin-dashboard-widget-vercel`
- `sanity-plugin-transifex`
- `sanity-plugin-shopify-assets`
- `sanity-plugin-google-translate`
- `sanity-plugin-dashboard-widget-netlify`
- `sanity-plugin-cloudinary`
- `sanity-plugin-asset-source-unsplash`
- `sanity-plugin-mux-input`
- `@sanity/debug-live-sync-tags`
- `@sanity/dashboard`
- `@sanity/cross-dataset-duplicator`
- `@sanity/sfcc`
- `@sanity/sanity-plugin-async-list`
- `@sanity/color-input`
- `@sanity/code-input`

Each changeset is a `patch` bump, per changeset guidelines in `AGENTS.md`.

**Testing**
- Verified with `pnpm changeset status` that all 28 packages are correctly picked up for a patch bump.
- Ran `pnpm format` (oxfmt) — no changes to the new changeset files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61fbc2fb-97c7-4b18-ad39-6e57a57a8413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61fbc2fb-97c7-4b18-ad39-6e57a57a8413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

