### PR TITLE
Remove redundant `dts` option from tsdown configs

### DIFF
--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -175,7 +175,6 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,7 @@ plugins/
 
 ### Build fails with "tsgo did not generate dts file"
 
-Declarations are generated with tsgo (`dts: {tsgo: true}` in each package's `tsdown.config.ts`), which requires exported types to be portable. A `TS2883` error printed above the failure means an inferred exported type references a module that is not publicly addressable (for example a deep `.pnpm` or dts-chunk path). Fix it by adding an explicit type annotation at the reported site so the emitted declaration can use a locally imported name (see the actor annotations in `plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts` for an example). Note that test files are part of the declaration program too, since the single `tsconfig.json` includes them.
+Declarations are generated with tsgo (tsdown enables dts generation automatically because the packages declare types, and picks the tsgo generator because the installed `typescript` is v7+), which requires exported types to be portable. A `TS2883` error printed above the failure means an inferred exported type references a module that is not publicly addressable (for example a deep `.pnpm` or dts-chunk path). Fix it by adding an explicit type annotation at the reported site so the emitted declaration can use a locally imported name (see the actor annotations in `plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts` for an example). Note that test files are part of the declaration program too, since the single `tsconfig.json` includes them.
 
 ### Lint Errors About Missing Types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,7 @@ plugins/
 
 ### Build fails with "tsgo did not generate dts file"
 
-Declarations are generated with tsgo (tsdown enables dts generation automatically because the packages declare types, and picks the tsgo generator because the installed `typescript` is v7+), which requires exported types to be portable. A `TS2883` error printed above the failure means an inferred exported type references a module that is not publicly addressable (for example a deep `.pnpm` or dts-chunk path). Fix it by adding an explicit type annotation at the reported site so the emitted declaration can use a locally imported name (see the actor annotations in `plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts` for an example). Note that test files are part of the declaration program too, since the single `tsconfig.json` includes them.
+Declarations are generated with tsgo (tsdown enables dts generation automatically — packages either declare types in `package.json` or inherit `declaration: true` from the shared `@sanity/tsconfig` presets — and picks the tsgo generator because the installed `typescript` is v7+), which requires exported types to be portable. A `TS2883` error printed above the failure means an inferred exported type references a module that is not publicly addressable (for example a deep `.pnpm` or dts-chunk path). Fix it by adding an explicit type annotation at the reported site so the emitted declaration can use a locally imported name (see the actor annotations in `plugins/sanity-plugin-dashboard-widget-vercel/src/machines/form.ts` for an example). Note that test files are part of the declaration program too, since the single `tsconfig.json` includes them.
 
 ### Lint Errors About Missing Types
 

--- a/packages/@sanity/plugin-kit/tsdown.config.ts
+++ b/packages/@sanity/plugin-kit/tsdown.config.ts
@@ -4,7 +4,6 @@ import type {UserConfig} from 'tsdown'
 const config: UserConfig = {
   ...(await defineConfig({
     platform: 'node',
-    dts: {tsgo: true},
   })),
   // `platform: 'node'` defaults to `.mjs`/`.d.mts` output; keep the published `.js`/`.d.ts`
   // layout that `bin/plugin-kit.js` and `types` already point at

--- a/plugins/@sanity/assist/tsdown.config.ts
+++ b/plugins/@sanity/assist/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/code-input/tsdown.config.ts
+++ b/plugins/@sanity/code-input/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/color-input/tsdown.config.ts
+++ b/plugins/@sanity/color-input/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/cross-dataset-duplicator/tsdown.config.ts
+++ b/plugins/@sanity/cross-dataset-duplicator/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/dashboard/tsdown.config.ts
+++ b/plugins/@sanity/dashboard/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/debug-preview-url-secret-plugin/tsdown.config.ts
+++ b/plugins/@sanity/debug-preview-url-secret-plugin/tsdown.config.ts
@@ -1,6 +1,4 @@
 import {defineConfig} from '@sanity/tsdown-config'
 import type {UserConfig} from 'tsdown'
 
-export default defineConfig({
-  dts: {tsgo: true},
-}) satisfies Promise<UserConfig>
+export default defineConfig() satisfies Promise<UserConfig>

--- a/plugins/@sanity/document-internationalization/tsdown.config.ts
+++ b/plugins/@sanity/document-internationalization/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/embeddings-index-ui/tsdown.config.ts
+++ b/plugins/@sanity/embeddings-index-ui/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/form-toolkit/tsdown.config.ts
+++ b/plugins/@sanity/form-toolkit/tsdown.config.ts
@@ -10,5 +10,4 @@ export default defineConfig({
     './src/form-renderer/index.ts',
   ],
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/google-maps-input/tsdown.config.ts
+++ b/plugins/@sanity/google-maps-input/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/hierarchical-document-list/tsdown.config.ts
+++ b/plugins/@sanity/hierarchical-document-list/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/language-filter/tsdown.config.ts
+++ b/plugins/@sanity/language-filter/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/orderable-document-list/tsdown.config.ts
+++ b/plugins/@sanity/orderable-document-list/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/personalization-plugin/tsdown.config.ts
+++ b/plugins/@sanity/personalization-plugin/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   entry: ['./src/index.ts', './src/launchDarkly/index.ts', './src/growthbook/index.ts'],
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/presets/tsdown.config.ts
+++ b/plugins/@sanity/presets/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/rich-date-input/tsdown.config.ts
+++ b/plugins/@sanity/rich-date-input/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/sanity-plugin-async-list/tsdown.config.ts
+++ b/plugins/@sanity/sanity-plugin-async-list/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/sfcc/tsdown.config.ts
+++ b/plugins/@sanity/sfcc/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/studio-secrets/tsdown.config.ts
+++ b/plugins/@sanity/studio-secrets/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/table/tsdown.config.ts
+++ b/plugins/@sanity/table/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/vercel-protection-bypass/tsdown.config.ts
+++ b/plugins/@sanity/vercel-protection-bypass/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-naive-html-serializer/tsdown.config.ts
+++ b/plugins/sanity-naive-html-serializer/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-aprimo/tsdown.config.ts
+++ b/plugins/sanity-plugin-aprimo/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-asset-source-unsplash/tsdown.config.ts
+++ b/plugins/sanity-plugin-asset-source-unsplash/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-bynder-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-bynder-input/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-cloudinary/tsdown.config.ts
+++ b/plugins/sanity-plugin-cloudinary/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-dashboard-widget-document-list/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-dashboard-widget-netlify/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-netlify/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-dashboard-widget-vercel/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-documents-pane/tsdown.config.ts
+++ b/plugins/sanity-plugin-documents-pane/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-google-translate/tsdown.config.ts
+++ b/plugins/sanity-plugin-google-translate/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-graph-view/tsdown.config.ts
+++ b/plugins/sanity-plugin-graph-view/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-hotspot-array/tsdown.config.ts
+++ b/plugins/sanity-plugin-hotspot-array/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-iframe-pane/tsdown.config.ts
+++ b/plugins/sanity-plugin-iframe-pane/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-internationalized-array/tsdown.config.ts
+++ b/plugins/sanity-plugin-internationalized-array/tsdown.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
     'migrations/index': './migrations/index.ts',
   },
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-latex-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-latex-input/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-markdown/tsdown.config.ts
+++ b/plugins/sanity-plugin-markdown/tsdown.config.ts
@@ -8,5 +8,4 @@ export default defineConfig({
   },
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-media/tsdown.config.ts
+++ b/plugins/sanity-plugin-media/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-mux-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-mux-input/tsdown.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
   entry: ['./src/_exports/index.ts'],
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
   define: {__PKG_VERSION__: JSON.stringify(pkg.version)},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-shopify-assets/tsdown.config.ts
+++ b/plugins/sanity-plugin-shopify-assets/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-studio-smartling/tsdown.config.ts
+++ b/plugins/sanity-plugin-studio-smartling/tsdown.config.ts
@@ -3,5 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-transifex/tsdown.config.ts
+++ b/plugins/sanity-plugin-transifex/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-utils/tsdown.config.ts
+++ b/plugins/sanity-plugin-utils/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-workflow/tsdown.config.ts
+++ b/plugins/sanity-plugin-workflow/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-plugin-workspace-home/tsdown.config.ts
+++ b/plugins/sanity-plugin-workspace-home/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/plugins/sanity-translations-tab/tsdown.config.ts
+++ b/plugins/sanity-translations-tab/tsdown.config.ts
@@ -4,5 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/turbo/generators/templates/tsdown.config.ts.hbs
+++ b/turbo/generators/templates/tsdown.config.ts.hbs
@@ -9,5 +9,4 @@ export default defineConfig({
 {{#if hasVanillaExtract}}
   vanillaExtract: true,
 {{/if}}
-  dts: {tsgo: true},
 }) satisfies Promise<UserConfig>

--- a/turbo/generators/tsdown.config.mts
+++ b/turbo/generators/tsdown.config.mts
@@ -6,6 +6,5 @@ import {defineConfig} from 'tsdown'
 export default defineConfig({
   entry: './src/config.ts',
   format: ['cjs'],
-  dts: true,
   deps: {neverBundle: ['@turbo/gen']},
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Since the TypeScript v7 (tsgo) update (#1531), the explicit `dts` option in our tsdown configs is a no-op:

- tsdown auto-enables dts generation when the package declares types in `package.json`, or — for packages without a `types` field, like `@sanity/form-toolkit` and `@repo/generators` — when the resolved tsconfig sets `declaration: true` (all our tsconfigs extend `@sanity/tsconfig/strictest` → `recommended`, which does).
- `rolldown-plugin-dts` auto-selects the tsgo generator whenever the installed `typescript` major is >= 7, so `{tsgo: true}` is implied.

This removes `dts: {tsgo: true}` from all 48 plugin/package configs and the plugin generator template, `dts: true` from `turbo/generators/tsdown.config.mts`, and updates the stale references in `AGENTS.md` and the `sanity-plugin-best-practices` skill.

## Verification

Built all 50 packages on `main`, hashed every file under each `dist/` (282 files, including `.d.ts` and `.d.ts.map`), then rebuilt with this change and compared: **all outputs are byte-identical**. The tsgo path is still exercised — builds still print `TypeScript 7.0 does not yet have a stable API and is experimental` and emit declarations.

Because the published `dist/` output is unchanged and `tsdown.config.ts` isn't shipped (`files: ["dist"]`), no changesets are included.

- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm knip`
- ✅ `pnpm build` (50/50 tasks)
- ✅ `pnpm test run` (167 files, 893 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12722b33-b587-45e3-8ee2-9dbd5f5bc717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12722b33-b587-45e3-8ee2-9dbd5f5bc717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

