### PR TITLE
fix(assist): respect document language for image descriptions

### DIFF
--- a/.changeset/assist-image-description-language.md
+++ b/.changeset/assist-image-description-language.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Use `translate.document.languageField` when generating image descriptions so captions match the document language

--- a/plugins/@sanity/assist/README.md
+++ b/plugins/@sanity/assist/README.md
@@ -392,6 +392,10 @@ This will add a **Generate image description** action to the configured field.
 The **Generate image description** action will automatically run whenever the image changes.
 `imageDescriptionField` can be a nested field, if the image has an object field, i.e. `imageDescriptionField: 'wrapper.altText'`.
 Fields within array items are not supported.
+
+When `translate.document.languageField` is configured, generated image descriptions use that
+document language field (the same path used for document translations) instead of defaulting to English.
+
 By default, the caption field will regenerate whenever the image asset changes. To disable this behavior use the following configuration:
 
 ```ts
@@ -478,6 +482,7 @@ AI Assist allows editors to translate these documents into the desired language 
 ### Configure document translations
 To enable full document translations, set `translate.document.languageField` to the path of the language field in your documents.
 All documents with a corresponding language field will get a "Translate document" instruction added to the AI Assist drop-down for the document.
+The same `languageField` is also used when generating image descriptions, so captions are written in the document language.
 To further limit which document types should be enabled for translation instructions, provide an array of document type names to `translate.document.documentTypes`.
 If the studio is using [@sanity/document-internationalization](https://github.com/sanity-io/document-internationalization), these options should be the same as those used for that plugin.
 **Example configs**

--- a/plugins/@sanity/assist/src/translate/types.ts
+++ b/plugins/@sanity/assist/src/translate/types.ts
@@ -149,6 +149,9 @@ export interface DocumentTranslationConfig {
    * For projects that use the `@sanity/document-internationalization` plugin,
    * this should be the same as `languageField` config for that plugin.
    *
+   * Also used when generating image descriptions (`options.aiAssist.imageDescriptionField`)
+   * so captions match the document language instead of defaulting to English.
+   *
    * Default: 'language'
    */
   languageField: string

--- a/plugins/@sanity/assist/src/useApiClient.ts
+++ b/plugins/@sanity/assist/src/useApiClient.ts
@@ -126,6 +126,10 @@ export function useGenerateCaption(apiClient: SanityClient) {
   const user = useCurrentUser()
   const types = useSerializedTypes()
   const toast = useToast()
+  const {config} = useAiAssistanceConfig()
+  // When document translations are configured, use the same language field so
+  // generated image descriptions match the document language (not always English).
+  const languagePath = config.translate?.document?.languageField
 
   const generateCaption = useCallback(
     ({path, documentId}: {path: string; documentId: string}) => {
@@ -142,6 +146,7 @@ export function useGenerateCaption(apiClient: SanityClient) {
             documentId,
             types,
             userId: user?.id,
+            languagePath,
           },
         })
         .catch((e) => {
@@ -161,7 +166,7 @@ export function useGenerateCaption(apiClient: SanityClient) {
           }, 2000)
         })
     },
-    [setLoading, apiClient, toast, user, types],
+    [setLoading, apiClient, toast, user, types, languagePath],
   )
 
   return useMemo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1606

## Problem

Image description generation (`options.aiAssist.imageDescriptionField`) always produced English text, even when `translate.document.languageField` was configured for document translations. Editors writing alt text in their document language would see it overwritten in English after a few seconds.

## Fix

`useGenerateCaption` now sends `languagePath` from `translate.document.languageField` on the generate-caption API request — the same field path already used by document translate. Both automatic generation (on asset change) and the manual **Generate image description** action pick this up.

Docs/JSDoc updated to note that `languageField` also applies to image descriptions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e308c3a3-2755-4c93-af16-7ce39633d1a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e308c3a3-2755-4c93-af16-7ce39633d1a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

