### PR TITLE
feat!: support TypeScript 7 in plugin-kit, require typescript 6.x || 7.x

### DIFF
--- a/.changeset/plugin-kit-typescript-7-support.md
+++ b/.changeset/plugin-kit-typescript-7-support.md
@@ -1,0 +1,9 @@
+---
+"@sanity/plugin-kit": major
+---
+
+feat: support TypeScript 7 (the Go-native compiler), require TypeScript 6 or later
+
+**BREAKING**: the `typescript` peer dependency range is now `6.x || 7.x` — TypeScript 5.x is no longer supported. TypeScript 7 is not required yet, but 6.0 is the new minimum.
+
+The JS compiler API (used by `verify-package` and `verify-studio` to parse `tsconfig.json`) is now always loaded from the official [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6) compat package (a regular dependency), since TypeScript 7 no longer ships it. The installed `typescript` peer no longer affects tsconfig parsing and is only used to run `tsc --build`.

--- a/.changeset/plugin-kit-typescript-7-support.md
+++ b/.changeset/plugin-kit-typescript-7-support.md
@@ -7,3 +7,5 @@ feat: support TypeScript 7 (the Go-native compiler), require TypeScript 6 or lat
 **BREAKING**: the `typescript` peer dependency range is now `6.x || 7.x` — TypeScript 5.x is no longer supported. TypeScript 7 is not required yet, but 6.0 is the new minimum.
 
 The JS compiler API (used by `verify-package` and `verify-studio` to parse `tsconfig.json`) is now always loaded from the official [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6) compat package (a regular dependency), since TypeScript 7 no longer ships it. The installed `typescript` peer no longer affects tsconfig parsing and is only used to run `tsc --build`.
+
+`plugin-kit init` now scaffolds `typescript` at the latest 6.x instead of `latest`. This fixes scaffolding, which broke when TypeScript 7 became `latest` on npm: the scaffolded ESLint toolchain (`@typescript-eslint` v8) declares a `typescript` peer range that excludes 7.x, so the initial `npm install` failed with a peer dependency conflict.

--- a/packages/@sanity/plugin-kit/package.json
+++ b/packages/@sanity/plugin-kit/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@rexxars/choosealicense-list": "^1.1.2",
+    "@typescript/typescript6": "^6.0.2",
     "chalk": "^4.1.2",
     "concurrently": "^8.2.2",
     "email-validator": "^2.0.4",
@@ -98,7 +99,7 @@
   "peerDependencies": {
     "@sanity/pkg-utils": "catalog:",
     "eslint": ">=8.0.0",
-    "typescript": "5.8.x || 5.9.x || 6.0.x"
+    "typescript": "6.x || 7.x"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
@@ -1,9 +1,9 @@
 import {createRequire} from 'node:module'
 import path from 'path'
 
+import type {ParsedCommandLine} from '@typescript/typescript6'
 import chalk from 'chalk'
 import outdent from 'outdent'
-import type {ParsedCommandLine} from 'typescript'
 import validateNpmPackageName from 'validate-npm-package-name'
 
 import {deprecatedDevDeps, mergedPackages} from '../../configs/banned-packages'

--- a/packages/@sanity/plugin-kit/src/actions/verify/verify-common.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify/verify-common.ts
@@ -1,7 +1,7 @@
+import type {ParsedCommandLine} from '@typescript/typescript6'
 import chalk from 'chalk'
 import type {TypedFlags} from 'meow'
 import outdent from 'outdent'
-import type {ParsedCommandLine} from 'typescript'
 
 import sharedFlags from '../../sharedFlags'
 import {runCommand} from '../../util/command-parser'

--- a/packages/@sanity/plugin-kit/src/npm/resolveLatestVersions.ts
+++ b/packages/@sanity/plugin-kit/src/npm/resolveLatestVersions.ts
@@ -5,6 +5,10 @@ import pProps from 'p-props'
 const lockedDependencies: Record<string, string> = {
   'styled-components': '^6.1',
   'eslint': '^8.57.0',
+  // The scaffolded ESLint toolchain (@typescript-eslint v8) requires the classic JS compiler API,
+  // which TypeScript 7 (the Go-native compiler) no longer ships. Unlock once typescript-eslint
+  // supports TypeScript 7.
+  'typescript': '^6',
 }
 
 export function resolveLatestVersions(packages: string[]) {

--- a/packages/@sanity/plugin-kit/src/util/ts.ts
+++ b/packages/@sanity/plugin-kit/src/util/ts.ts
@@ -1,6 +1,9 @@
 import path from 'path'
 
-import * as ts from 'typescript'
+// The JS compiler API is loaded from the official `@typescript/typescript6` compat package
+// instead of the `typescript` peer dependency, as TypeScript 7 (the Go-native compiler) no longer
+// ships it
+import * as ts from '@typescript/typescript6'
 
 import {fileExists} from './files'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,9 @@ importers:
       '@rexxars/choosealicense-list':
         specifier: ^1.1.2
         version: 1.1.2
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       chalk:
         specifier: ^4.1.2
         version: 4.1.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Applies the same fix to `@sanity/plugin-kit` as [sanity-io/pkg-utils#2978](https://github.com/sanity-io/pkg-utils/pull/2978): the TypeScript baseline moves to 6/7, and the JS compiler API is loaded from `@typescript/typescript6` instead of `typescript`.

## Why

TypeScript 7 (the Go-native compiler) no longer ships the JS compiler API — its npm entry point only exports `version`/`versionMajorMinor`. plugin-kit's `readTSConfig` (used by `verify-package`/`verify-studio` to parse `tsconfig.json` via `ts.readConfigFile`/`ts.parseJsonConfigFileContent`/`ts.sys`) breaks at runtime when a consumer installs `typescript@7`, which is now `latest` on npm.

## Changes

- **Peer range (breaking)**: `typescript` peer moves from `5.8.x || 5.9.x || 6.0.x` to `6.x || 7.x`. TypeScript 5.x is no longer supported; 7 is not required.
- **Compiler API via `@typescript/typescript6`**: `src/util/ts.ts` and the `ParsedCommandLine` type imports in `verify-common.ts`/`validations.ts` now use the official [`@typescript/typescript6`](https://www.npmjs.com/package/@typescript/typescript6) compat package, added as a regular dependency (statically imported, same as pkg-utils@11). The installed `typescript` peer no longer affects tsconfig parsing and is only used to run `tsc --build`. `@sanity/pkg-utils@11` already ships the same dependency, so it dedupes in consumer trees.
- **`plugin-kit init` scaffolds `typescript` at `^6` instead of `latest`**: discovered while smoke-testing — with `typescript@7` as `latest`, freshly scaffolded plugins failed `npm install` with an `ERESOLVE` conflict because the scaffolded `@typescript-eslint`@8 toolchain declares peer `typescript ">=4.8.4 <6.1.0"`. Locked with a comment to unlock once typescript-eslint supports TS 7.
- **Changeset**: major for `@sanity/plugin-kit`.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm knip`, `pnpm build`, `pnpm test run` (167 files, 893 tests) all pass, including plugin-kit's `init -> verify-package -> tsc -> pkg-utils build` integration test.
- Packed-tarball consumer smoke tests:
  - pnpm consumer with `typescript@7.0.2`: `verify-package` parses tsconfig via `@typescript/typescript6` and its spawned `tsc --build` runs the Go-native TS7 compiler; full `npm run build` passes.
  - npm consumer with `typescript@7.0.2`: TS7 `tsc --build` compiles the scaffold directly; `verify-package` and the full build pass (npm's hoisted `.bin/tsc` collision with `@typescript/old` pre-exists for every pkg-utils@11 consumer).
  - Default `plugin-kit init` scaffold: installs cleanly again with `typescript ^6.0.3` (previously failed with `ERESOLVE` against `latest` = 7.0.2).

<details><summary>Smoke test log</summary>

```
=== 1) pnpm consumer with typescript 7.0.2 ===
plugin-kit peer typescript: 6.x || 7.x
plugin-kit dependency @typescript/typescript6: ^6.0.2
node_modules/.bin/tsc --version: Version 7.0.2   <-- the Go-native TS7 compiler

--- npx plugin-kit verify-package (tsconfig parsed via @typescript/typescript6; spawned 'tsc --build' is TypeScript 7) ---
[info] All checks ok, running TypeScript compiler.
[info] Running command: tsc --build
[success] No outstanding upgrade issues detected.

--- npm run build (plugin-kit verify-package --silent && pkg-utils build --strict --check --clean) ---
sanity-plugin-ts7-smoke@1.0.0
├─ type: module
└─ exports
   └─ sanity-plugin-ts7-smoke
      ├─ source: ./src/index.ts 573 B
      ├─ import: ./dist/index.js 236 B
      └─ default: ./dist/index.js 236 B

[success] 35ms

=== 2) npm consumer with typescript 7.0.2 ===
direct devDependency typescript: 7.0.2
TS7 native tsc builds the project directly:
Version 7.0.2
tsc --build (7.0.2): OK

--- npx plugin-kit verify-package ---
[info] All checks ok, running TypeScript compiler.
[info] Running command: tsc --build
[success] No outstanding upgrade issues detected.

=== 3) default 'plugin-kit init' scaffold now locks typescript to ^6 ===
scaffolded devDependencies.typescript: ^6.0.3
installed typescript: 6.0.3
(before: init scaffolded 'latest' = 7.0.2 and npm install failed with ERESOLVE, because
 @typescript-eslint/parser@8 declares peer typescript '>=4.8.4 <6.1.0')

--- npm run build ---
[success] 34ms
```

</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c227ebec-96dc-4edb-b177-d966093f5eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c227ebec-96dc-4edb-b177-d966093f5eb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

