### PR TITLE
chore(deps): bump @sanity/vanilla-extract-vite-plugin to ^0.2.4

### DIFF
--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -1,9 +1,6 @@
-import {readFile} from 'node:fs/promises'
-
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {DevTools} from '@vitejs/devtools'
 import {defineCliConfig} from 'sanity/cli'
-import type {Plugin} from 'vite'
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'ppsg7ml5'
 const dataset = process.env.SANITY_STUDIO_DATASET || 'plugins'
@@ -13,36 +10,6 @@ const appId = process.env.SANITY_STUDIO_APP_ID || 'bi1ktslqwmu1cawds5ce3jn6'
 // the DevTools dock in a running `sanity dev` server without restarting it.
 // Usage: `pnpm devtools:test-studio` from the repo root (see AGENTS.md).
 const isViteDevToolsEnabled = process.env.ENABLE_VITE_DEVTOOLS === 'true'
-
-/**
- * `@bynder/compact-view` ships `Styles.css.js` — a plain JS module exporting a CSS string, not a
- * vanilla-extract module — but its name matches vanilla-extract's `cssFileFilter`. When the
- * Bynder modal's lazy chunk is compiled on demand (`unstable_bundledDev`), the vanilla-extract
- * compiler's `fetchModule` for that file deadlocks and crashes `sanity dev`. Resolve the module
- * to an id the filter doesn't match so the vanilla-extract plugin leaves it alone. Only this
- * source-consuming studio needs the workaround — consumer studios pre-bundle the package.
- */
-function bynderStylesCssJsWorkaround(): Plugin {
-  const suffix = '.bynder-workaround.mjs'
-  return {
-    name: 'bynder-compact-view-styles-css-js-workaround',
-    enforce: 'pre',
-    resolveId: {
-      filter: {id: /Styles\.css\.js$/},
-      async handler(source, importer, options) {
-        if (!importer?.includes('@bynder/compact-view')) return null
-        const resolved = await this.resolve(source, importer, options)
-        return resolved ? resolved.id + suffix : null
-      },
-    },
-    load: {
-      filter: {id: /Styles\.css\.js\.bynder-workaround\.mjs$/},
-      handler(id) {
-        return readFile(id.slice(0, -suffix.length), 'utf8')
-      },
-    },
-  }
-}
 
 export default defineCliConfig({
   api: {projectId, dataset},
@@ -56,11 +23,7 @@ export default defineCliConfig({
   // for that session (confirmed fast, sub-10ms HMR with it unset).
   unstable_bundledDev: true,
   vite: {
-    plugins: [
-      bynderStylesCssJsWorkaround(),
-      vanillaExtractPlugin(),
-      ...(isViteDevToolsEnabled ? [DevTools()] : []),
-    ],
+    plugins: [vanillaExtractPlugin(), ...(isViteDevToolsEnabled ? [DevTools()] : [])],
     // `devtools: {}` makes `sanity build` emit a Rolldown build session that the DevTools dock can inspect
     build: isViteDevToolsEnabled ? {rolldownOptions: {devtools: {}}} : {},
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ catalogs:
       specifier: ^3.0.3
       version: 3.0.3
     '@sanity/vanilla-extract-vite-plugin':
-      specifier: ^0.2.2
-      version: 0.2.2
+      specifier: ^0.2.4
+      version: 0.2.4
     '@sanity/vision':
       specifier: ^6.5.0
       version: 6.5.0
@@ -318,7 +318,7 @@ importers:
         version: 3.3.5(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.2.2(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.4(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@sanity/vercel-protection-bypass':
         specifier: workspace:*
         version: link:../../plugins/@sanity/vercel-protection-bypass
@@ -1129,7 +1129,7 @@ importers:
         version: 0.19.3(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.9)(typescript@7.0.2)(vite@8.1.5)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.2.2(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.4(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@types/google.maps':
         specifier: ^3.65.2
         version: 3.65.2
@@ -1885,7 +1885,7 @@ importers:
         version: 0.19.3(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.9)(typescript@7.0.2)(vite@8.1.5)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
-        version: 0.2.2(babel-plugin-macros@3.1.0)(vite@8.1.5)
+        version: 0.2.4(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -6224,6 +6224,10 @@ packages:
     resolution: {integrity: sha512-RPe+pLH9P5OYqlnvybLD+zRUXyzILlYtN0RyNAvUEL3+XmaA68YlsvxtljQBBxcwVeCl6kRN4V2G7aVH9MOD3g==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@sanity/vanilla-extract-integration@0.1.4':
+    resolution: {integrity: sha512-ko5t+GgyLmF+lG0dWFwAbU5w+OJ8QTVF6D/AEwPCgPh31CN8Ok3sk7Og0UY+QcX+qb3O/Fj98Be6UYVD9UxoGQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
   '@sanity/vanilla-extract-rolldown-plugin@0.2.2':
     resolution: {integrity: sha512-Ej9KDlwsB88n1y9fdX35cM7JR8VTepk63t/6GYTzai2l/J5zGuLyr2oIv81ZjlCT37IG//m16uQcZo6+20bbEQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -6239,8 +6243,8 @@ packages:
     peerDependencies:
       tsdown: ^0.22.5
 
-  '@sanity/vanilla-extract-vite-plugin@0.2.2':
-    resolution: {integrity: sha512-M6EQYqVnCKxp8stgruiHgwI2cA78Rw9cXn7U238o4NtIkvx9oZ/cRF0IGM1ngbUysRGw/d3G7dtTDtAy2w5ONg==}
+  '@sanity/vanilla-extract-vite-plugin@0.2.4':
+    resolution: {integrity: sha512-V4HO9fPsF5blnVIlKahFa1k4MNT+ejpybNMfky+pnq0RuKp05cNwB37QW2tT1VKKa0487aThAfS+xIc5iii+jQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       vite: ^8.0.0
@@ -15117,6 +15121,15 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
+  '@sanity/vanilla-extract-integration@0.1.4(babel-plugin-macros@3.1.0)':
+    dependencies:
+      '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
+      javascript-stringify: 2.1.0
+      rolldown: 1.2.0
+      yuku-parser: 0.6.5
+    transitivePeerDependencies:
+      - babel-plugin-macros
+
   '@sanity/vanilla-extract-rolldown-plugin@0.2.2(babel-plugin-macros@3.1.0)(rolldown@1.2.0)':
     dependencies:
       '@sanity/vanilla-extract-integration': 0.1.2(babel-plugin-macros@3.1.0)
@@ -15134,9 +15147,9 @@ snapshots:
       - babel-plugin-macros
       - rolldown
 
-  '@sanity/vanilla-extract-vite-plugin@0.2.2(babel-plugin-macros@3.1.0)(vite@8.1.5)':
+  '@sanity/vanilla-extract-vite-plugin@0.2.4(babel-plugin-macros@3.1.0)(vite@8.1.5)':
     dependencies:
-      '@sanity/vanilla-extract-integration': 0.1.2(babel-plugin-macros@3.1.0)
+      '@sanity/vanilla-extract-integration': 0.1.4(babel-plugin-macros@3.1.0)
       '@vanilla-extract/css': 1.21.1(babel-plugin-macros@3.1.0)
       vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   '@sanity/ui': ^3.3.5
   '@sanity/util': ^6.5.0
   '@sanity/uuid': ^3.0.3
-  '@sanity/vanilla-extract-vite-plugin': ^0.2.2
+  '@sanity/vanilla-extract-vite-plugin': ^0.2.4
   '@sanity/vision': ^6.5.0
   '@testing-library/jest-dom': ^6.9.1
   '@testing-library/react': ^16.3.2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump `@sanity/vanilla-extract-vite-plugin` in the workspace catalog from `^0.2.2` to `^0.2.4`.
- Remove the test-studio Vite workaround that remapped `@bynder/compact-view`'s plain `Styles.css.js` module so vanilla-extract would not try to compile it under `unstable_bundledDev`.

`@sanity/vanilla-extract-vite-plugin@0.2.4` keeps the vanilla-extract compiler alive while Vite's experimental bundled-dev mode continues serving lazy chunks, so that hang (`Failed to compile lazy entry … transport invoke timed out`) no longer happens for non-vanilla-extract `*.css.js` modules. See [pkg-utils#3085](https://github.com/sanity-io/pkg-utils/pull/3085) / the 0.2.4 changelog.

## Test plan

- [x] `pnpm format`, `pnpm lint`, `pnpm knip`, `pnpm build`, `pnpm test` pass
- [x] `pnpm dev` with Bynder workspace: open a Bynder asset field and confirm Compact View modal loads without crashing the dev server
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7e38-3dca-7f9a-8de5-e05f0134c927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7e38-3dca-7f9a-8de5-e05f0134c927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

