### PR TITLE
fix(sanity-plugin-markdown): declare @sanity/client as a regular dependency

### DIFF
--- a/.changeset/markdown-regular-deps.md
+++ b/.changeset/markdown-regular-deps.md
@@ -2,4 +2,4 @@
 "sanity-plugin-markdown": patch
 ---
 
-Move `@sanity/client` and `rxjs` from inlined dependencies to regular dependencies
+Move `@sanity/client` from inlined/dev dependencies to a regular dependency

--- a/.changeset/markdown-regular-deps.md
+++ b/.changeset/markdown-regular-deps.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-markdown": patch
+---
+
+Move `@sanity/client` and `rxjs` from inlined dependencies to regular dependencies

--- a/plugins/sanity-plugin-markdown/package.json
+++ b/plugins/sanity-plugin-markdown/package.json
@@ -44,8 +44,7 @@
   "dependencies": {
     "@sanity/client": "catalog:",
     "@sanity/ui": "catalog:",
-    "react-simplemde-editor": "^5.2.0",
-    "rxjs": "catalog:"
+    "react-simplemde-editor": "^5.2.0"
   },
   "devDependencies": {
     "@sanity/tsconfig": "catalog:",

--- a/plugins/sanity-plugin-markdown/package.json
+++ b/plugins/sanity-plugin-markdown/package.json
@@ -42,11 +42,12 @@
     "prepack": "turbo run build"
   },
   "dependencies": {
+    "@sanity/client": "catalog:",
     "@sanity/ui": "catalog:",
-    "react-simplemde-editor": "^5.2.0"
+    "react-simplemde-editor": "^5.2.0",
+    "rxjs": "catalog:"
   },
   "devDependencies": {
-    "@sanity/client": "catalog:",
     "@sanity/tsconfig": "catalog:",
     "@sanity/tsdown-config": "catalog:",
     "@types/node": "catalog:",
@@ -66,9 +67,5 @@
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"
-  },
-  "inlinedDependencies": {
-    "@sanity/client": "7.23.2",
-    "rxjs": "7.8.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2552,9 +2552,6 @@ importers:
       react-simplemde-editor:
         specifier: ^5.2.0
         version: 5.2.0(easymde@2.21.0)(react-dom@19.2.7)(react@19.2.7)
-      rxjs:
-        specifier: 'catalog:'
-        version: 7.8.2
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2543,19 +2543,22 @@ importers:
 
   plugins/sanity-plugin-markdown:
     dependencies:
+      '@sanity/client':
+        specifier: 'catalog:'
+        version: 7.24.0
       '@sanity/ui':
         specifier: 'catalog:'
         version: 3.3.5(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-simplemde-editor:
         specifier: ^5.2.0
         version: 5.2.0(easymde@2.21.0)(react-dom@19.2.7)(react@19.2.7)
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
     devDependencies:
-      '@sanity/client':
-        specifier: 'catalog:'
-        version: 7.24.0
       '@sanity/tsconfig':
         specifier: 'catalog:'
         version: 2.2.1
@@ -13983,7 +13986,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@portabletext/editor@7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)':
+  '@portabletext/editor@7.10.8(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@portabletext/html': 1.1.1
       '@portabletext/keyboard-shortcuts': 2.1.3
@@ -14020,7 +14023,7 @@ snapshots:
 
   '@portabletext/plugin-character-pair-decorator@8.0.36(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 6.0.5(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -14028,12 +14031,12 @@ snapshots:
 
   '@portabletext/plugin-dnd@1.0.20(@portabletext/editor@7.10.8)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-input-rule@6.0.5(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.5)
       react: 19.2.7
       xstate: 5.32.5
@@ -14042,12 +14045,12 @@ snapshots:
 
   '@portabletext/plugin-list-index@1.0.20(@portabletext/editor@7.10.8)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-markdown-shortcuts@8.0.36(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-character-pair-decorator': 8.0.36(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 6.0.5(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -14056,17 +14059,17 @@ snapshots:
 
   '@portabletext/plugin-one-line@7.0.35(@portabletext/editor@7.10.8)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-paste-link@4.0.35(@portabletext/editor@7.10.8)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
 
   '@portabletext/plugin-typography@8.0.36(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/plugin-input-rule': 6.0.5(@portabletext/editor@7.10.8)(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     transitivePeerDependencies:
@@ -19404,7 +19407,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.20(@portabletext/editor@7.10.8)(react@19.2.7)
@@ -19551,7 +19554,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.20(@portabletext/editor@7.10.8)(react@19.2.7)
@@ -19698,7 +19701,7 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@19.2.7)
       '@isaacs/ttlcache': 1.4.1
       '@mux/mux-player-react': 3.13.0(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.7)(react@19.2.7)
-      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)(supports-color@8.1.1)
+      '@portabletext/editor': 7.10.8(@types/react@19.2.17)(react@19.2.7)
       '@portabletext/html': 1.1.1
       '@portabletext/patches': 2.0.5
       '@portabletext/plugin-dnd': 1.0.20(@portabletext/editor@7.10.8)(react@19.2.7)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves `@sanity/client` from `devDependencies` / `inlinedDependencies` to a regular `dependency` on `sanity-plugin-markdown`.

### Why
With `@sanity/client` only as a `devDependency`, tsdown inlines it into the published types/bundle and records both `@sanity/client` and transitive `rxjs` under `inlinedDependencies`. Declaring `@sanity/client` as a regular dependency externalizes it, so neither package is inlined.

### Note on `rxjs`
`rxjs` is not imported by this plugin. Adding it as a direct dependency fails `knip` (unused). Once `@sanity/client` is externalized, rebuilding no longer writes `rxjs` to `inlinedDependencies`, so a direct `rxjs` dependency is unnecessary.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-537cb157-12ad-4bda-9887-98b148341b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-537cb157-12ad-4bda-9887-98b148341b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

