### PR TITLE
Move turbo/**/*.hbs oxfmt ignore to root config

### DIFF
--- a/.changeset/oxfmt-turbo-ignore.md
+++ b/.changeset/oxfmt-turbo-ignore.md
@@ -1,0 +1,5 @@
+---
+"@sanity/plugin-kit": patch
+---
+
+Move `turbo/**/*.hbs` oxfmt ignore pattern from the shared preset to the monorepo root config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,7 +444,7 @@ We use [oxfmt](https://oxc.rs/docs/formatter.html):
 pnpm format
 ```
 
-The formatter settings live in the shared `@sanity/plugin-kit/oxfmt` preset (`packages/@sanity/plugin-kit/src/oxfmt.ts`), which the root `oxfmt.config.ts` re-exports. Standalone plugins scaffolded with `plugin-kit init` reuse the same preset. Note that loading the TypeScript config requires Node `^20.19 || >=22.18`.
+The formatter settings live in the shared `@sanity/plugin-kit/oxfmt` preset (`packages/@sanity/plugin-kit/src/oxfmt.ts`), which the root `oxfmt.config.ts` extends with workspace-specific `ignorePatterns` (for example `turbo/**/*.hbs`). Standalone plugins scaffolded with `plugin-kit init` reuse the same preset. Note that loading the TypeScript config requires Node `^20.19 || >=22.18`.
 
 ### Linting
 

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,1 +1,9 @@
-export {default} from '@sanity/plugin-kit/oxfmt'
+import pluginKitOxfmt from '@sanity/plugin-kit/oxfmt'
+import {defineConfig} from 'oxfmt'
+
+// Shared Sanity plugin formatting settings live in the @sanity/plugin-kit preset;
+// only workspace-specific ignore patterns belong here.
+export default defineConfig({
+  ...pluginKitOxfmt,
+  ignorePatterns: [...(pluginKitOxfmt.ignorePatterns ?? []), 'turbo/**/*.hbs'],
+})

--- a/packages/@sanity/plugin-kit/src/oxfmt.ts
+++ b/packages/@sanity/plugin-kit/src/oxfmt.ts
@@ -33,7 +33,7 @@ const config: OxfmtConfig = {
   quoteProps: 'consistent',
   sortImports: true,
   sortPackageJson: {sortScripts: true},
-  ignorePatterns: ['dist/**', 'pnpm-lock.yaml', 'turbo/**/*.hbs'],
+  ignorePatterns: ['dist/**', 'pnpm-lock.yaml'],
   overrides: [
     {
       files: ['.changeset/*.md'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the `turbo/**/*.hbs` oxfmt ignore pattern out of the shared `@sanity/plugin-kit/oxfmt` preset and into the monorepo root `oxfmt.config.ts`.

The plugin-kit preset should only contain formatting rules and ignore patterns that apply broadly to Sanity plugins (like `dist/**` and `pnpm-lock.yaml`). Turbo generator Handlebars templates are specific to this monorepo's scaffolding setup.

## Changes

- **`packages/@sanity/plugin-kit/src/oxfmt.ts`**: Remove `turbo/**/*.hbs` from `ignorePatterns`
- **`oxfmt.config.ts`**: Spread the plugin-kit preset and add the monorepo-specific ignore (mirrors how `oxlint.config.ts` handles workspace-specific patterns)
- **`AGENTS.md`**: Document that root `oxfmt.config.ts` extends the preset with workspace-specific ignores

## Testing

- `pnpm format`
- `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6a34-c186-733f-9958-ad91afd4f476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6a34-c186-733f-9958-ad91afd4f476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

