### PR TITLE
refactor(color-input): migrate styling to vanilla-extract

### DIFF
--- a/.changeset/color-input-vanilla-extract.md
+++ b/.changeset/color-input-vanilla-extract.md
@@ -1,0 +1,5 @@
+---
+"@sanity/color-input": minor
+---
+
+Migrate styling from `styled-components` and inline `style` objects to vanilla-extract. The plugin no longer requires a `styled-components` peer dependency; styles ship via the `./bundle.css` export (auto-injected when importing the package).

--- a/plugins/@sanity/color-input/package.json
+++ b/plugins/@sanity/color-input/package.json
@@ -29,11 +29,25 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./bundle.css": {
+      "types": "./dist/bundle-css.d.ts",
+      "browser": "./dist/bundle.css",
+      "style": "./dist/bundle.css",
+      "node": "./dist/bundle-css.js",
+      "default": "./dist/bundle-css.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "exports": {
       ".": "./dist/index.js",
+      "./bundle.css": {
+        "types": "./dist/bundle-css.d.ts",
+        "browser": "./dist/bundle.css",
+        "style": "./dist/bundle.css",
+        "node": "./dist/bundle-css.js",
+        "default": "./dist/bundle-css.js"
+      },
       "./package.json": "./package.json"
     }
   },
@@ -44,26 +58,27 @@
   "dependencies": {
     "@sanity/icons": "catalog:",
     "@sanity/ui": "catalog:",
+    "@vanilla-extract/dynamic": "catalog:",
     "lodash-es": "catalog:",
     "tinycolor2": "^1.6.0"
   },
   "devDependencies": {
     "@sanity/tsconfig": "catalog:",
     "@sanity/tsdown-config": "catalog:",
+    "@sanity/vanilla-extract-vite-plugin": "catalog:",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/tinycolor2": "^1.4.6",
+    "@vanilla-extract/css": "catalog:",
     "babel-plugin-react-compiler": "catalog:",
     "react": "catalog:",
     "sanity": "catalog:",
-    "styled-components": "catalog:",
     "tsdown": "catalog:"
   },
   "peerDependencies": {
     "react": "catalog:peer",
-    "sanity": "catalog:peer",
-    "styled-components": "catalog:peer"
+    "sanity": "catalog:peer"
   },
   "engines": {
     "node": ">=20.19 <22 || >=22.12"

--- a/plugins/@sanity/color-input/src/ColorInput.css.ts
+++ b/plugins/@sanity/color-input/src/ColorInput.css.ts
@@ -20,13 +20,24 @@ export const sliderCard = style({
 export const alphaCard = style({
   position: 'relative',
   height: '10px',
-  background: '#fff',
+  selectors: {
+    // Doubled class doubles specificity so the white checkerboard base wins
+    // over Card's own `background-color` (same 0-1-0 specificity, but the
+    // styled-components rule is injected later and would win the tie).
+    '&&': {
+      background: '#fff',
+    },
+  },
 })
 
 export const previewCard = style({
   position: 'relative',
   minWidth: '4em',
-  background: '#fff',
+  selectors: {
+    '&&': {
+      background: '#fff',
+    },
+  },
 })
 
 export const colorBox = style({

--- a/plugins/@sanity/color-input/src/ColorInput.css.ts
+++ b/plugins/@sanity/color-input/src/ColorInput.css.ts
@@ -1,0 +1,50 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const widthVar = createVar()
+export const previewBackgroundVar = createVar()
+
+export const root = style({
+  width: widthVar,
+})
+
+export const saturationCard = style({
+  position: 'relative',
+  height: '5em',
+})
+
+export const sliderCard = style({
+  position: 'relative',
+  height: '10px',
+})
+
+export const alphaCard = style({
+  position: 'relative',
+  height: '10px',
+  background: '#fff',
+})
+
+export const previewCard = style({
+  position: 'relative',
+  minWidth: '4em',
+  background: '#fff',
+})
+
+export const colorBox = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: previewBackgroundVar,
+})
+
+export const readOnlyContainer = style({
+  marginTop: '6rem',
+  backgroundColor: 'var(--card-bg-color)',
+  position: 'relative',
+  width: '100%',
+})
+
+export const fieldsBox = style({
+  width: 200,
+})

--- a/plugins/@sanity/color-input/src/ColorInput.tsx
+++ b/plugins/@sanity/color-input/src/ColorInput.tsx
@@ -1,9 +1,9 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {TrashIcon} from '@sanity/icons/Trash'
 import {Box, Button, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
-import {startTransition, useOptimistic, useRef} from 'react'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {startTransition, useOptimistic, useRef, type ComponentProps} from 'react'
 import {type ObjectInputProps, set, setIfMissing, unset} from 'sanity'
-import {styled} from 'styled-components'
 
 import {ColorList} from './ColorList'
 import {ColorPickerFields} from './ColorPickerFields'
@@ -19,20 +19,32 @@ import {
 } from './react-color'
 import type {ColorSchemaType, ColorValue} from './types'
 
-const ColorBox = styled(Box)`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`
+import {
+  alphaCard,
+  colorBox,
+  fieldsBox,
+  previewBackgroundVar,
+  previewCard,
+  readOnlyContainer,
+  root,
+  saturationCard,
+  sliderCard,
+  widthVar,
+} from './ColorInput.css'
 
-const ReadOnlyContainer = styled(Flex)`
-  margin-top: 6rem;
-  background-color: var(--card-bg-color);
-  position: relative;
-  width: 100%;
-`
+function ColorBox({backgroundColor}: {backgroundColor: string}) {
+  return (
+    <Box className={colorBox} style={assignInlineVars({[previewBackgroundVar]: backgroundColor})} />
+  )
+}
+
+function ReadOnlyContainer(props: ComponentProps<typeof Flex>) {
+  return <Flex {...props} className={readOnlyContainer} />
+}
+
+function FieldsBox(props: ComponentProps<typeof Box>) {
+  return <Box {...props} className={fieldsBox} />
+}
 
 interface ColorPickerProps {
   width?: string
@@ -79,49 +91,30 @@ const ColorPicker = (props: ColorPickerProps) => {
   }
 
   return (
-    <div style={{width}}>
+    <div className={root} style={width ? assignInlineVars({[widthVar]: width}) : undefined}>
       <Card padding={1} border radius={1}>
         <Stack gap={2}>
           {!readOnly && (
             <>
-              <Card overflow="hidden" style={{position: 'relative', height: '5em'}}>
+              <Card overflow="hidden" className={saturationCard}>
                 <Saturation onChange={onChange} hsl={hsl} hsv={hsv} />
               </Card>
 
-              <Card
-                shadow={1}
-                radius={3}
-                overflow="hidden"
-                style={{position: 'relative', height: '10px'}}
-              >
+              <Card shadow={1} radius={3} overflow="hidden" className={sliderCard}>
                 <Hue hsl={hsl} onChange={!readOnly && onChange} />
               </Card>
 
               {!disableAlpha && (
-                <Card
-                  shadow={1}
-                  radius={3}
-                  overflow="hidden"
-                  style={{position: 'relative', height: '10px', background: '#fff'}}
-                >
+                <Card shadow={1} radius={3} overflow="hidden" className={alphaCard}>
                   <Alpha rgb={rgb} hsl={hsl} onChange={onChange} />
                 </Card>
               )}
             </>
           )}
           <Flex>
-            <Card
-              flex={1}
-              radius={2}
-              overflow="hidden"
-              style={{position: 'relative', minWidth: '4em', background: '#fff'}}
-            >
+            <Card flex={1} radius={2} overflow="hidden" className={previewCard}>
               <Checkboard size={8} white="transparent" grey="rgba(0,0,0,.08)" />
-              <ColorBox
-                style={{
-                  backgroundColor: `rgba(${rgb?.r},${rgb?.g},${rgb?.b},${rgb?.a})`,
-                }}
-              />
+              <ColorBox backgroundColor={`rgba(${rgb?.r},${rgb?.g},${rgb?.b},${rgb?.a})`} />
 
               {readOnly && (
                 <ReadOnlyContainer
@@ -152,7 +145,7 @@ const ColorPicker = (props: ColorPickerProps) => {
 
             {!readOnly && (
               <Flex align="flex-start" marginLeft={2}>
-                <Box style={{width: 200}}>
+                <FieldsBox>
                   <ColorPickerFields
                     rgb={rgb}
                     hsl={hsl}
@@ -160,7 +153,7 @@ const ColorPicker = (props: ColorPickerProps) => {
                     onChange={onChange}
                     disableAlpha={disableAlpha}
                   />
-                </Box>
+                </FieldsBox>
                 <Box marginLeft={2}>
                   <Button onClick={onUnset} title="Delete color" icon={TrashIcon} tone="critical" />
                 </Box>

--- a/plugins/@sanity/color-input/src/ColorList.css.ts
+++ b/plugins/@sanity/color-input/src/ColorList.css.ts
@@ -20,7 +20,6 @@ export const colorBoxContainer = style({
 export const colorBox = style({
   borderRadius: 'inherit',
   boxShadow: 'inset 0 0 0 1px var(--card-shadow-outline-color)',
-  content: "''",
   position: 'absolute',
   inset: 0,
   zIndex: 1,

--- a/plugins/@sanity/color-input/src/ColorList.css.ts
+++ b/plugins/@sanity/color-input/src/ColorList.css.ts
@@ -1,0 +1,28 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const swatchBackgroundVar = createVar()
+
+export const colorListWrap = style({
+  gap: '0.25em',
+})
+
+export const colorBoxContainer = style({
+  width: '2.1em',
+  height: '2.1em',
+  cursor: 'pointer',
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: '3px',
+  background:
+    "url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAADFJREFUOE9jZGBgEGHAD97gk2YcNYBhmIQBgWSAP52AwoAQwJvQRg1gACckQoC2gQgAIF8IscwEtKYAAAAASUVORK5CYII=') left center #fff",
+})
+
+export const colorBox = style({
+  borderRadius: 'inherit',
+  boxShadow: 'inset 0 0 0 1px var(--card-shadow-outline-color)',
+  content: "''",
+  position: 'absolute',
+  inset: 0,
+  zIndex: 1,
+  background: swatchBackgroundVar,
+})

--- a/plugins/@sanity/color-input/src/ColorList.tsx
+++ b/plugins/@sanity/color-input/src/ColorList.tsx
@@ -1,32 +1,25 @@
 import {Flex} from '@sanity/ui'
-import {styled} from 'styled-components'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import type {ComponentProps} from 'react'
 import tinycolor from 'tinycolor2'
 
 import type {Color, ColorChangeHandler} from './react-color'
 
-const ColorListWrap = styled(Flex)`
-  gap: 0.25em;
-`
+import {colorBox, colorBoxContainer, colorListWrap, swatchBackgroundVar} from './ColorList.css'
 
-const ColorBoxContainer = styled.div`
-  width: 2.1em;
-  height: 2.1em;
-  cursor: pointer;
-  position: relative;
-  overflow: hidden;
-  border-radius: 3px;
-  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAADFJREFUOE9jZGBgEGHAD97gk2YcNYBhmIQBgWSAP52AwoAQwJvQRg1gACckQoC2gQgAIF8IscwEtKYAAAAASUVORK5CYII=')
-    left center #fff;
-`
+function ColorListWrap(props: ComponentProps<typeof Flex>) {
+  return <Flex {...props} className={colorListWrap} />
+}
 
-const ColorBox = styled.div`
-  border-radius: inherit;
-  box-shadow: inset 0 0 0 1px var(--card-shadow-outline-color);
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-`
+function ColorBoxContainer(props: ComponentProps<'div'>) {
+  return <div {...props} className={colorBoxContainer} />
+}
+
+function ColorBox({backgroundColor}: {backgroundColor: string}) {
+  return (
+    <div className={colorBox} style={assignInlineVars({[swatchBackgroundVar]: backgroundColor})} />
+  )
+}
 
 interface ValidatedColor {
   key: string
@@ -67,7 +60,7 @@ export function ColorList({colors, onChange}: ColorListProps): React.JSX.Element
             onChange(color)
           }}
         >
-          <ColorBox style={{background: backgroundColor}} />
+          <ColorBox backgroundColor={backgroundColor} />
         </ColorBoxContainer>
       ))}
     </ColorListWrap>

--- a/plugins/@sanity/color-input/src/ColorPickerFields.tsx
+++ b/plugins/@sanity/color-input/src/ColorPickerFields.tsx
@@ -1,15 +1,24 @@
-import {Box, Flex, useTheme} from '@sanity/ui'
-import {useCallback, useMemo} from 'react'
+import {Box, Flex, useTheme_v2} from '@sanity/ui'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {useCallback} from 'react'
 
 import {
   type Color,
   type ColorChangeHandler,
   EditableInput,
-  type EditableInputStyles,
   type HSLColor,
   isValidHex,
   type RGBColor,
 } from './react-color'
+
+import {
+  inputBgVar,
+  inputBorderVar,
+  inputFgVar,
+  inputFontSizeVar,
+  labelFgVar,
+  labelFontSizeVar,
+} from './react-color/EditableInput.css'
 
 interface ColorPickerFieldsProps {
   rgb?: RGBColor
@@ -26,39 +35,10 @@ export const ColorPickerFields = ({
   hex,
   disableAlpha,
 }: ColorPickerFieldsProps): React.JSX.Element => {
-  const {sanity} = useTheme()
-
-  const inputStyles: EditableInputStyles = useMemo(
-    () => ({
-      input: {
-        width: '80%',
-        padding: '4px 10% 3px',
-        border: 'none',
-        // TODO: when upgrading to @sanity/ui@4 start using the new tokens
-        // oxlint-disable-next-line typescript/no-deprecated
-        boxShadow: `inset 0 0 0 1px ${sanity.color.input.default.enabled.border}`,
-        // oxlint-disable-next-line typescript/no-deprecated
-        color: sanity.color.input.default.enabled.fg,
-        // oxlint-disable-next-line typescript/no-deprecated
-        backgroundColor: sanity.color.input.default.enabled.bg,
-        // oxlint-disable-next-line typescript/no-deprecated
-        fontSize: sanity.fonts.text.sizes[0]?.fontSize,
-        textAlign: 'center',
-      },
-      label: {
-        display: 'block',
-        textAlign: 'center',
-        // oxlint-disable-next-line typescript/no-deprecated
-        fontSize: sanity.fonts.label.sizes[0]?.fontSize,
-        // oxlint-disable-next-line typescript/no-deprecated
-        color: sanity.color.base.fg,
-        paddingTop: '3px',
-        paddingBottom: '4px',
-        textTransform: 'capitalize',
-      },
-    }),
-    [sanity],
-  )
+  const {color, font} = useTheme_v2()
+  const inputEnabled = color.input.default.enabled
+  const textFontSize = font.text.sizes[0]?.fontSize
+  const labelFontSize = font.label.sizes[0]?.fontSize
 
   const handleChange: ColorChangeHandler<Record<string, string>> = useCallback(
     (data) => {
@@ -100,49 +80,31 @@ export const ColorPickerFields = ({
   )
 
   return (
-    <Flex>
+    <Flex
+      style={assignInlineVars({
+        [inputBorderVar]: inputEnabled.border,
+        [inputFgVar]: inputEnabled.fg,
+        [inputBgVar]: inputEnabled.bg,
+        [inputFontSizeVar]: textFontSize === undefined ? undefined : `${textFontSize}px`,
+        [labelFontSizeVar]: labelFontSize === undefined ? undefined : `${labelFontSize}px`,
+        [labelFgVar]: color.fg,
+      })}
+    >
       <Box flex={2} marginRight={1}>
-        <EditableInput
-          style={inputStyles}
-          label="hex"
-          value={hex?.replace('#', '')}
-          onChange={handleChange}
-        />
+        <EditableInput label="hex" value={hex?.replace('#', '')} onChange={handleChange} />
       </Box>
       <Box flex={1} marginRight={1}>
-        <EditableInput
-          style={inputStyles}
-          label="r"
-          value={rgb?.r}
-          onChange={handleChange}
-          dragLabel
-          dragMax={255}
-        />
+        <EditableInput label="r" value={rgb?.r} onChange={handleChange} dragLabel dragMax={255} />
       </Box>
       <Box flex={1} marginRight={1}>
-        <EditableInput
-          style={inputStyles}
-          label="g"
-          value={rgb?.g}
-          onChange={handleChange}
-          dragLabel
-          dragMax={255}
-        />
+        <EditableInput label="g" value={rgb?.g} onChange={handleChange} dragLabel dragMax={255} />
       </Box>
       <Box flex={1} marginRight={1}>
-        <EditableInput
-          style={inputStyles}
-          label="b"
-          value={rgb?.b}
-          onChange={handleChange}
-          dragLabel
-          dragMax={255}
-        />
+        <EditableInput label="b" value={rgb?.b} onChange={handleChange} dragLabel dragMax={255} />
       </Box>
       {!disableAlpha && (
         <Box flex={1}>
           <EditableInput
-            style={inputStyles}
             label="a"
             value={Math.round((rgb?.a ?? 1) * 100)}
             onChange={handleChange}

--- a/plugins/@sanity/color-input/src/index.test.ts
+++ b/plugins/@sanity/color-input/src/index.test.ts
@@ -19,6 +19,7 @@ test('package exports', {timeout: 30_000}, async () => {
         "hsvaColor": "object",
         "rgbaColor": "object",
       },
+      "./bundle.css": {},
     }
   `)
 })

--- a/plugins/@sanity/color-input/src/react-color/Alpha.css.ts
+++ b/plugins/@sanity/color-input/src/react-color/Alpha.css.ts
@@ -1,0 +1,56 @@
+import {createVar, style, styleVariants} from '@vanilla-extract/css'
+
+export const radiusVar = createVar()
+export const shadowVar = createVar()
+export const gradientVar = createVar()
+export const pointerLeftVar = createVar()
+export const pointerTopVar = createVar()
+
+export const root = style({
+  position: 'absolute',
+  inset: 0,
+  borderRadius: radiusVar,
+})
+
+export const checkboardLayer = style({
+  position: 'absolute',
+  inset: 0,
+  overflow: 'hidden',
+  borderRadius: radiusVar,
+})
+
+export const gradientLayer = style({
+  position: 'absolute',
+  inset: 0,
+  background: gradientVar,
+  boxShadow: shadowVar,
+  borderRadius: radiusVar,
+})
+
+export const container = style({
+  position: 'relative',
+  height: '100%',
+  margin: '0 3px',
+})
+
+export const pointer = styleVariants({
+  horizontal: {
+    position: 'absolute',
+    left: pointerLeftVar,
+  },
+  vertical: {
+    position: 'absolute',
+    left: 0,
+    top: pointerTopVar,
+  },
+})
+
+export const pointerKnob = style({
+  width: '4px',
+  borderRadius: '1px',
+  height: '8px',
+  boxShadow: '0 0 2px rgba(0, 0, 0, .6)',
+  background: '#fff',
+  marginTop: '1px',
+  transform: 'translateX(-2px)',
+})

--- a/plugins/@sanity/color-input/src/react-color/Alpha.tsx
+++ b/plugins/@sanity/color-input/src/react-color/Alpha.tsx
@@ -5,7 +5,8 @@
  * {@link https://github.com/casesandberg/react-color/blob/v2.19.3/src/components/common/Alpha.js | react-color's Alpha}
  * (MIT, Copyright (c) 2015 Case Sandberg). See the plugin LICENSE.
  */
-import {useRef, type CSSProperties, type ReactElement} from 'react'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {useRef, type ReactElement} from 'react'
 
 import {Checkboard} from './Checkboard'
 import * as alpha from './helpers/alpha'
@@ -18,6 +19,20 @@ import type {
   PickerEvent,
   RGBColor,
 } from './types'
+
+import {
+  checkboardLayer,
+  container,
+  gradientLayer,
+  gradientVar,
+  pointer,
+  pointerKnob,
+  pointerLeftVar,
+  pointerTopVar,
+  radiusVar,
+  root,
+  shadowVar,
+} from './Alpha.css'
 
 export interface AlphaProps {
   rgb: RGBColor
@@ -43,11 +58,11 @@ export function Alpha({
   const containerRef = useRef<HTMLDivElement | null>(null)
 
   const handleChange = (event: PickerEvent) => {
-    const container = containerRef.current
-    if (!container) {
+    const containerEl = containerRef.current
+    if (!containerEl) {
       return
     }
-    const change = alpha.calculateChange(event, hsl, direction, a, container)
+    const change = alpha.calculateChange(event, hsl, direction, a, containerEl)
     if (change && typeof onChange === 'function') {
       onChange(change)
     }
@@ -66,43 +81,31 @@ export function Alpha({
     direction === 'vertical'
       ? `linear-gradient(to bottom, rgba(${rgb.r},${rgb.g},${rgb.b}, 0) 0%, rgba(${rgb.r},${rgb.g},${rgb.b}, 1) 100%)`
       : `linear-gradient(to right, rgba(${rgb.r},${rgb.g},${rgb.b}, 0) 0%, rgba(${rgb.r},${rgb.g},${rgb.b}, 1) 100%)`
-  const pointerStyle: CSSProperties =
-    direction === 'vertical'
-      ? {position: 'absolute', left: 0, top: `${alphaValue * 100}%`}
-      : {position: 'absolute', left: `${alphaValue * 100}%`}
+  const pointerDirection = direction === 'vertical' ? 'vertical' : 'horizontal'
 
   return (
-    <div style={{position: 'absolute', inset: 0, borderRadius: radius}}>
-      <div style={{position: 'absolute', inset: 0, overflow: 'hidden', borderRadius: radius}}>
+    <div
+      className={root}
+      style={assignInlineVars({
+        [radiusVar]: radius,
+        [shadowVar]: shadow,
+        [gradientVar]: gradient,
+        [pointerLeftVar]: pointerDirection === 'horizontal' ? `${alphaValue * 100}%` : undefined,
+        [pointerTopVar]: pointerDirection === 'vertical' ? `${alphaValue * 100}%` : undefined,
+      })}
+    >
+      <div className={checkboardLayer}>
         <Checkboard renderers={renderers} />
       </div>
+      <div className={gradientLayer} />
       <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          background: gradient,
-          boxShadow: shadow,
-          borderRadius: radius,
-        }}
-      />
-      <div
-        style={{position: 'relative', height: '100%', margin: '0 3px'}}
+        className={container}
         ref={containerRef}
         onTouchMove={handleChange}
         onTouchStart={handleChange}
       >
-        <div style={pointerStyle}>
-          <div
-            style={{
-              width: '4px',
-              borderRadius: '1px',
-              height: '8px',
-              boxShadow: '0 0 2px rgba(0, 0, 0, .6)',
-              background: '#fff',
-              marginTop: '1px',
-              transform: 'translateX(-2px)',
-            }}
-          />
+        <div className={pointer[pointerDirection]}>
+          <div className={pointerKnob} />
         </div>
       </div>
     </div>

--- a/plugins/@sanity/color-input/src/react-color/Checkboard.css.ts
+++ b/plugins/@sanity/color-input/src/react-color/Checkboard.css.ts
@@ -1,0 +1,13 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const borderRadiusVar = createVar()
+export const boxShadowVar = createVar()
+export const backgroundImageVar = createVar()
+
+export const checkboard = style({
+  borderRadius: borderRadiusVar,
+  boxShadow: boxShadowVar,
+  position: 'absolute',
+  inset: 0,
+  background: backgroundImageVar,
+})

--- a/plugins/@sanity/color-input/src/react-color/Checkboard.tsx
+++ b/plugins/@sanity/color-input/src/react-color/Checkboard.tsx
@@ -6,10 +6,13 @@
  * (MIT, Copyright (c) 2015 Case Sandberg). See the plugin LICENSE. The upstream
  * `children` cloning branch is dropped as it is unused here.
  */
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import type {ReactElement} from 'react'
 
-import * as checkboard from './helpers/checkboard'
+import * as checkboardHelper from './helpers/checkboard'
 import type {CheckboardRenderers, RenderersProps} from './types'
+
+import {backgroundImageVar, borderRadiusVar, boxShadowVar, checkboard} from './Checkboard.css'
 
 const EMPTY_RENDERERS: CheckboardRenderers = {}
 
@@ -29,16 +32,15 @@ export function Checkboard({
   borderRadius,
   boxShadow,
 }: CheckboardProps): ReactElement {
-  const background = checkboard.get(white, grey, size, renderers.canvas)
+  const background = checkboardHelper.get(white, grey, size, renderers.canvas)
   return (
     <div
-      style={{
-        borderRadius,
-        boxShadow,
-        position: 'absolute',
-        inset: 0,
-        background: background ? `url(${background}) center left` : undefined,
-      }}
+      className={checkboard}
+      style={assignInlineVars({
+        [borderRadiusVar]: borderRadius,
+        [boxShadowVar]: boxShadow,
+        [backgroundImageVar]: background ? `url(${background}) center left` : undefined,
+      })}
     />
   )
 }

--- a/plugins/@sanity/color-input/src/react-color/EditableInput.css.ts
+++ b/plugins/@sanity/color-input/src/react-color/EditableInput.css.ts
@@ -1,0 +1,37 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const inputBorderVar = createVar()
+export const inputFgVar = createVar()
+export const inputBgVar = createVar()
+export const inputFontSizeVar = createVar()
+export const labelFontSizeVar = createVar()
+export const labelFgVar = createVar()
+
+export const wrap = style({
+  position: 'relative',
+})
+
+export const input = style({
+  width: '80%',
+  padding: '4px 10% 3px',
+  border: 'none',
+  boxShadow: `inset 0 0 0 1px ${inputBorderVar}`,
+  color: inputFgVar,
+  backgroundColor: inputBgVar,
+  fontSize: inputFontSizeVar,
+  textAlign: 'center',
+})
+
+export const label = style({
+  display: 'block',
+  textAlign: 'center',
+  fontSize: labelFontSizeVar,
+  color: labelFgVar,
+  paddingTop: '3px',
+  paddingBottom: '4px',
+  textTransform: 'capitalize',
+})
+
+export const labelDrag = style({
+  cursor: 'ew-resize',
+})

--- a/plugins/@sanity/color-input/src/react-color/EditableInput.tsx
+++ b/plugins/@sanity/color-input/src/react-color/EditableInput.tsx
@@ -4,6 +4,10 @@
  * Forked from
  * {@link https://github.com/casesandberg/react-color/blob/v2.19.3/src/components/common/EditableInput.js | react-color's EditableInput}
  * (MIT, Copyright (c) 2015 Case Sandberg). See the plugin LICENSE.
+ *
+ * @remarks
+ * Theme-driven colors are applied via vanilla-extract CSS variables set by the
+ * parent (`ColorPickerFields`).
  */
 import {
   startTransition,
@@ -12,13 +16,13 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactElement,
 } from 'react'
 
 import {useDrag} from './helpers/useDrag'
-import type {EditableInputStyles} from './types'
+
+import {input, label as labelClass, labelDrag, wrap} from './EditableInput.css'
 
 const DEFAULT_ARROW_OFFSET = 1
 
@@ -35,7 +39,6 @@ type EditableInputEvent =
 export interface EditableInputProps {
   label: string
   value?: string | number | undefined
-  style?: EditableInputStyles | undefined
   arrowOffset?: number | undefined
   placeholder?: string | undefined
   hideLabel?: boolean | undefined
@@ -47,7 +50,6 @@ export interface EditableInputProps {
 export function EditableInput({
   label,
   value: valueProp,
-  style,
   arrowOffset,
   placeholder,
   hideLabel,
@@ -139,19 +141,11 @@ export function EditableInput({
     onDrag: handleDrag,
   })
 
-  const resolvedStyle = style ?? {}
-  const wrapStyle: CSSProperties = {position: 'relative', ...resolvedStyle.wrap}
-  const inputStyle: CSSProperties = {...resolvedStyle.input}
-  const labelStyle: CSSProperties = {
-    ...resolvedStyle.label,
-    ...(dragLabel ? {cursor: 'ew-resize'} : null),
-  }
-
   return (
-    <div style={wrapStyle}>
+    <div className={wrap}>
       <input
         id={inputId}
-        style={inputStyle}
+        className={input}
         ref={inputRef}
         value={inputValue}
         onKeyDown={handleKeyDown}
@@ -161,7 +155,11 @@ export function EditableInput({
         spellCheck="false"
       />
       {showLabel ? (
-        <label htmlFor={inputId} ref={labelRef} style={labelStyle}>
+        <label
+          htmlFor={inputId}
+          ref={labelRef}
+          className={dragLabel ? `${labelClass} ${labelDrag}` : labelClass}
+        >
           {label}
         </label>
       ) : null}

--- a/plugins/@sanity/color-input/src/react-color/Hue.css.ts
+++ b/plugins/@sanity/color-input/src/react-color/Hue.css.ts
@@ -1,0 +1,54 @@
+import {createVar, style, styleVariants} from '@vanilla-extract/css'
+
+export const radiusVar = createVar()
+export const shadowVar = createVar()
+export const pointerLeftVar = createVar()
+export const pointerTopVar = createVar()
+
+export const root = style({
+  position: 'absolute',
+  inset: 0,
+  borderRadius: radiusVar,
+  boxShadow: shadowVar,
+})
+
+export const gradient = styleVariants({
+  horizontal: {
+    background:
+      'linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)',
+    padding: '0 2px',
+    position: 'relative',
+    height: '100%',
+    borderRadius: radiusVar,
+  },
+  vertical: {
+    background:
+      'linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)',
+    padding: '0 2px',
+    position: 'relative',
+    height: '100%',
+    borderRadius: radiusVar,
+  },
+})
+
+export const pointer = styleVariants({
+  horizontal: {
+    position: 'absolute',
+    left: pointerLeftVar,
+  },
+  vertical: {
+    position: 'absolute',
+    left: '0px',
+    top: pointerTopVar,
+  },
+})
+
+export const pointerKnob = style({
+  marginTop: '1px',
+  width: '4px',
+  borderRadius: '1px',
+  height: '8px',
+  boxShadow: '0 0 2px rgba(0, 0, 0, .6)',
+  background: '#fff',
+  transform: 'translateX(-2px)',
+})

--- a/plugins/@sanity/color-input/src/react-color/Hue.tsx
+++ b/plugins/@sanity/color-input/src/react-color/Hue.tsx
@@ -5,19 +5,23 @@
  * {@link https://github.com/casesandberg/react-color/blob/v2.19.3/src/components/common/Hue.js | react-color's Hue}
  * (MIT, Copyright (c) 2015 Case Sandberg). See the plugin LICENSE.
  */
-import {useRef, type CSSProperties, type ReactElement} from 'react'
-import {styled} from 'styled-components'
+import {assignInlineVars} from '@vanilla-extract/dynamic'
+import {useRef, type ReactElement} from 'react'
 
 import * as hue from './helpers/hue'
 import {useDrag} from './helpers/useDrag'
 import type {ColorChangeHandler, HSLColor, HueColorResult, PickerEvent} from './types'
 
-const HueGradient = styled.div<{$direction: 'horizontal' | 'vertical'}>`
-  background: ${({$direction}) =>
-    $direction === 'vertical'
-      ? 'linear-gradient(to top, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)'
-      : 'linear-gradient(to right, #f00 0%, #ff0 17%, #0f0 33%, #0ff 50%, #00f 67%, #f0f 83%, #f00 100%)'};
-`
+import {
+  gradient,
+  pointer,
+  pointerKnob,
+  pointerLeftVar,
+  pointerTopVar,
+  radiusVar,
+  root,
+  shadowVar,
+} from './Hue.css'
 
 export interface HueProps {
   hsl: HSLColor
@@ -55,34 +59,29 @@ export function Hue({
     onDrag: handleChange,
   })
 
-  const pointerStyle: CSSProperties =
-    direction === 'vertical'
-      ? {position: 'absolute', left: '0px', top: `${-((hsl.h * 100) / 360) + 100}%`}
-      : {position: 'absolute', left: `${(hsl.h * 100) / 360}%`}
+  const pointerDirection = direction === 'vertical' ? 'vertical' : 'horizontal'
 
   return (
-    <div style={{position: 'absolute', inset: 0, borderRadius: radius, boxShadow: shadow}}>
-      <HueGradient
-        $direction={direction}
-        style={{padding: '0 2px', position: 'relative', height: '100%', borderRadius: radius}}
+    <div
+      className={root}
+      style={assignInlineVars({
+        [radiusVar]: radius,
+        [shadowVar]: shadow,
+        [pointerLeftVar]: pointerDirection === 'horizontal' ? `${(hsl.h * 100) / 360}%` : undefined,
+        [pointerTopVar]:
+          pointerDirection === 'vertical' ? `${-((hsl.h * 100) / 360) + 100}%` : undefined,
+      })}
+    >
+      <div
+        className={gradient[pointerDirection]}
         ref={containerRef}
         onTouchMove={handleChange}
         onTouchStart={handleChange}
       >
-        <div style={pointerStyle}>
-          <div
-            style={{
-              marginTop: '1px',
-              width: '4px',
-              borderRadius: '1px',
-              height: '8px',
-              boxShadow: '0 0 2px rgba(0, 0, 0, .6)',
-              background: '#fff',
-              transform: 'translateX(-2px)',
-            }}
-          />
+        <div className={pointer[pointerDirection]}>
+          <div className={pointerKnob} />
         </div>
-      </HueGradient>
+      </div>
     </div>
   )
 }

--- a/plugins/@sanity/color-input/src/react-color/Saturation.css.ts
+++ b/plugins/@sanity/color-input/src/react-color/Saturation.css.ts
@@ -1,0 +1,45 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const radiusVar = createVar()
+export const shadowVar = createVar()
+export const hueBackgroundVar = createVar()
+export const pointerTopVar = createVar()
+export const pointerLeftVar = createVar()
+
+export const root = style({
+  position: 'absolute',
+  inset: 0,
+  background: hueBackgroundVar,
+  borderRadius: radiusVar,
+})
+
+export const white = style({
+  position: 'absolute',
+  inset: 0,
+  borderRadius: radiusVar,
+  background: 'linear-gradient(to right, #fff, rgba(255, 255, 255, 0))',
+})
+
+export const black = style({
+  position: 'absolute',
+  inset: 0,
+  boxShadow: shadowVar,
+  borderRadius: radiusVar,
+  background: 'linear-gradient(to top, #000, rgba(0, 0, 0, 0))',
+})
+
+export const pointer = style({
+  position: 'absolute',
+  top: pointerTopVar,
+  left: pointerLeftVar,
+  cursor: 'default',
+})
+
+export const pointerKnob = style({
+  width: '4px',
+  height: '4px',
+  boxShadow: '0 0 0 1.5px #fff, inset 0 0 1px 1px rgba(0,0,0,.3), 0 0 1px 2px rgba(0,0,0,.4)',
+  borderRadius: '50%',
+  cursor: 'pointer',
+  transform: 'translate(-2px, -2px)',
+})

--- a/plugins/@sanity/color-input/src/react-color/Saturation.tsx
+++ b/plugins/@sanity/color-input/src/react-color/Saturation.tsx
@@ -5,9 +5,9 @@
  * {@link https://github.com/casesandberg/react-color/blob/v2.19.3/src/components/common/Saturation.js | react-color's Saturation}
  * (MIT, Copyright (c) 2015 Case Sandberg). See the plugin LICENSE.
  */
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import throttle from 'lodash-es/throttle'
-import {useEffect, useMemo, useRef, type CSSProperties, type ReactElement} from 'react'
-import {styled} from 'styled-components'
+import {useEffect, useMemo, useRef, type ReactElement} from 'react'
 
 import * as saturation from './helpers/saturation'
 import {useDrag} from './helpers/useDrag'
@@ -19,19 +19,24 @@ import type {
   SaturationColorResult,
 } from './types'
 
+import {
+  black,
+  hueBackgroundVar,
+  pointer,
+  pointerKnob,
+  pointerLeftVar,
+  pointerTopVar,
+  radiusVar,
+  root,
+  shadowVar,
+  white,
+} from './Saturation.css'
+
 type ThrottledChange = ReturnType<
   typeof throttle<
     (handler: ColorChangeHandler<SaturationColorResult>, data: SaturationColorResult) => void
   >
 >
-
-const SaturationWhite = styled.div`
-  background: linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
-`
-
-const SaturationBlack = styled.div`
-  background: linear-gradient(to top, #000, rgba(0, 0, 0, 0));
-`
 
 export interface SaturationProps {
   hsl: HSLColor
@@ -89,43 +94,26 @@ export function Saturation({hsl, hsv, radius, shadow, onChange}: SaturationProps
     },
   })
 
-  const pointerStyle: CSSProperties = {
-    position: 'absolute',
-    top: `${-(hsv.v * 100) + 100}%`,
-    left: `${hsv.s * 100}%`,
-    cursor: 'default',
-  }
-
   return (
     <div
-      style={{
-        position: 'absolute',
-        inset: 0,
-        background: `hsl(${hsl.h},100%, 50%)`,
-        borderRadius: radius,
-      }}
+      className={root}
+      style={assignInlineVars({
+        [hueBackgroundVar]: `hsl(${hsl.h},100%, 50%)`,
+        [radiusVar]: radius,
+        [shadowVar]: shadow,
+        [pointerTopVar]: `${-(hsv.v * 100) + 100}%`,
+        [pointerLeftVar]: `${hsv.s * 100}%`,
+      })}
       ref={containerRef}
       onTouchMove={handleChange}
       onTouchStart={handleChange}
     >
-      <SaturationWhite style={{position: 'absolute', inset: 0, borderRadius: radius}}>
-        <SaturationBlack
-          style={{position: 'absolute', inset: 0, boxShadow: shadow, borderRadius: radius}}
-        />
-        <div style={pointerStyle}>
-          <div
-            style={{
-              width: '4px',
-              height: '4px',
-              boxShadow:
-                '0 0 0 1.5px #fff, inset 0 0 1px 1px rgba(0,0,0,.3), 0 0 1px 2px rgba(0,0,0,.4)',
-              borderRadius: '50%',
-              cursor: 'pointer',
-              transform: 'translate(-2px, -2px)',
-            }}
-          />
+      <div className={white}>
+        <div className={black} />
+        <div className={pointer}>
+          <div className={pointerKnob} />
         </div>
-      </SaturationWhite>
+      </div>
     </div>
   )
 }

--- a/plugins/@sanity/color-input/src/react-color/index.ts
+++ b/plugins/@sanity/color-input/src/react-color/index.ts
@@ -8,17 +8,28 @@
  * blocks and the color-state helpers are vendored.
  */
 export {Alpha} from './Alpha'
+export type {AlphaProps} from './Alpha'
 export {Checkboard} from './Checkboard'
+export type {CheckboardProps} from './Checkboard'
 export {EditableInput} from './EditableInput'
+export type {EditableInputProps} from './EditableInput'
 export {isValidHex, simpleCheckForValidColor, toState} from './helpers/color'
 export {Hue} from './Hue'
+export type {HueProps} from './Hue'
 export {Saturation} from './Saturation'
+export type {SaturationProps} from './Saturation'
 export type {
+  AlphaColorResult,
+  CheckboardRenderers,
   Color,
   ColorChangeHandler,
   ColorState,
-  EditableInputStyles,
+  HEXColor,
   HSLColor,
   HSVColor,
+  HueColorResult,
+  PickerEvent,
+  RenderersProps,
   RGBColor,
+  SaturationColorResult,
 } from './types'

--- a/plugins/@sanity/color-input/src/react-color/index.ts
+++ b/plugins/@sanity/color-input/src/react-color/index.ts
@@ -8,28 +8,9 @@
  * blocks and the color-state helpers are vendored.
  */
 export {Alpha} from './Alpha'
-export type {AlphaProps} from './Alpha'
 export {Checkboard} from './Checkboard'
-export type {CheckboardProps} from './Checkboard'
 export {EditableInput} from './EditableInput'
-export type {EditableInputProps} from './EditableInput'
 export {isValidHex, simpleCheckForValidColor, toState} from './helpers/color'
 export {Hue} from './Hue'
-export type {HueProps} from './Hue'
 export {Saturation} from './Saturation'
-export type {SaturationProps} from './Saturation'
-export type {
-  AlphaColorResult,
-  CheckboardRenderers,
-  Color,
-  ColorChangeHandler,
-  ColorState,
-  HEXColor,
-  HSLColor,
-  HSVColor,
-  HueColorResult,
-  PickerEvent,
-  RenderersProps,
-  RGBColor,
-  SaturationColorResult,
-} from './types'
+export type {Color, ColorChangeHandler, ColorState, HSLColor, HSVColor, RGBColor} from './types'

--- a/plugins/@sanity/color-input/src/react-color/types.ts
+++ b/plugins/@sanity/color-input/src/react-color/types.ts
@@ -7,11 +7,7 @@
  * ({@link https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-color | @types/react-color}).
  * MIT, Copyright (c) 2015 Case Sandberg. See the plugin LICENSE.
  */
-import type {
-  CSSProperties,
-  MouseEvent as ReactMouseEvent,
-  TouchEvent as ReactTouchEvent,
-} from 'react'
+import type {MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent} from 'react'
 
 export interface HEXColor {
   hex: string
@@ -62,12 +58,6 @@ export interface CheckboardRenderers {
 
 export interface RenderersProps {
   renderers?: CheckboardRenderers | undefined
-}
-
-export interface EditableInputStyles {
-  input?: CSSProperties | undefined
-  label?: CSSProperties | undefined
-  wrap?: CSSProperties | undefined
 }
 
 export interface SaturationColorResult extends HSVColor {

--- a/plugins/@sanity/color-input/src/schemas/color.tsx
+++ b/plugins/@sanity/color-input/src/schemas/color.tsx
@@ -1,7 +1,10 @@
+import {assignInlineVars} from '@vanilla-extract/dynamic'
 import {defineType, type ObjectDefinition} from 'sanity'
 
 import {ColorInput} from '../LazyColorInput'
 import {type ColorOptions} from '../types'
+
+import {backgroundColorVar, colorPreview, opacityVar} from './colorPreview.css'
 
 const round = (val: number = 1) => Math.round(val * 100)
 
@@ -20,6 +23,18 @@ declare module 'sanity' {
   export interface IntrinsicDefinitions {
     color: ColorDefinition
   }
+}
+
+function ColorPreviewMedia({hex, alpha}: {hex?: string; alpha?: number}) {
+  return (
+    <div
+      className={colorPreview}
+      style={assignInlineVars({
+        [backgroundColorVar]: hex ?? '#000',
+        [opacityVar]: String(alpha ?? 1),
+      })}
+    />
+  )
 }
 
 export const color = defineType({
@@ -79,19 +94,7 @@ export const color = defineType({
       return {
         title: title,
         subtitle: subtitle,
-        media: () => (
-          <div
-            style={{
-              backgroundColor: hex ?? '#000',
-              opacity: alpha ?? 1,
-              position: 'absolute',
-              height: '100%',
-              width: '100%',
-              top: '0',
-              left: '0',
-            }}
-          />
-        ),
+        media: () => <ColorPreviewMedia hex={hex} alpha={alpha} />,
       }
     },
   },

--- a/plugins/@sanity/color-input/src/schemas/colorPreview.css.ts
+++ b/plugins/@sanity/color-input/src/schemas/colorPreview.css.ts
@@ -1,0 +1,14 @@
+import {createVar, style} from '@vanilla-extract/css'
+
+export const backgroundColorVar = createVar()
+export const opacityVar = createVar()
+
+export const colorPreview = style({
+  backgroundColor: backgroundColorVar,
+  opacity: opacityVar,
+  position: 'absolute',
+  height: '100%',
+  width: '100%',
+  top: 0,
+  left: 0,
+})

--- a/plugins/@sanity/color-input/tsdown.config.ts
+++ b/plugins/@sanity/color-input/tsdown.config.ts
@@ -2,6 +2,6 @@ import {defineConfig} from '@sanity/tsdown-config'
 import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
-  styledComponents: true,
   reactCompiler: true,
+  vanillaExtract: true,
 }) satisfies Promise<UserConfig>

--- a/plugins/@sanity/color-input/vitest.config.ts
+++ b/plugins/@sanity/color-input/vitest.config.ts
@@ -1,6 +1,8 @@
+import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  plugins: [vanillaExtractPlugin()],
   test: {
     server: {
       deps: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ catalogs:
     '@vanilla-extract/css':
       specifier: ^1.21.2
       version: 1.21.2
+    '@vanilla-extract/dynamic':
+      specifier: ^2.1.5
+      version: 2.1.5
     '@vis.gl/react-google-maps':
       specifier: ^1.9.0
       version: 1.9.0
@@ -792,6 +795,9 @@ importers:
       '@sanity/ui':
         specifier: 'catalog:'
         version: 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
+      '@vanilla-extract/dynamic':
+        specifier: 'catalog:'
+        version: 2.1.5
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -805,6 +811,9 @@ importers:
       '@sanity/tsdown-config':
         specifier: 'catalog:'
         version: 0.21.2(@babel/runtime@7.29.7)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(rolldown@1.2.0)(tsdown@0.22.14)(typescript@7.0.2)(vite@8.1.5)
+      '@sanity/vanilla-extract-vite-plugin':
+        specifier: 'catalog:'
+        version: 0.2.8(babel-plugin-macros@3.1.0)(vite@8.1.5)
       '@types/lodash-es':
         specifier: 'catalog:'
         version: 4.17.12
@@ -817,6 +826,9 @@ importers:
       '@types/tinycolor2':
         specifier: ^1.4.6
         version: 1.4.6
+      '@vanilla-extract/css':
+        specifier: 'catalog:'
+        version: 1.21.2(babel-plugin-macros@3.1.0)
       babel-plugin-react-compiler:
         specifier: 'catalog:'
         version: 1.0.0
@@ -826,9 +838,6 @@ importers:
       sanity:
         specifier: ^6.6.0
         version: 6.6.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.15)(jiti@2.7.0)(oxfmt@0.60.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(terser@5.49.0)(typescript@7.0.2)
-      styled-components:
-        specifier: 'catalog:'
-        version: 6.4.4(react-dom@19.2.8)(react@19.2.8)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.14(@vitejs/devtools@0.4.9)(oxc-resolver@11.24.2)(publint@0.3.22)(tsx@4.23.1)(typescript@7.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalog:
   '@types/react-is': ^19.2.0
   '@types/video.js': ^7.3.58
   '@vanilla-extract/css': ^1.21.2
+  '@vanilla-extract/dynamic': ^2.1.5
   '@vis.gl/react-google-maps': ^1.9.0
   '@vitest/coverage-v8': ^4.1.10
   babel-plugin-react-compiler: ^1.0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates `@sanity/color-input` from `styled-components` + inline `style` objects to **vanilla-extract**, stacked on top of #1362 (ban React class components / function-component + `useDrag` pickers).

### Stack

```
main
 └── cursor/ban-react-class-components-ca2a  (#1362)
      └── cursor/color-input-vanilla-extract-35df  (#1670)  ← this PR
```

**Base branch:** `cursor/ban-react-class-components-ca2a` (not `main`). Merge only after #1362 lands, or keep stacked.

### Changes

- Colocated `.css.ts` modules with `style` / `styleVariants` / `createVar`
- Dynamic values via `assignInlineVars` from `@vanilla-extract/dynamic`
- Theme tokens via `useTheme_v2()` where needed
- Removed `styled-components` peer/devDependency from the package
- Enabled `vanillaExtract: true` in `tsdown.config.ts`; Vite plugin in `vitest.config.ts`
- Added `./bundle.css` export; CSS auto-injected on package import
- Catalog entry for `@vanilla-extract/dynamic`
- Minor changeset

### Test plan

- [x] `pnpm --filter @sanity/color-input build` / vitest
- [x] Merge conflicts with ban branch resolved (kept VE over styled-components/inline styles)
- [ ] Manual studio check of saturation / hue / alpha / fields / presets
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2d13ea1-fe78-4331-aa6d-ea5d546935df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2d13ea1-fe78-4331-aa6d-ea5d546935df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

