### PR TITLE
fix(@sanity/assist): render instruction preview icons from @sanity/icons v5

### DIFF
--- a/.changeset/assist-icons-v5-troubleshooting.md
+++ b/.changeset/assist-icons-v5-troubleshooting.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Fix a crash ("Element type is invalid … got: <Icon />") when rendering the instruction list for instructions with a custom icon. Since the `@sanity/icons` v5 migration the instruction preview received a rendered icon element but kept rendering it as a component; it now handles both. The README also gains a troubleshooting section for `MISSING_EXPORT` icon build errors, which come from code importing icons from the `@sanity/icons` package root — a pattern removed in v5 (this plugin already uses the per-icon export paths).

--- a/plugins/@sanity/assist/README.md
+++ b/plugins/@sanity/assist/README.md
@@ -5,6 +5,7 @@
 - [Table of contents](#table-of-contents)
 - [About Sanity AI Assist](#about-sanity-ai-assist)
 - [Installation](#installation)
+  - [Build errors about missing icon exports](#build-errors-about-missing-icon-exports)
 - [Setup](#setup)
   - [Add the plugin](#add-the-plugin)
   - [Enabling the AI Assist API](#enabling-the-ai-assist-api)
@@ -56,6 +57,30 @@ npm install @sanity/assist sanity@latest
 ```
 
 This plugin requires `sanity` version `3.26` or greater.
+
+### Build errors about missing icon exports
+
+This plugin depends on `@sanity/icons` v5, which [removed the per-icon exports from the package root](https://github.com/sanity-io/icons/releases/tag/v5.0.0): every icon now lives on its own export path. If `sanity build` or `sanity dev` fails with an error like
+
+```
+[MISSING_EXPORT] "CopyIcon" is not exported by "node_modules/@sanity/icons/dist/index.js"
+```
+
+the file referenced by the error still imports icons from the package root — usually the studio's own schema or structure code, or another dependency that has not been updated yet. Update those imports to the per-icon export paths:
+
+```diff
+- import {CopyIcon, ListIcon} from '@sanity/icons'
++ import {CopyIcon} from '@sanity/icons/Copy'
++ import {ListIcon} from '@sanity/icons/List'
+```
+
+Also make sure `@sanity/icons` is declared in the studio's own `package.json` when studio code imports it; which copy an undeclared import resolves to depends on package manager hoisting, and can change when installing or upgrading plugins.
+
+If you cannot update the importing code right away (for example when it lives in a third-party package), pin `@sanity/icons` to v4 in the studio's own `package.json` until it catches up — v4 supports both import styles:
+
+```sh
+npm install @sanity/icons@4
+```
 
 ## Setup
 

--- a/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
+++ b/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
@@ -5,6 +5,7 @@ import {LockIcon} from '@sanity/icons/Lock'
 import {SparklesIcon} from '@sanity/icons/Sparkles'
 import {ThListIcon} from '@sanity/icons/ThList'
 import {Box, Flex, Stack, Text, Tooltip} from '@sanity/ui'
+import {isValidElement} from 'react'
 import {defineArrayMember, defineField, defineType, type ObjectSchemaType} from 'sanity'
 
 import {AssistDocumentForm} from '../assistDocument/components/AssistDocumentForm'
@@ -267,16 +268,17 @@ export const instruction = defineType({
   components: {
     input: InstructionInput,
     preview: (props: any) => {
-      const Icon = props.icon
+      // `icon` from `prepare` is either a rendered element (<Icon symbol={...} />) or a
+      // component (the SparklesIcon fallback), so it cannot be rendered as <IconValue /> directly
+      const IconValue = props.icon
+      const icon = isValidElement(IconValue) ? IconValue : IconValue ? <IconValue /> : null
       return (
         <Flex gap={3} align="center" padding={2}>
-          {Icon && (
+          {icon ? (
             <Box flex="none">
-              <Text size={1}>
-                <Icon />
-              </Text>
+              <Text size={1}>{icon}</Text>
             </Box>
-          )}
+          ) : null}
 
           <Stack flex={1} gap={2}>
             <Text size={1} textOverflow="ellipsis" weight="medium">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1495

## Investigation

The issue reports that `@sanity/assist` still imports removed per-icon exports from the `@sanity/icons` root entrypoint, breaking `sanity build` after upgrading to `@sanity/icons@5.0.0`. That claim was verified against the published package and is outdated: `@sanity/assist` has used the v5 per-icon export paths since 6.1.5/6.1.6, and its only remaining root-entry imports (`Icon`, `icons`, `IconSymbol`) are exactly the "dynamic pieces" the v5 root entry is designed to expose.

Reproduction attempts of the reported scenario (Studio 6.3.0 + `@sanity/assist@6.1.9` + direct `@sanity/icons@5.0.0`) with clean npm, pnpm, and yarn-classic installs all **build successfully** — package managers give `sanity`/`@sanity/ui` their own nested icons v3 copies.

The reported `[MISSING_EXPORT] "CopyIcon" is not exported by "node_modules/@sanity/icons/dist/index.js"` failure reproduces when code *outside this plugin* still imports icons from the package root and that import resolves to a v5 copy:

- the studio's own schema/structure code using classic barrel imports (`import {CopyIcon, ListIcon} from '@sanity/icons'`) once icons v5 is hoisted to the app root — installing a plugin that depends on icons v5 can flip which copy wins the hoist, and an app-level `@sanity/icons@5.0.0` dependency (the issue's repro step 1) makes it definite;
- `overrides`/`resolutions` forcing a single icons v5 copy, which breaks `sanity`'s own barrel imports (fixed upstream on `sanity@main`, which is on `@sanity/icons@^5.0.0` with subpath imports).

The README now has a troubleshooting section for this failure mode with the two verified remediations (migrate the offending imports to per-icon paths, or pin `@sanity/icons@4` — which supports both import styles — until the importing code catches up).

## Bug found and fixed while verifying

Runtime verification in the test studio surfaced a real icons-v5 regression in the plugin: opening **Manage instructions** for a document whose instruction has a custom icon crashed the instruction list with:

> Element type is invalid: expected a string ... but got: `<Icon />`. Check the render method of `preview`.

Since the v5 lazy-map migration (#1485), the instruction schema's `prepare()` returns a **rendered element** (`<Icon symbol={...} />`) for custom icons, while the fallback stays a **component** (`SparklesIcon`) — but the custom preview component still rendered `props.icon` as a component. The preview now handles both shapes.

<img alt="Before: instruction list crashes with 'Element type is invalid ... got: <Icon />'" src="/opt/cursor/artifacts/before_instruction_list_icon_crash.webp" />

*Before: instruction list crashes when an instruction has a custom icon.*

[assist_icon_picker_and_instruction_list_icons_v5.mp4](https://cursor.com/agents/bc-019f37c4-881d-7bfb-8a65-676cae8cc284/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_icon_picker_and_instruction_list_icons_v5.mp4)

*After: icon picker opens with lazily loaded v5 icons, selecting "robot" works, and the instruction list renders the custom icon without crashing.*

[After: instruction list renders Test Instruction with robot icon, no error](https://cursor.com/agents/bc-019f37c4-881d-7bfb-8a65-676cae8cc284/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_instruction_list_with_custom_icon.webp)

## Changes

- `plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx`: instruction preview accepts both a rendered icon element and an icon component.
- `plugins/@sanity/assist/README.md`: troubleshooting section for `MISSING_EXPORT` icon build errors after `@sanity/icons` v5.
- `.changeset/assist-icons-v5-troubleshooting.md`: patch changeset for `@sanity/assist`.

## Testing

- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm knip`
- ✅ `pnpm build` (50 tasks, includes `sanity build` of the test studio, which uses assist + icons 5.0.0)
- ✅ `pnpm test run` (167 files, 893 tests)
- ✅ Manual: reproduced the pre-fix instruction-list crash in the test studio, then verified post-fix that the icon picker opens, icons render, selecting an icon works, and the instruction list renders custom icons (video above)
- ✅ Manual: `sanity build` of a standalone Studio 6.3.0 app with `@sanity/assist@6.1.9` + `@sanity/icons@5.0.0` on npm/pnpm/yarn (clean installs pass; the reported error only reproduces from non-plugin code importing icons from the package root, and both README remediations were verified)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f37c4-881d-7bfb-8a65-676cae8cc284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f37c4-881d-7bfb-8a65-676cae8cc284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

