### PR TITLE
chore: disable automatic issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -3,8 +3,6 @@ name: Issue Triage
 on:
   issues:
     types:
-      - closed
-      - opened
       - labeled
   workflow_dispatch:
     inputs:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -3,7 +3,7 @@ name: Issue Triage
 on:
   issues:
     types:
-      - labeled
+      - closed
   workflow_dispatch:
     inputs:
       issue_url:


### PR DESCRIPTION
### Description
Disabling automatic invocations of the issue triage, we can invoque it from the actions panel by providing the url.
Keeping the `close` so it automatically closes the thread when the issue is resolved.


<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->


