### PR TITLE
chore(test-studio): use turbo transit for build cache invalidation

### DIFF
--- a/dev/test-studio/turbo.jsonc
+++ b/dev/test-studio/turbo.jsonc
@@ -2,10 +2,13 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "tasks": {
+    // Workspace plugins export ./src for monorepo consumption, so sanity build
+    // does not need their dist/. Use transit (not ^build) so Turbo still
+    // invalidates this cache when dependency source changes.
     // ENABLE_VITE_DEVTOOLS opts into Vite DevTools (see sanity.cli.ts); declaring it here
     // invalidates turbo-cached builds when it flips and passes it through in strict env mode
     "build": {
-      "dependsOn": [],
+      "dependsOn": ["transit"],
       "env": ["ENABLE_VITE_DEVTOOLS"],
     },
     "dev": {

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -16,6 +16,12 @@
       "dependsOn": ["^build"],
       "outputs": [".sanity/**", "dist/**"],
     },
+    // No-op graph edge: packages that read workspace source (not dist) can
+    // dependOn ["transit"] instead of ["^build"] to keep cache invalidation
+    // when deps change without waiting for their build tasks.
+    "transit": {
+      "dependsOn": ["^transit"],
+    },
     "dev": {
       "cache": false,
       "persistent": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1652: `test-studio` already skipped workspace `^build` via empty `dependsOn`, which is correct for `sanity build` (plugins export `./src` in the monorepo), but empty `dependsOn` also drops Turbo cache invalidation when dependency source changes.

This PR switches to the [transit node](https://turborepo.com/docs/crafting-your-repository/structuring-a-repository#building-libraries) pattern:

- Root `turbo.jsonc` defines a no-op `transit` task with `dependsOn: ["^transit"]`
- `dev/test-studio/turbo.jsonc` sets `build.dependsOn: ["transit"]` instead of `[]`

Verified with `turbo run build --filter=test-studio --dry-run`: only `test-studio#build` runs as a real build; workspace deps appear as `<NONEXISTENT>` transit tasks in the graph.

## Test plan

- [x] `pnpm turbo run build --filter=test-studio --dry-run` shows 1 `build` task + transit no-ops (no plugin `build`s)
- [ ] Optional: run `pnpm --filter=test-studio build` and confirm it succeeds without a prior monorepo `pnpm build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02b9e18d-93ce-44da-adbe-77cf5aefdae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02b9e18d-93ce-44da-adbe-77cf5aefdae9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

