### PR TITLE
test(test-studio): add repro case for orderable-document-list issue #1506

### DIFF
--- a/dev/test-studio/schema.json
+++ b/dev/test-studio/schema.json
@@ -4717,6 +4717,101 @@
     }
   },
   {
+    "name": "issue1506TeamMember",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "issue1506TeamMember"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "orderRank": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "issue1506Page",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "issue1506Page"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "orderableProject",
     "type": "document",
     "attributes": {

--- a/dev/test-studio/src/home/index.tsx
+++ b/dev/test-studio/src/home/index.tsx
@@ -3,7 +3,7 @@ import type {DefaultDocumentNodeResolver, StructureResolver} from 'sanity/struct
 import {documentsPaneDefaultDocumentNode} from '#documents-pane'
 import {hierarchicalDocumentListDeskItems} from '#hierarchical-document-list'
 import {iframePaneDefaultDocumentNode} from '#iframe-pane'
-import {orderableDocumentListDeskItems} from '#orderable-document-list'
+import {issue1506ReproList, orderableDocumentListDeskItems} from '#orderable-document-list'
 import {sanityNaiveHtmlSerializerDefaultDocumentNode} from '#sanity-naive-html-serializer'
 import {smartlingDefaultDocumentNode} from '#smartling'
 import {transifexDefaultDocumentNode} from '#transifex'
@@ -66,6 +66,11 @@ const MISC_NAMED_TYPES = [
   'media.tag', // sanity-plugin-media (Media Tag)
 ]
 
+const ISSUE_REPRO_TYPES = [
+  'issue1506Page', // @sanity/orderable-document-list (#1506)
+  'issue1506TeamMember', // @sanity/orderable-document-list (#1506)
+]
+
 // Surfaced through the "Document list builders" folder via desk-item helpers,
 // so they should not also appear in the catch-all.
 const DESK_BUILDER_TYPES = [
@@ -99,6 +104,7 @@ export const homeStructure: StructureResolver = (S, context) => {
     ...CUSTOM_PANE_TYPES,
     ...INTERNATIONALIZATION_TYPES,
     ...MISC_NAMED_TYPES,
+    ...ISSUE_REPRO_TYPES,
     ...DESK_BUILDER_TYPES,
   ])
 
@@ -110,6 +116,10 @@ export const homeStructure: StructureResolver = (S, context) => {
   return S.list()
     .title('Content')
     .items([
+      S.listItem()
+        .id('issue-1506-repro')
+        .title('Issue #1506 repro (orderable intent hijack)')
+        .child(issue1506ReproList(S, context)),
       S.divider().title('Plugins'),
       folder('input-plugins', 'Input plugins', INPUT_PLUGIN_TYPES),
       folder('asset-source-plugins', 'Asset source plugins', ASSET_SOURCE_TYPES),

--- a/dev/test-studio/src/orderable-document-list/REPRO.md
+++ b/dev/test-studio/src/orderable-document-list/REPRO.md
@@ -1,0 +1,90 @@
+# Reproducing issue #1506 in the test-studio
+
+Tracking: https://github.com/sanity-io/plugins/issues/1506
+
+## Summary
+
+`orderableDocumentListDeskItem()` sets a `canHandleIntent` callback that returns
+`true` for **every** create/edit intent regardless of `params.type`. When an
+orderable list for type `X` sits in the same structure as other creatable types,
+creating a document of any other type gets routed into the orderable list.
+
+The regressing line is in
+`plugins/@sanity/orderable-document-list/src/desk-structure/orderableDocumentListDeskItem.ts`:
+
+```ts
+.canHandleIntent(() => createIntent !== false)
+```
+
+Because `createIntent` defaults to `undefined`, `createIntent !== false` is
+always `true`, and the arity-0 callback ignores `params.type`.
+
+## End-to-end repro in the dev test-studio
+
+### 1. Schema and structure
+
+Two document types are defined in
+`dev/test-studio/src/orderable-document-list/issue-1506-repro.ts`:
+
+- `issue1506Page` — a regular document type
+- `issue1506TeamMember` — an orderable document type (with `orderRankField`)
+
+The `home` workspace structure includes a dedicated **Issue #1506 repro**
+section that mirrors the issue report:
+
+```ts
+S.list().items([
+  S.documentTypeListItem('issue1506Page').title('Pages'),
+  orderableDocumentListDeskItem({
+    type: 'issue1506TeamMember',
+    title: 'Team Members (orderable)',
+    S,
+    context,
+  }),
+])
+```
+
+### 2. Run the test-studio
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Open the studio at `http://localhost:3333/home` (authenticate if prompted).
+
+### 3. Observe the bug
+
+1. In the Structure tool sidebar, open **Issue #1506 repro (orderable intent hijack)**.
+2. Click the global **Create** button (or use **Create new document** from the
+   command palette / navbar).
+3. Choose **Issue #1506 Page** (the non-orderable type).
+
+**Buggy behavior:** Studio opens the new page document inside the **Team Members
+(orderable)** list view instead of the **Pages** list.
+
+**Expected behavior:** The new `issue1506Page` document should open in (or
+resolve to) the **Pages** list. The orderable list for `issue1506TeamMember`
+should only handle intents where `params.type === 'issue1506TeamMember'`.
+
+### 4. Additional checks
+
+- Creating **Issue #1506 Team Member** from the global create menu correctly
+  lands in the orderable list (this path works even with the bug).
+- With multiple orderable lists at the same structure level, the intent resolves
+  to whichever orderable list is closest to the structure root.
+
+## Suggested fix
+
+Make the callback type-aware while keeping the `createIntent` opt-out:
+
+```ts
+.canHandleIntent(
+  (intentName, params) => createIntent !== false && params?.type === type,
+)
+```
+
+After applying the fix, repeat step 3 — creating a Page should no longer be
+captured by the Team Members orderable list.

--- a/dev/test-studio/src/orderable-document-list/index.tsx
+++ b/dev/test-studio/src/orderable-document-list/index.tsx
@@ -7,6 +7,8 @@ import {
 import {definePlugin, defineType, type ConfigContext} from 'sanity'
 import type {StructureBuilder} from 'sanity/structure'
 
+import {issue1506Page, issue1506TeamMember} from './issue-1506-repro'
+
 type StructureListItem = Parameters<ReturnType<StructureBuilder['list']>['items']>[0][number]
 
 function orderableDeskItem(
@@ -53,7 +55,7 @@ const orderableProject = defineType({
 })
 
 export const orderableDocumentListExample = definePlugin(() => ({
-  schema: {types: [orderableCategory, orderableProject]},
+  schema: {types: [orderableCategory, orderableProject, issue1506Page, issue1506TeamMember]},
 }))
 
 // Desk items for the orderable-document-list plugin, composed into the home
@@ -66,4 +68,22 @@ export function orderableDocumentListDeskItems(
     orderableDeskItem({type: 'orderableCategory', title: 'Categories'}, S, context),
     orderableDeskItem({type: 'orderableProject', title: 'Projects'}, S, context),
   ]
+}
+
+/**
+ * Structure for https://github.com/sanity-io/plugins/issues/1506 — a regular
+ * document list alongside an orderable list at the same level. See REPRO.md.
+ */
+export function issue1506ReproList(S: StructureBuilder, context: ConfigContext) {
+  return S.list()
+    .title('Issue #1506 repro')
+    .items([
+      S.documentTypeListItem('issue1506Page').title('Pages'),
+      orderableDocumentListDeskItem({
+        type: 'issue1506TeamMember',
+        title: 'Team Members (orderable)',
+        S,
+        context,
+      }),
+    ])
 }

--- a/dev/test-studio/src/orderable-document-list/issue-1506-repro.ts
+++ b/dev/test-studio/src/orderable-document-list/issue-1506-repro.ts
@@ -1,0 +1,40 @@
+import {orderRankField, orderRankOrdering} from '@sanity/orderable-document-list'
+import {defineField, defineType} from 'sanity'
+
+/**
+ * Document types used to reproduce
+ * https://github.com/sanity-io/plugins/issues/1506
+ *
+ * The bug: `orderableDocumentListDeskItem()` sets a `canHandleIntent` that
+ * returns true for every create/edit intent regardless of `params.type`. When
+ * a regular document type list sits alongside an orderable list in the same
+ * structure, creating a document of the non-orderable type gets routed into
+ * the orderable list instead.
+ */
+export const issue1506Page = defineType({
+  name: 'issue1506Page',
+  title: 'Issue #1506 Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+    }),
+  ],
+})
+
+export const issue1506TeamMember = defineType({
+  name: 'issue1506TeamMember',
+  title: 'Issue #1506 Team Member',
+  type: 'document',
+  orderings: [orderRankOrdering],
+  fields: [
+    orderRankField({type: 'issue1506TeamMember'}),
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+    }),
+  ],
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a manual reproduction case in the dev test-studio for https://github.com/sanity-io/plugins/issues/1506.

## What

- **`issue1506Page`** and **`issue1506TeamMember`** schema types with `orderRankField` on the team member type
- A dedicated **Issue #1506 repro (orderable intent hijack)** section in the `home` workspace structure that mirrors the issue report: a regular `documentTypeListItem` alongside an `orderableDocumentListDeskItem` at the same level
- **`REPRO.md`** with step-by-step verification instructions

## How to verify

```bash
pnpm install
pnpm dev
```

1. Open `http://localhost:3333/home`
2. In the Structure sidebar, open **Issue #1506 repro (orderable intent hijack)**
3. Click the global **Create** button and choose **Issue #1506 Page**
4. **Bug:** the new page opens inside the **Team Members (orderable)** list instead of **Pages**

See `dev/test-studio/src/orderable-document-list/REPRO.md` for full details.

## Notes

- No plugin code changes — this is repro-only scaffolding for issue #1506 / fix PR #1507
- No changeset required (test-studio is private dev tooling)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-143f4dd9-1064-4d2d-ae1f-756af60bbf83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-143f4dd9-1064-4d2d-ae1f-756af60bbf83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

