### PR TITLE
refactor: move debug-live-sync-tags to tsdown

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -251,7 +251,6 @@
     },
 
     "plugins/@sanity/debug-live-sync-tags": {
-      "entry": ["package.config.ts"],
       "project": ["src/**/*.{ts,tsx}"],
     },
 

--- a/plugins/@sanity/debug-live-sync-tags/package.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/package.config.ts
@@ -1,8 +1,0 @@
-import config from '@repo/package.config'
-import {defineConfig} from '@sanity/pkg-utils'
-
-export default defineConfig({
-  ...config,
-  babel: {reactCompiler: true, styledComponents: true},
-  reactCompilerOptions: {target: '19'},
-})

--- a/plugins/@sanity/debug-live-sync-tags/package.json
+++ b/plugins/@sanity/debug-live-sync-tags/package.json
@@ -23,11 +23,7 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "source": "./src/index.ts",
-      "development": "./src/index.ts",
-      "default": "./dist/index.js"
-    },
+    ".": "./src/index.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -37,7 +33,7 @@
     }
   },
   "scripts": {
-    "build": "pkg build --strict --check --clean",
+    "build": "tsdown",
     "prepack": "turbo run build"
   },
   "dependencies": {
@@ -45,18 +41,17 @@
     "@sanity/ui": "catalog:"
   },
   "devDependencies": {
-    "@repo/package.config": "workspace:*",
-    "@sanity/pkg-utils": "catalog:",
     "@sanity/tsconfig": "catalog:",
+    "@sanity/tsdown-config": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
-    "babel-plugin-styled-components": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "sanity": "catalog:",
-    "styled-components": "catalog:"
+    "styled-components": "catalog:",
+    "tsdown": "catalog:"
   },
   "peerDependencies": {
     "react": "^19.2",

--- a/plugins/@sanity/debug-live-sync-tags/tsconfig.json
+++ b/plugins/@sanity/debug-live-sync-tags/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": ["@sanity/tsconfig/strictest"],
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["dist", "node_modules"],
-  "compilerOptions": {
-    "customConditions": ["development"]
-  }
+  "exclude": ["dist", "node_modules"]
 }

--- a/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from '@sanity/tsdown-config'
+import type {UserConfig} from 'tsdown'
+
+export default defineConfig({
+  styledComponents: true,
+  reactCompiler: true,
+}) satisfies Promise<UserConfig>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,11 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     '@sanity/tsconfig':
-      specifier: ^2.1.0
-      version: 2.1.0
+      specifier: ^2.2.0
+      version: 2.2.0
+    '@sanity/tsdown-config':
+      specifier: ^0.10.0
+      version: 0.10.0
     '@sanity/ui':
       specifier: ^3.3.0
       version: 3.3.0
@@ -154,6 +157,9 @@ catalogs:
     suspend-react:
       specifier: ^0.1.3
       version: 0.1.3
+    tsdown:
+      specifier: ^0.22.3
+      version: 0.22.3
     typescript:
       specifier: 6.0.3
       version: 6.0.3
@@ -422,7 +428,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
 
   packages/@sanity/plugin-kit:
     dependencies:
@@ -495,7 +501,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/eslint':
         specifier: ^8.56.12
         version: 8.56.12
@@ -610,7 +616,7 @@ importers:
         version: 6.3.0(@types/react@19.2.17)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -704,7 +710,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -750,7 +756,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -811,7 +817,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -860,7 +866,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -895,15 +901,12 @@ importers:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
     devDependencies:
-      '@repo/package.config':
-        specifier: workspace:*
-        version: link:../../../packages/@repo/package.config
-      '@sanity/pkg-utils':
-        specifier: 'catalog:'
-        version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
+      '@sanity/tsdown-config':
+        specifier: 'catalog:'
+        version: 0.10.0(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.1.3)(rollup@4.62.2)(tsdown@0.22.3)(typescript@6.0.3)(vite@8.1.0)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -916,9 +919,6 @@ importers:
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
-      babel-plugin-styled-components:
-        specifier: 'catalog:'
-        version: 2.3.0(@babel/core@7.29.7)(@sanity/styled-components@6.1.24)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -928,6 +928,9 @@ importers:
       sanity:
         specifier: ^6.3.0
         version: 6.3.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.11)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.1.2)(@sanity/styled-components@6.1.24)(@types/node@24.13.2)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.3.4)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.8)(jiti@2.7.0)(node-fetch@2.7.0)(oxfmt@0.57.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.1.3)(terser@5.48.0)(typescript@6.0.3)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260421.2)(@vitejs/devtools@0.3.4)(oxc-resolver@11.21.3)(publint@0.3.21)(tsx@4.22.4)(typescript@6.0.3)
 
   plugins/@sanity/debug-preview-url-secret-plugin:
     dependencies:
@@ -949,7 +952,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -992,7 +995,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1053,7 +1056,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1108,7 +1111,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/mailchimp__mailchimp_marketing':
         specifier: ^3.0.22
         version: 3.0.22
@@ -1154,7 +1157,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/google.maps':
         specifier: ^3.65.2
         version: 3.65.2
@@ -1224,7 +1227,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1270,7 +1273,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1337,7 +1340,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1389,7 +1392,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1429,7 +1432,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1487,7 +1490,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1539,7 +1542,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -1585,7 +1588,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1634,7 +1637,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1689,7 +1692,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1738,7 +1741,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1787,7 +1790,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1830,7 +1833,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1876,7 +1879,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -1919,7 +1922,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -1971,7 +1974,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2017,7 +2020,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -2060,7 +2063,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2139,7 +2142,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/object-hash':
         specifier: ^3.0.6
         version: 3.0.6
@@ -2200,7 +2203,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/dlv':
         specifier: ^1.1.5
         version: 1.1.5
@@ -2243,7 +2246,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2301,7 +2304,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/deep-equal':
         specifier: ^1.0.4
         version: 1.0.4
@@ -2353,7 +2356,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -2411,7 +2414,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -2466,7 +2469,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -2518,7 +2521,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2561,7 +2564,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -2676,7 +2679,7 @@ importers:
         version: link:../../packages/@sanity/plugin-kit
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -2794,7 +2797,7 @@ importers:
         version: link:../../packages/@sanity/plugin-kit
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -2864,7 +2867,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2907,7 +2910,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2944,7 +2947,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -2999,7 +3002,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -3057,7 +3060,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -3100,7 +3103,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -3155,7 +3158,7 @@ importers:
         version: 10.9.0(@types/node@24.13.2)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@6.0.3)
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -3194,7 +3197,7 @@ importers:
     devDependencies:
       '@sanity/tsconfig':
         specifier: 'catalog:'
-        version: 2.1.0
+        version: 2.2.0
       '@turbo/gen':
         specifier: 2.10.0
         version: 2.10.0(@types/node@24.13.2)
@@ -6322,8 +6325,19 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@sanity/tsconfig@2.1.0':
-    resolution: {integrity: sha512-Cnz0EycMsfeILkxL/gYzzfPs511OzP3sjQxU4XkDtujdiFAc+bteMYXi4/SJ83m98cXLum63HbHDk+he6AbbIA==}
+  '@sanity/tsconfig@2.2.0':
+    resolution: {integrity: sha512-zJ7E4efYtQtxkW5o8st6iHCR3PARxfw1lYy9txW2tySR5oQAQbgfvL2MR2OPRokHILuA+L6DIuDtqnqtBfDSkw==}
+
+  '@sanity/tsdown-config@0.10.0':
+    resolution: {integrity: sha512-w6TE29kp+ZHW9LKhq2+RiyekBbO5r43fkNmLQVOkMTJFyWQ0Dz2TK6dTIIgjAsaQknbcYCBMLlmcmfj5KnB5VA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      babel-plugin-react-compiler: '*'
+      tsdown: 0.22.x
+      typescript: 5.8.x || 5.9.x || 6.0.x
+    peerDependenciesMeta:
+      babel-plugin-react-compiler:
+        optional: true
 
   '@sanity/types@6.3.0':
     resolution: {integrity: sha512-IMll1cRPr8DGHEwiOoYiGIvRCA4i0ug25V5tzrCBeWhvJPX9vr4vA7jTHf6dEzvSZW9q6Fo/0X/9aBS42IOrxQ==}
@@ -15503,7 +15517,30 @@ snapshots:
       '@actions/github': 9.1.1
       yaml: 2.9.0
 
-  '@sanity/tsconfig@2.1.0': {}
+  '@sanity/tsconfig@2.2.0': {}
+
+  '@sanity/tsdown-config@0.10.0(@babel/runtime@7.29.7)(babel-plugin-react-compiler@1.0.0)(rolldown@1.1.3)(rollup@4.62.2)(tsdown@0.22.3)(typescript@6.0.3)(vite@8.1.0)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0)
+      '@sanity/browserslist-config': 1.0.5
+      '@vanilla-extract/rollup-plugin': 1.5.3(babel-plugin-macros@3.1.0)(rollup@4.62.2)
+      '@vitejs/plugin-react': 6.0.3(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.0)
+      browserslist: 4.28.4
+      lightningcss: 1.32.0
+      publint: 0.3.21
+      tsdown: 0.22.3(@typescript/native-preview@7.0.0-dev.20260421.2)(@vitejs/devtools@0.3.4)(oxc-resolver@11.21.3)(publint@0.3.21)(tsx@4.22.4)(typescript@6.0.3)
+      typescript: 6.0.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - babel-plugin-macros
+      - rolldown
+      - rollup
+      - supports-color
+      - vite
 
   '@sanity/types@6.3.0(@types/react@19.2.17)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,8 @@ catalog:
   '@sanity/preview-url-secret': ^4.0.7
   '@sanity/schema': ^6.3.0
   '@sanity/telemetry': '^1.1.0'
-  '@sanity/tsconfig': ^2.1.0
+  '@sanity/tsconfig': ^2.2.0
+  '@sanity/tsdown-config': ^0.10.0
   '@sanity/ui': ^3.3.0
   '@sanity/util': ^6.3.0
   '@sanity/uuid': ^3.0.3
@@ -64,6 +65,7 @@ catalog:
   sanity: ^6.3.0
   styled-components: ^6.4.3
   suspend-react: ^0.1.3
+  tsdown: ^0.22.3
   typescript: 6.0.3
   validate-npm-package-name: ^8.0.0
   video.js: ^7.21.7


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build and export-map changes only; published artifacts still use `publishConfig` pointing at `dist`.
> 
> **Overview**
> **`@sanity/debug-live-sync-tags`** switches from **`@sanity/pkg-utils`** / **`package.config.ts`** to **`tsdown`** with **`@sanity/tsdown-config`** (styled-components + React Compiler preserved in **`tsdown.config.ts`**).
> 
> The package **`build`** script is now **`tsdown`**; **`package.json`** drops **`@repo/package.config`** and **`@sanity/pkg-utils`**, simplifies dev **`exports`** to **`./src/index.ts`**, and **`tsconfig`** no longer sets **`customConditions: ["development"]`**. **Knip** drops the **`package.config.ts`** entry for this plugin.
> 
> The workspace **catalog** adds **`tsdown`**, **`@sanity/tsdown-config`**, and bumps **`@sanity/tsconfig`** to **2.2.0** (lockfile updated repo-wide).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a31b025d51520e04b04c9239c890595accdcf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->