### PR TITLE
fix(deps): patch @sanity/vanilla-extract-vite-plugin so vanilla-extract CSS survives `sanity build`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,6 +495,21 @@ corepack enable
 2. Verify you have access to the project
 3. Check the browser console for specific errors
 
+### vanilla-extract CSS missing from `sanity build` output
+
+`@sanity/vanilla-extract-vite-plugin` is currently patched via `patchedDependencies`
+(`patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch`): without it, `sanity build` emits the
+compiled `.css.ts` class names but silently drops the extracted CSS (e.g. the google-maps-input
+picker dialog collapses), while `sanity dev` is unaffected. The patch pins every stateful
+`@vanilla-extract/css` entrypoint to one module instance by importing them eagerly at plugin module
+load — see the comment inside the patch for the full root-cause analysis (NODE_ENV-dispatched CJS
+dists resolving to different dev/prod copies before vs. after Vite sets `NODE_ENV=production`).
+Drop the patch once the fix ships upstream in
+[sanity-io/pkg-utils](https://github.com/sanity-io/pkg-utils); when Renovate bumps the plugin past
+`0.2.0`, pnpm will fail install with `ERR_PNPM_PATCH_NOT_APPLIED` — refresh the patch against the
+new version (`pnpm patch <pkg>@<version>`) if it is still unfixed, or delete the patch and the
+`patchedDependencies` entry if it is.
+
 ## Cursor Cloud specific instructions
 
 ### Services

--- a/patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch
+++ b/patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch
@@ -1,0 +1,35 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index ed8afc6403bf1821f82e3eb6e4d5a0a64ae80827..9bdd2e8920243e877f74964f2e588f36d70f0a73 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -3,6 +3,30 @@ import { createServer, createServerModuleRunner, loadConfigFromFile } from "vite
+ import { isAbsolute, join, posix } from "node:path";
+ import { transformCss } from "@vanilla-extract/css/transformCss";
+ /**
++* Pin every stateful `@vanilla-extract/css` entrypoint to a single module instance
++* (https://github.com/sanity-io/pkg-utils/issues — vanilla-extract CSS silently missing from
++* `sanity build` output).
++*
++* `@vanilla-extract/css`'s CJS dists are dev/prod dispatchers: `dist/*.cjs.js` picks
++* `*.cjs.dev.js` or `*.cjs.prod.js` based on `process.env.NODE_ENV` **at first require**, and the
++* dev/prod files require their siblings (e.g. `adapter/dist/*.cjs.prod.js`) directly, bypassing
++* the dispatcher. `@sanity/vanilla-extract-integration` requires `@vanilla-extract/css/adapter`
++* when this module loads — during config loading, before Vite's `resolveConfig` sets
++* `NODE_ENV=production` for a build — so the adapter dispatcher caches the *dev* copy. The
++* `.css.ts` modules evaluated later through the ModuleRunner then import `@vanilla-extract/css`
++* itself for the first time *after* `NODE_ENV` became `production`, loading the *prod* copy,
++* whose `style()` dispatches `appendCss` through the *prod* adapter instance — not the *dev*
++* instance `setAdapter()` registered the collecting adapter on. The css lands in the built-in
++* no-op mock adapter and the build emits class names without any CSS.
++*
++* Importing the entrypoints eagerly right here makes all their dispatchers resolve at the same
++* moment, with the same `NODE_ENV` value, so host and evaluated modules always share one adapter
++* and one fileScope instance.
++*/
++import "@vanilla-extract/css";
++import "@vanilla-extract/css/adapter";
++import "@vanilla-extract/css/fileScope";
++/**
+ * Serializes compilations: the vanilla-extract css adapter is handed to the evaluated modules
+ * through a global, so only one `.css.ts` module may be evaluated at a time. Ported from
+ * `@vanilla-extract/compiler` (MIT licensed, Copyright (c) 2021 SEEK).

--- a/patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch
+++ b/patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch
@@ -1,30 +1,36 @@
 diff --git a/dist/index.mjs b/dist/index.mjs
-index ed8afc6403bf1821f82e3eb6e4d5a0a64ae80827..9bdd2e8920243e877f74964f2e588f36d70f0a73 100644
+index ed8afc6403bf1821f82e3eb6e4d5a0a64ae80827..bbc42a7defc8aac24ffed3ac201a2eee26187ab0 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -3,6 +3,30 @@ import { createServer, createServerModuleRunner, loadConfigFromFile } from "vite
+@@ -3,6 +3,36 @@ import { createServer, createServerModuleRunner, loadConfigFromFile } from "vite
  import { isAbsolute, join, posix } from "node:path";
  import { transformCss } from "@vanilla-extract/css/transformCss";
  /**
-+* Pin every stateful `@vanilla-extract/css` entrypoint to a single module instance
-+* (https://github.com/sanity-io/pkg-utils/issues — vanilla-extract CSS silently missing from
-+* `sanity build` output).
++* Pin every stateful `@vanilla-extract/css` entrypoint to a single module instance — without
++* this, vanilla-extract CSS is silently missing from `sanity build` output (class names are
++* emitted, zero CSS). To be upstreamed to sanity-io/pkg-utils: the equivalent source change is
++* these three side-effect imports in `packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts`.
 +*
 +* `@vanilla-extract/css`'s CJS dists are dev/prod dispatchers: `dist/*.cjs.js` picks
 +* `*.cjs.dev.js` or `*.cjs.prod.js` based on `process.env.NODE_ENV` **at first require**, and the
 +* dev/prod files require their siblings (e.g. `adapter/dist/*.cjs.prod.js`) directly, bypassing
 +* the dispatcher. `@sanity/vanilla-extract-integration` requires `@vanilla-extract/css/adapter`
-+* when this module loads — during config loading, before Vite's `resolveConfig` sets
-+* `NODE_ENV=production` for a build — so the adapter dispatcher caches the *dev* copy. The
-+* `.css.ts` modules evaluated later through the ModuleRunner then import `@vanilla-extract/css`
-+* itself for the first time *after* `NODE_ENV` became `production`, loading the *prod* copy,
-+* whose `style()` dispatches `appendCss` through the *prod* adapter instance — not the *dev*
-+* instance `setAdapter()` registered the collecting adapter on. The css lands in the built-in
-+* no-op mock adapter and the build emits class names without any CSS.
++* when this module loads (`processVanillaFile.ts` module scope) — during config loading, before
++* Vite's `resolveConfig` sets `NODE_ENV=production` for a build — so the adapter dispatcher
++* caches the *dev* copy. The `.css.ts` modules evaluated later through the ModuleRunner are
++* externalized to Node's own loader (`default` condition — unlike legacy vite-node, which
++* resolved the dispatch-free `module`-condition ESM files, why upstream's plugin is unaffected)
++* and import `@vanilla-extract/css` for the first time *after* `NODE_ENV` became `production`,
++* loading the *prod* copy, whose `style()` dispatches `appendCss` through the *prod* adapter
++* instance — not the *dev* instance `setAdapter()` registered the collecting adapter on. The css
++* lands in the built-in no-op mock adapter and the build emits class names without any CSS.
 +*
-+* Importing the entrypoints eagerly right here makes all their dispatchers resolve at the same
-+* moment, with the same `NODE_ENV` value, so host and evaluated modules always share one adapter
-+* and one fileScope instance.
++* The integration's `processVanillaFile` already guards this bug class on the sync `node:vm`
++* path by restoring `originalNodeEnv` around eval; the async ModuleRunner path can't safely
++* mutate the env (it interleaves with the concurrent main build). Importing the entrypoints
++* eagerly right here instead makes all their dispatchers resolve at the same moment, with the
++* same `NODE_ENV` value, so host and evaluated modules always share one adapter and one
++* fileScope instance.
 +*/
 +import "@vanilla-extract/css";
 +import "@vanilla-extract/css/adapter";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ catalogs:
       specifier: ^3.0.3
       version: 3.0.3
     '@sanity/vanilla-extract-vite-plugin':
-      specifier: ^0.1.1
-      version: 0.1.1
+      specifier: ^0.2.0
+      version: 0.2.0
     '@sanity/vision':
       specifier: ^6.5.0
       version: 6.5.0
@@ -190,6 +190,7 @@ overrides:
 
 patchedDependencies:
   '@bynder/compact-view': c71de21a98b99e126cf6a513070404932603d4254f3614440c3a5f5ee7e7e8a6
+  '@sanity/vanilla-extract-vite-plugin@0.2.0': a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86
 
 importers:
 
@@ -315,7 +316,7 @@ importers:
         version: 3.3.5(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.1.1(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@sanity/vercel-protection-bypass':
         specifier: workspace:*
         version: link:../../plugins/@sanity/vercel-protection-bypass
@@ -333,7 +334,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       sanity:
         specifier: ^6.5.0
-        version: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)
+        version: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)
       sanity-naive-html-serializer:
         specifier: workspace:*
         version: link:../../plugins/sanity-naive-html-serializer
@@ -500,7 +501,7 @@ importers:
     devDependencies:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 11.0.8(@types/node@24.13.3)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@7.0.2)
+        version: 11.0.8(@types/node@24.13.3)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@7.0.2)
       '@sanity/tsconfig':
         specifier: 'catalog:'
         version: 2.2.1
@@ -1126,7 +1127,7 @@ importers:
         version: 0.17.2(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.8)(typescript@7.0.2)(vite@8.1.5)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.1.1(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@types/google.maps':
         specifier: ^3.65.2
         version: 3.65.2
@@ -2760,7 +2761,7 @@ importers:
         version: 3.3.5(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       axios:
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(supports-color@8.1.1)
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -6226,8 +6227,8 @@ packages:
     peerDependencies:
       tsdown: ^0.22.5
 
-  '@sanity/vanilla-extract-vite-plugin@0.1.1':
-    resolution: {integrity: sha512-5FPmsoxPiZFauqSm476+s4q9oh/knlLAO8o+JA/yzp/0gu33LWtTAq8XdfuKMyW/B2RC4mWrHwza6qT+As4bXA==}
+  '@sanity/vanilla-extract-vite-plugin@0.2.0':
+    resolution: {integrity: sha512-7zCWVjixn5IAcFFHRIwENUi1jkBHnu8QedVtV6cBRpU7Nm7K+QLTZRK48aLybRtvgP56sjNGdkotoXNhCzoJqg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       vite: ^8.0.0
@@ -11675,7 +11676,7 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
@@ -12211,7 +12212,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
@@ -12280,7 +12281,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
@@ -13912,7 +13913,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7)':
+  '@portabletext/editor@7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)':
     dependencies:
       '@portabletext/html': 1.1.1
       '@portabletext/keyboard-shortcuts': 2.1.3
@@ -13949,7 +13950,7 @@ snapshots:
 
   '@portabletext/plugin-character-pair-decorator@8.0.35(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/plugin-input-rule': 6.0.4(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -13957,12 +13958,12 @@ snapshots:
 
   '@portabletext/plugin-dnd@1.0.19(@portabletext/editor@7.10.7)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       react: 19.2.7
 
   '@portabletext/plugin-input-rule@6.0.4(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.5)
       react: 19.2.7
       xstate: 5.32.5
@@ -13971,12 +13972,12 @@ snapshots:
 
   '@portabletext/plugin-list-index@1.0.19(@portabletext/editor@7.10.7)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       react: 19.2.7
 
   '@portabletext/plugin-markdown-shortcuts@8.0.35(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/plugin-character-pair-decorator': 8.0.35(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 6.0.4(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -13985,17 +13986,17 @@ snapshots:
 
   '@portabletext/plugin-one-line@7.0.34(@portabletext/editor@7.10.7)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       react: 19.2.7
 
   '@portabletext/plugin-paste-link@4.0.34(@portabletext/editor@7.10.7)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       react: 19.2.7
 
   '@portabletext/plugin-typography@8.0.35(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/plugin-input-rule': 6.0.4(@portabletext/editor@7.10.7)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -14374,7 +14375,7 @@ snapshots:
 
   '@sanity/browserslist-config@1.0.5': {}
 
-  '@sanity/cli-build@4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+  '@sanity/cli-build@4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
     dependencies:
       '@oclif/core': 4.11.14
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5)
@@ -14467,20 +14468,20 @@ snapshots:
       - terser
       - yaml
 
-  '@sanity/cli@7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
+  '@sanity/cli@7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
     dependencies:
       '@oclif/core': 4.11.14
       '@oclif/plugin-help': 6.2.53
       '@oclif/plugin-not-found': 3.2.88(@types/node@24.13.3)
-      '@sanity/cli-build': 4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-build': 4.1.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/cli-core': 2.4.0(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
       '@sanity/client': 7.23.2
-      '@sanity/codegen': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0)(oxfmt@0.58.0)(react@19.2.7)
+      '@sanity/codegen': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0)(oxfmt@0.58.0)(react@19.2.7)(supports-color@8.1.1)
       '@sanity/descriptors': 1.3.0
-      '@sanity/export': 6.2.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.23.2)(@types/react@19.2.17)
+      '@sanity/import': 6.0.3(@sanity/client@7.23.2)(@types/react@19.2.17)(supports-color@8.1.1)
       '@sanity/migrate': 7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0)(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/runtime-cli': 17.1.0(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       '@sanity/schema': 6.5.0(@types/react@19.2.17)
@@ -14499,7 +14500,7 @@ snapshots:
       execa: 9.6.1
       form-data: 4.0.6
       get-latest-version: 6.0.1
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       gunzip-maybe: 1.4.2
       import-meta-resolve: 4.2.0
       is-installed-globally: 1.0.0
@@ -14574,11 +14575,11 @@ snapshots:
       nanoid: 3.3.16
       rxjs: 7.8.2
 
-  '@sanity/codegen@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0)(oxfmt@0.58.0)(react@19.2.7)':
+  '@sanity/codegen@7.0.3(@oclif/core@4.11.14)(@sanity/cli-core@2.4.0)(oxfmt@0.58.0)(react@19.2.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/register': 7.29.7(@babel/core@7.29.7)
@@ -14592,7 +14593,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       groq: 6.5.0
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       json5: 2.2.3
       lodash-es: 4.18.1
       prettier: 3.9.5
@@ -14638,7 +14639,7 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
-  '@sanity/export@6.2.0':
+  '@sanity/export@6.2.0(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.8.0
@@ -14672,7 +14673,7 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.4
 
-  '@sanity/import@6.0.3(@sanity/client@7.23.2)(@types/react@19.2.17)':
+  '@sanity/import@6.0.3(@sanity/client@7.23.2)(@types/react@19.2.17)(supports-color@8.1.1)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
       '@sanity/client': 7.23.2
@@ -14749,7 +14750,7 @@ snapshots:
       console-table-printer: 2.16.1
       debug: 4.4.3(supports-color@8.1.1)
       fast-fifo: 1.3.2
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       p-map: 7.0.5
     transitivePeerDependencies:
       - '@types/react'
@@ -14785,7 +14786,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@sanity/pkg-utils@11.0.8(@types/node@24.13.3)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(typescript@7.0.2)':
+  '@sanity/pkg-utils@11.0.8(@types/node@24.13.3)(@typescript/native-preview@7.0.0-dev.20260421.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.21.3)(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
@@ -14802,7 +14803,7 @@ snapshots:
       '@sanity/browserslist-config': 1.0.5
       '@sanity/parse-package-json': 2.2.6
       '@typescript/typescript6': 6.0.2
-      '@vanilla-extract/rollup-plugin': 1.5.4(rollup@4.62.2)
+      '@vanilla-extract/rollup-plugin': 1.5.4(babel-plugin-macros@3.1.0)(rollup@4.62.2)
       browserslist: 4.28.6
       cac: 7.0.0
       chalk: 5.6.2
@@ -14824,7 +14825,7 @@ snapshots:
       rolldown: 1.2.0
       rolldown-plugin-dts: 0.27.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.21.3)(rolldown@1.2.0)(typescript@7.0.2)
       rollup: 4.62.2
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.23.1
@@ -14874,7 +14875,7 @@ snapshots:
       cardinal: 2.1.1
       empathic: 2.0.1
       eventsource: 4.1.0
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       jiti: 2.7.0
       mime-types: 3.0.2
       ora: 9.4.1
@@ -14908,7 +14909,7 @@ snapshots:
       '@sanity/types': 6.5.0(@types/react@19.2.17)
       arrify: 3.0.0
       get-it: 8.8.0
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       humanize-list: 1.0.1
       leven: 4.1.0
       lodash-es: 4.18.1
@@ -14932,7 +14933,7 @@ snapshots:
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
       groq: 3.88.1-typegen-experimental.0
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       reselect: 5.2.0
       rxjs: 7.8.2
       zustand: 5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.7)(use-sync-external-store@1.6.0)
@@ -15086,14 +15087,13 @@ snapshots:
       - babel-plugin-macros
       - rolldown
 
-  '@sanity/vanilla-extract-vite-plugin@0.1.1(babel-plugin-macros@3.1.0)(vite@8.1.5)':
+  '@sanity/vanilla-extract-vite-plugin@0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)':
     dependencies:
+      '@sanity/vanilla-extract-integration': 0.1.0(babel-plugin-macros@3.1.0)
       '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
-      '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
       vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - babel-plugin-macros
-      - supports-color
 
   '@sanity/vision@6.5.0(@babel/runtime@7.29.7)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(codemirror@6.0.2)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(sanity@6.5.0)':
     dependencies:
@@ -15122,7 +15122,7 @@ snapshots:
       react: 19.2.7
       react-rx: 4.2.3(react@19.2.7)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)
+      sanity: 6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@babel/runtime'
       - '@codemirror/lint'
@@ -15631,7 +15631,7 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/rollup-plugin@1.5.4(rollup@4.62.2)':
+  '@vanilla-extract/rollup-plugin@1.5.4(babel-plugin-macros@3.1.0)(rollup@4.62.2)':
     dependencies:
       '@vanilla-extract/integration': 8.0.10(babel-plugin-macros@3.1.0)
       magic-string: 0.30.21
@@ -15943,7 +15943,7 @@ snapshots:
       global: 4.4.0
       pkcs7: 1.0.4
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -16049,11 +16049,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1:
+  axios@1.18.1(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -16067,11 +16067,11 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -16079,7 +16079,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -16087,7 +16087,7 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17323,7 +17323,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  groq-js@1.30.3:
+  groq-js@1.30.3(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -17438,9 +17438,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -19227,7 +19227,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -19315,7 +19315,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity@6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2):
+  sanity@6.5.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.14)(@rolldown/plugin-babel@0.2.3)(@sanity/cli-core@2.4.0)(@sanity/styled-components@6.1.24)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.11)(jiti@2.7.0)(oxfmt@0.58.0)(react-dom@19.2.7)(react@19.2.7)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -19325,7 +19325,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.19(@portabletext/editor@7.10.7)(react@19.2.7)
@@ -19341,7 +19341,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
       '@sanity/client': 7.23.2
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -19380,7 +19380,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       exif-component: 1.0.1
       fast-deep-equal: 3.1.3
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       history: 5.3.0
       i18next: 26.3.6(typescript@7.0.2)
       is-hotkey-esm: 1.0.0
@@ -19472,7 +19472,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.19(@portabletext/editor@7.10.7)(react@19.2.7)
@@ -19488,7 +19488,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
       '@sanity/client': 7.23.2
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -19527,7 +19527,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       exif-component: 1.0.1
       fast-deep-equal: 3.1.3
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       history: 5.3.0
       i18next: 26.3.6(typescript@7.0.2)
       is-hotkey-esm: 1.0.0
@@ -19619,7 +19619,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)
+      '@portabletext/editor': 7.10.7(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.19(@portabletext/editor@7.10.7)(react@19.2.7)
@@ -19635,7 +19635,7 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.7)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 7.9.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.1)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.58.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
       '@sanity/client': 7.23.2
       '@sanity/color': 3.0.6
       '@sanity/comlink': 4.0.1
@@ -19674,7 +19674,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       exif-component: 1.0.1
       fast-deep-equal: 3.1.3
-      groq-js: 1.30.3
+      groq-js: 1.30.3(supports-color@8.1.1)
       history: 5.3.0
       i18next: 26.3.6(typescript@7.0.2)
       is-hotkey-esm: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,7 +190,7 @@ overrides:
 
 patchedDependencies:
   '@bynder/compact-view': c71de21a98b99e126cf6a513070404932603d4254f3614440c3a5f5ee7e7e8a6
-  '@sanity/vanilla-extract-vite-plugin@0.2.0': a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86
+  '@sanity/vanilla-extract-vite-plugin@0.2.0': f9a8499f6b1984c4dd4aa0d5542d9afe20e0a02d69d22a363d498429a3ea57f8
 
 importers:
 
@@ -316,7 +316,7 @@ importers:
         version: 3.3.5(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.0(patch_hash=f9a8499f6b1984c4dd4aa0d5542d9afe20e0a02d69d22a363d498429a3ea57f8)(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@sanity/vercel-protection-bypass':
         specifier: workspace:*
         version: link:../../plugins/@sanity/vercel-protection-bypass
@@ -1127,7 +1127,7 @@ importers:
         version: 0.17.2(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.8)(typescript@7.0.2)(vite@8.1.5)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.0(patch_hash=f9a8499f6b1984c4dd4aa0d5542d9afe20e0a02d69d22a363d498429a3ea57f8)(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@types/google.maps':
         specifier: ^3.65.2
         version: 3.65.2
@@ -15087,7 +15087,7 @@ snapshots:
       - babel-plugin-macros
       - rolldown
 
-  '@sanity/vanilla-extract-vite-plugin@0.2.0(patch_hash=a909cb42f4899607cbb92ba64d43ed43b26815f405cefac9fbb18fff14facb86)(babel-plugin-macros@3.1.0)(vite@8.1.5)':
+  '@sanity/vanilla-extract-vite-plugin@0.2.0(patch_hash=f9a8499f6b1984c4dd4aa0d5542d9afe20e0a02d69d22a363d498429a3ea57f8)(babel-plugin-macros@3.1.0)(vite@8.1.5)':
     dependencies:
       '@sanity/vanilla-extract-integration': 0.1.0(babel-plugin-macros@3.1.0)
       '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   '@sanity/ui': ^3.3.5
   '@sanity/util': ^6.5.0
   '@sanity/uuid': ^3.0.3
-  '@sanity/vanilla-extract-vite-plugin': ^0.1.1
+  '@sanity/vanilla-extract-vite-plugin': ^0.2.0
   '@sanity/vision': ^6.5.0
   '@testing-library/jest-dom': ^6.9.1
   '@testing-library/react': ^16.3.2
@@ -137,6 +137,7 @@ overrides:
 
 patchedDependencies:
   '@bynder/compact-view': patches/@bynder__compact-view.patch
+  '@sanity/vanilla-extract-vite-plugin@0.2.0': patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch
 
 publicHoistPattern:
   # Allows setting vite/client in dev/test-studio/tsconfig.json without installing vite


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Problem

Opening the Google Maps input's geopoint picker in a **production** studio build shows a collapsed dialog: the inner container renders with class `.mt1vq20` but no CSS rule for it exists anywhere in the build output, so the picker has zero height. Reproduced with `sanity build` + `sanity start`; `sanity dev` is unaffected. **All** vanilla-extract CSS from `@sanity/google-maps-input`'s `.css.ts` modules was missing from `dist/static/*.css`, while the compiled class names were present in the JS.

[Before: collapsed maps dialog, .mt1vq20 computed height 0px](https://cursor.com/agents/bc-336c276d-01c5-4228-81e9-4ef18f225734/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_collapsed_maps_dialog.webp)

# Root cause (bug in `@sanity/vanilla-extract-vite-plugin`, hosted in sanity-io/pkg-utils)

`@vanilla-extract/css` ships NODE_ENV-dispatched CJS dists: `dist/*.cjs.js` picks `*.cjs.dev.js` or `*.cjs.prod.js` based on `process.env.NODE_ENV` **at first require**, and the dev/prod files require their siblings (e.g. `adapter/dist/*.cjs.prod.js`) **directly**, bypassing the dispatcher. During `sanity build`:

1. Loading `sanity.cli.ts` imports `@sanity/vanilla-extract-vite-plugin`; its integration dependency imports `@vanilla-extract/css/adapter` at module scope ([`processVanillaFile.ts`](https://github.com/sanity-io/pkg-utils/blob/main/packages/%40sanity/vanilla-extract-integration/src/processVanillaFile.ts)) — `NODE_ENV` is still **unset**, so the adapter dispatcher caches the **dev** copy.
2. Vite's `resolveConfig` then sets `NODE_ENV=production`.
3. The plugin's compiler ([`compiler.ts`](https://github.com/sanity-io/pkg-utils/blob/main/packages/%40sanity/vanilla-extract-vite-plugin/src/compiler.ts)) evaluates `.css.ts` modules through Vite's `ModuleRunner` with `@vanilla-extract/*` externalized (the `sanity-vanilla-extract-externalize` plugin's stated goal is that they "must resolve to the same instances the adapter of the compilation binds to"). The runner's externalization hands the import to Node's own loader (`default` condition → the NODE_ENV-dispatched CJS entries). The evaluated module's spliced `setAdapter(globalThis[…])` resolves `@vanilla-extract/css/adapter` through the *cached* dispatcher → **dev** instance. But `@vanilla-extract/css` itself is loaded for the first time *now* → **prod** copy → its `style()` dispatches `appendCss` through the directly-required **prod** adapter instance, whose stack only holds the built-in no-op mock adapter.
4. The CSS is silently swallowed; only class names (generated via the mock adapter's `getIdentOption`, which reads `NODE_ENV=production` → `short`, hence `mt1vq20`) survive into the bundle.

Verified with instrumentation: `setAdapter` landed in `vanilla-extract-css-adapter.cjs.dev.js` while `appendCss` dispatched through `vanilla-extract-css-adapter.cjs.prod.js` with `adapterStack.length === 1` (mock only), and the plugin's collected `cssByModuleId` stayed empty.

Notably, **pkg-utils already guards against this exact bug class on its other eval path**: `@sanity/vanilla-extract-integration`'s `processVanillaFile` (the sync `node:vm` path used by the rolldown plugin) snapshots `originalNodeEnv` at module load and restores it around eval, with a comment describing this exact failure ("Vite sometimes modifies NODE_ENV which causes different versions (e.g. dev/prod) of vanilla packages to be loaded. This can cause CSS to be bound to the wrong instance, resulting in no CSS output"). The vite plugin's async `ModuleRunner` path has no equivalent guard — and can't safely use the same env-mutation trick, since `await runner.import(...)` interleaves with the concurrent main build.

Cross-checks: forcing `NODE_ENV=production` for the entire build (both dispatchers snapshot the same value) makes the CSS appear — as does the upstream `@vanilla-extract/vite-plugin@5.2.5` in the same build (its legacy vite-node runner resolves externals through Vite's resolver, which honors the `module` condition → single ESM files with no NODE_ENV dispatch). `sanity dev` works because `NODE_ENV` never transitions to `production` mid-process. The plugin's own vitest suite can't catch it because vitest sets `NODE_ENV=test` before anything loads, so all dispatchers agree there too — a regression test needs a child process with `NODE_ENV` unset.

# Fix in this repo

- Bump `@sanity/vanilla-extract-vite-plugin` to `^0.2.0` (latest; the bug exists in 0.1.x and 0.2.0 — both integrations import the adapter at module scope).
- Add a pnpm patch (`patches/@sanity__vanilla-extract-vite-plugin@0.2.0.patch`) that eagerly imports `@vanilla-extract/css`, `@vanilla-extract/css/adapter` and `@vanilla-extract/css/fileScope` at plugin module load. This pins every stateful entrypoint's dev/prod dispatcher at one moment with one `NODE_ENV` value, so the host, the evaluated `.css.ts` modules and `@vanilla-extract/css` itself always share a single adapter (and fileScope) instance. The patch file carries the full analysis as a comment.
- Document the patch and its removal path in `AGENTS.md` (pnpm fails install with `ERR_PNPM_PATCH_NOT_APPLIED` once Renovate bumps past 0.2.0, so it cannot silently linger).

No changeset: only a devDependency of the plugins and a dependency of the private test studio changed; published plugin dists (built by the tsdown/rolldown pipeline, which is protected by the integration's env restore) are unaffected.

# Verified upstream fix for sanity-io/pkg-utils

The same change was applied to a pkg-utils checkout and verified there: a child-process repro against the **pristine** source emits **no CSS asset at all**, passes with the fix, and the plugin's existing test suite (15 tests, including type checks) stays green.

```diff
--- a/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
+++ b/packages/@sanity/vanilla-extract-vite-plugin/src/compiler.ts
@@ -22,6 +22,23 @@ import {
 } from '@sanity/vanilla-extract-integration'
 import type {Adapter} from '@vanilla-extract/css'
 import {transformCss} from '@vanilla-extract/css/transformCss'
+// Pin every stateful `@vanilla-extract/css` entrypoint to a single module instance.
+// Their CJS dists are NODE_ENV dispatchers (`dist/*.cjs.js` picks `*.cjs.dev.js` or
+// `*.cjs.prod.js` at first require, and those require their siblings directly). The integration
+// requires `@vanilla-extract/css/adapter` when this module loads — at config-load time, before
+// Vite's `resolveConfig` sets `NODE_ENV=production` for a build — while the ModuleRunner
+// externalizes the evaluated `.css.ts` modules' imports to Node's own loader, which loads
+// `@vanilla-extract/css` only at evaluation time. If `NODE_ENV` changed in between, `style()`
+// appends CSS through a *second* adapter instance whose stack only holds the no-op mock
+// adapter, and the extracted CSS is silently lost (class names still emit). Importing the
+// entrypoints eagerly makes all their dispatchers resolve at the same moment, with the same
+// `NODE_ENV`, so host and evaluated modules always share one adapter and one fileScope
+// instance. (`processVanillaFile` guards the sync `node:vm` path by restoring
+// `originalNodeEnv` around eval; this async path can't safely mutate the env, since
+// `runner.import` interleaves with the consuming build.)
+import '@vanilla-extract/css'
+import '@vanilla-extract/css/adapter'
+import '@vanilla-extract/css/fileScope'
 import {
   createServer,
   createServerModuleRunner,
```

<details>
<summary>Child-process repro (basis for an upstream regression test) — run with <code>env -u NODE_ENV node build-repro.mjs</code> from the plugin package</summary>

```js
// Mimics `sanity build`: the plugin module is imported while NODE_ENV is unset (config-load
// time), then `vite.build()` runs — Vite's resolveConfig sets NODE_ENV=production itself.
import assert from 'node:assert'

assert.strictEqual(process.env.NODE_ENV, undefined, 'NODE_ENV must be unset at startup')

const {vanillaExtractPlugin} = await import('./dist/index.mjs')
const {build} = await import('vite')

const result = await build({
  root: './test/fixtures/app',
  configFile: false,
  logLevel: 'silent',
  plugins: [vanillaExtractPlugin()],
  build: {write: false},
})

const {output} = Array.isArray(result) ? result[0] : result
const cssAsset = output.find((a) => a.type === 'asset' && a.fileName.endsWith('.css'))
const css = cssAsset
  ? typeof cssAsset.source === 'string'
    ? cssAsset.source
    : new TextDecoder().decode(cssAsset.source)
  : ''
const hasMarker = css.includes('rgb(1, 2, 3)') || css.includes('#010203')
console.log(hasMarker ? 'PASS: extracted CSS present' : 'FAIL: extracted CSS missing (bug reproduced)')
process.exit(hasMarker ? 0 : 1)
```

Pristine source: `css asset emitted: false | length: 0 | has marker: false`. With the fix: `css asset emitted: true | has marker: true`.

</details>

<details>
<summary>Minimal repro of the module-instance split (no vite, no sanity — just Node + @vanilla-extract/css)</summary>

```js
// env -u NODE_ENV node repro.mjs        -> collected: 0  (bug)
// env -u NODE_ENV node repro.mjs --fix  -> collected: 1  (fix)
import {createRequire} from 'node:module'
const require = createRequire(import.meta.url)
const fix = process.argv.includes('--fix')

// Phase 1: config load (NODE_ENV unset) — what the integration does at module scope:
const adapter = require('@vanilla-extract/css/adapter')
if (fix) {
  require('@vanilla-extract/css')
  require('@vanilla-extract/css/adapter')
  require('@vanilla-extract/css/fileScope')
}

// Phase 2: eval time — Vite's resolveConfig has set NODE_ENV=production:
process.env.NODE_ENV = 'production'
const {setFileScope, endFileScope} = require('@vanilla-extract/css/fileScope')
const {style} = require('@vanilla-extract/css')

const collected = []
adapter.setAdapter({
  appendCss: (css) => collected.push(css),
  registerClassName: () => {}, registerComposition: () => {},
  markCompositionUsed: () => {}, onEndFileScope: () => {},
  getIdentOption: () => 'short',
})
setFileScope('src/styles.css.ts', 'repro')
style({height: '40rem'})
endFileScope()
adapter.removeAdapter()
console.log({collected: collected.length}) // 0 without --fix, 1 with --fix
```

</details>

# Verification

After the patch, a `sanity build` emits all six vanilla-extract rules (including `.mt1vq20{height:40rem}`) into `dist/static/sanity-*.css`, and the picker dialog renders full height in both the production preview and `sanity dev` (checked in the browser with a placeholder Google Maps API key, hence the expected "couldn't load" card inside the dialog):

[maps_picker_dialog_full_height_after_fix.mp4](https://cursor.com/agents/bc-336c276d-01c5-4228-81e9-4ef18f225734/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmaps_picker_dialog_full_height_after_fix.mp4)

[After: dialog inner container back to 40rem in the production build](https://cursor.com/agents/bc-336c276d-01c5-4228-81e9-4ef18f225734/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_maps_dialog_full_height.webp)

- ✅ `pnpm format`
- ✅ `pnpm lint`
- ✅ `pnpm knip`
- ✅ `pnpm build` (50/50 tasks)
- ✅ `pnpm test run` (169 files, 925 tests)
- ✅ `sanity build` → `rg "height:40rem" dist/static/*.css` (before: missing, after: present)
- ✅ Child-process repro against pristine pkg-utils source fails; passes with the source fix; plugin's own suite 15/15 green
- ✅ Manual GUI test of the picker dialog in production preview (`sanity start`) and `sanity dev`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-336c276d-01c5-4228-81e9-4ef18f225734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-336c276d-01c5-4228-81e9-4ef18f225734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

