### PR TITLE
fix(@sanity/assist): open icon picker reliably with lazy-loaded icons

### DIFF
--- a/.changeset/assist-icon-picker-open.md
+++ b/.changeset/assist-icon-picker-open.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Fix the instruction icon picker not opening on first click. The lazy-loaded icons from `@sanity/icons` v5 suspended the menu before it could render; each menu item now renders through the `Icon` component, which provides its own suspense fallback.

--- a/plugins/@sanity/assist/src/assistDocument/components/instruction/appearance/IconInput.tsx
+++ b/plugins/@sanity/assist/src/assistDocument/components/instruction/appearance/IconInput.tsx
@@ -1,6 +1,6 @@
 import {icons, Icon, type IconSymbol} from '@sanity/icons'
 import {Button, Menu, MenuButton, MenuItem} from '@sanity/ui'
-import {type ElementType, type ReactNode, useCallback, useId, useMemo} from 'react'
+import {useCallback, useId, useMemo} from 'react'
 import {set, type StringInputProps} from 'sanity'
 
 export function IconInput(props: StringInputProps) {
@@ -8,9 +8,9 @@ export function IconInput(props: StringInputProps) {
   const id = useId()
   const items = useMemo(
     () =>
-      Object.entries(icons).map(([key, icon]) => (
-        <IconItem key={key} iconKey={key} icon={icon} onChange={onChange} />
-      )),
+      Object.keys(icons)
+        .filter(isIconSymbol)
+        .map((key) => <IconItem key={key} iconKey={key} onChange={onChange} />),
     [onChange],
   )
 
@@ -35,17 +35,17 @@ export function IconInput(props: StringInputProps) {
 }
 
 function IconItem({
-  icon,
   iconKey: key,
   onChange,
 }: {
-  iconKey: string
-  // oxlint-disable-next-line no-redundant-type-constituents
-  icon: ElementType | ReactNode
+  iconKey: IconSymbol
   onChange: StringInputProps['onChange']
 }) {
   const onClick = useCallback(() => onChange(set(key)), [onChange, key])
-  return <MenuItem icon={icon} title={key} text={key} onClick={onClick} />
+  // `Icon` wraps the lazy-loaded icon in its own `Suspense` boundary. Rendering the raw
+  // lazy component from `icons` would suspend the whole menu (there is no boundary between
+  // it and the popover), which unmounts the menu and closes it before it can be seen.
+  return <MenuItem icon={<Icon symbol={key} />} title={key} text={key} onClick={onClick} />
 }
 
 export function getIcon(iconName?: string): IconSymbol {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

After the `@sanity/icons` v5 upgrade (lazy-loaded icons), clicking the sparkles icon button in the AI instruction editor failed to open the icon picker. `IconInput` passed the raw `lazy()` components from the `icons` map straight to each `MenuItem`, so opening the menu suspended all ~300 items at once. With no Suspense boundary between the items and the popover, the suspension escaped the menu, unmounting it before it could be shown. Once the icon chunks finished loading in the background, later clicks worked — which made the failure look intermittent.

### Fix

Render each menu item icon through the `Icon` component from `@sanity/icons`, which wraps the lazy icon in its own `Suspense` boundary with a same-size svg fallback. The menu now opens instantly on the first click, with icon glyphs streaming in as their chunks load. Same pattern already used for the button icon and field actions in the previous lazy-loading commit.

### Demo

[assist_icon_picker_single_click_open_and_select_heart.mp4](https://cursor.com/agents/bc-abc12a0a-d434-4a00-bf74-248409e2936b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_icon_picker_single_click_open_and_select_heart.mp4)

Single click opens the picker immediately after a fresh page load (cold icon cache); selecting "heart" closes the menu and updates the button.

[Bug reproduction: nothing happens on first click](https://cursor.com/agents/bc-abc12a0a-d434-4a00-bf74-248409e2936b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbug_repro_icon_picker_not_opening.webp)

Before the fix: first click does nothing (menu suspended and closed before paint).

### Testing

- Reproduced the bug in the test studio before the fix (first click after fresh load does nothing; works only after chunks load)
- Verified after the fix: menu opens on first click after fresh reload, stays open, icons render, selection works
- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm build`
- ✅ `pnpm test run` (167 files, 893 tests)

### Changeset

- `.changeset/assist-icon-picker-open.md` — patch for `@sanity/assist`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abc12a0a-d434-4a00-bf74-248409e2936b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abc12a0a-d434-4a00-bf74-248409e2936b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

