### PR TITLE
Prevent Renovate from rewriting pnpm `peer` catalog ranges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,12 @@
   "ignorePresets": [
     "github>sanity-io/renovate-config:group-non-major",
     "github>sanity-io/renovate-config:workarounds-esm"
+  ],
+  "packageRules": [
+    {
+      "description": "Never rewrite the manually curated ranges in the pnpm `peer` catalog — they declare what consumers may use and are intentionally wider than the default catalog",
+      "matchDepTypes": ["pnpm.catalog.peer"],
+      "enabled": false
+    }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ The catalog only holds peers shared across many packages (`react`, `react-dom`, 
 - **Niche one-off peers** used by a single package (e.g. `easymde` in `sanity-plugin-markdown`, `eslint`/`typescript` in `@sanity/plugin-kit`)
 - **Peers on other workspace packages**, which keep the `workspace:^` protocol (e.g. `@sanity/dashboard` in the dashboard widgets) or an explicit range when older majors are intentionally supported (e.g. `sanity-plugin-internationalized-array` in `@sanity/sfcc`) — changesets can't track dependents through `catalog:` references
 
-Note that the `peer` catalog entries are intentionally wider than the default catalog's (e.g. `react: ^19.2` vs `^19.2.7`): the default catalog pins what we develop against, the `peer` catalog declares what consumers may use.
+Note that the `peer` catalog entries are intentionally wider than the default catalog's (e.g. `react: ^19.2` vs `^19.2.7`): the default catalog pins what we develop against, the `peer` catalog declares what consumers may use. Renovate is configured (a `packageRules` entry in `.github/renovate.json` disables the `pnpm.catalog.peer` depType) to never rewrite these ranges — changing a peer range is a deliberate, manual decision.
 
 **Always use `lodash-es` instead of `lodash`**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

Renovate keeps rewriting the manually curated ranges in the `catalogs.peer` section of `pnpm-workspace.yaml` — #1566 bumps `styled-components: ^6.1` to `^6.4.3`, and #1564 (closed unmerged) rewrote `react`/`react-dom` from `^19.2` to `^19.2.7`. Those ranges are intentionally wider than the default catalog: they declare what consumers may use, so they must only change through deliberate, manual edits.

This happens because the shared `github>sanity-io/renovate-config:strategy` preset only applies `rangeStrategy: widen` to the `peerDependencies` depType, while pnpm catalog entries get the dynamic depType `pnpm.catalog.peer` — which falls through to the default `rangeStrategy: bump`.

### Fix

Add a `packageRules` entry to `.github/renovate.json` that disables Renovate entirely for `matchDepTypes: ["pnpm.catalog.peer"]`. Repo-level `packageRules` are appended after preset rules, so this rule wins. The default catalog (`pnpm.catalog.default`) is unaffected.

Once this lands on `main` (Renovate reads config from the default branch), the next Renovate run should autoclose #1566 since its update is no longer wanted. It also stops #1564 from coming back: closing that PR only ignored the exact `^19.2.7` update, so Renovate would have opened a fresh PR for the next react patch release — now peer-catalog entries are skipped entirely.

Also documents the policy in the `peer` catalog section of `AGENTS.md`.

### Verification

Ran `renovate --platform=local` dry runs against this repo with the old and new config (comparison below): before, the `react`, `react-dom` (= #1564), and `styled-components` (= #1566) peer entries would be rewritten; after, all four peer entries report `skipReason: "disabled"`, and the only branches dropped from Renovate's plan are the two peer-catalog-only ones (`renovate/styled-components-6.x`, `renovate/react-monorepo`) — the other 66 branches are untouched.

[Renovate dry-run before/after comparison](https://cursor.com/agents/bc-aae630f3-212d-4a82-9454-c991e81c690f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frenovate_dry_run_before_after.log)

- ✅ `renovate-config-validator .github/renovate.json`
- ✅ `renovate --platform=local` dry run before/after comparison
- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm knip`
- ✅ `pnpm build`
- ✅ `pnpm test run --changed origin/main` (no affected packages — config/docs only, so no changeset needed)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aae630f3-212d-4a82-9454-c991e81c690f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aae630f3-212d-4a82-9454-c991e81c690f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

