### PR TITLE
fix(deps): update dependency @sanity/ui to ^3.4.3

### DIFF
--- a/.changeset/deps-sanity-ui-bump-3-4-3.md
+++ b/.changeset/deps-sanity-ui-bump-3-4-3.md
@@ -1,0 +1,46 @@
+---
+"@sanity/assist": patch
+"@sanity/block-insert-picker": patch
+"@sanity/code-input": patch
+"@sanity/color-input": patch
+"@sanity/cross-dataset-duplicator": patch
+"@sanity/dashboard": patch
+"@sanity/debug-live-sync-tags": patch
+"@sanity/document-internationalization": patch
+"@sanity/embeddings-index-ui": patch
+"@sanity/form-toolkit": patch
+"@sanity/google-maps-input": patch
+"@sanity/hierarchical-document-list": patch
+"@sanity/language-filter": patch
+"@sanity/orderable-document-list": patch
+"@sanity/personalization-plugin": patch
+"@sanity/rich-date-input": patch
+"@sanity/sanity-plugin-async-list": patch
+"@sanity/sfcc": patch
+"@sanity/studio-secrets": patch
+"@sanity/table": patch
+"@sanity/vercel-protection-bypass": patch
+"sanity-plugin-aprimo": patch
+"sanity-plugin-asset-source-unsplash": patch
+"sanity-plugin-bynder-input": patch
+"sanity-plugin-cloudinary": patch
+"sanity-plugin-dashboard-widget-document-list": patch
+"sanity-plugin-dashboard-widget-netlify": patch
+"sanity-plugin-dashboard-widget-vercel": patch
+"sanity-plugin-documents-pane": patch
+"sanity-plugin-google-translate": patch
+"sanity-plugin-graph-view": patch
+"sanity-plugin-hotspot-array": patch
+"sanity-plugin-iframe-pane": patch
+"sanity-plugin-internationalized-array": patch
+"sanity-plugin-markdown": patch
+"sanity-plugin-media": patch
+"sanity-plugin-mux-input": patch
+"sanity-plugin-shopify-assets": patch
+"sanity-plugin-utils": patch
+"sanity-plugin-workflow": patch
+"sanity-plugin-workspace-home": patch
+"sanity-translations-tab": patch
+---
+
+Update `@sanity/ui` dependency to ^3.4.3.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ catalogs:
       specifier: ^0.19.6
       version: 0.19.6
     '@sanity/ui':
-      specifier: ^3.4.0
-      version: 3.4.0
+      specifier: ^3.4.3
+      version: 3.4.3
     '@sanity/util':
       specifier: ^6.5.0
       version: 6.5.0
@@ -181,10 +181,6 @@ catalogs:
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
-  peer:
-    react:
-      specifier: ^19.2
-      version: 19.2.7
 
 overrides:
   '@types/node': ^24.13.3
@@ -315,7 +311,7 @@ importers:
         version: link:../../plugins/@sanity/table
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/vanilla-extract-vite-plugin':
         specifier: 'catalog:'
         version: 0.2.5(babel-plugin-macros@3.1.0)(vite@8.1.5)
@@ -563,7 +559,7 @@ importers:
         version: 6.5.0(@types/react@19.2.17)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       date-fns:
         specifier: 'catalog:'
         version: 4.4.0
@@ -630,7 +626,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
@@ -721,7 +717,7 @@ importers:
         version: 1.0.4
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@uiw/codemirror-themes':
         specifier: ^4.25.11
         version: 4.25.11(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
@@ -764,7 +760,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -822,7 +818,7 @@ importers:
         version: link:../studio-secrets
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       dset:
         specifier: ^3.1.4
         version: 3.1.4
@@ -871,7 +867,7 @@ importers:
         version: 2.1.1
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -914,7 +910,7 @@ importers:
         version: 7.24.0
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
@@ -991,7 +987,7 @@ importers:
         version: 6.5.0(@types/react@19.2.17)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -1058,7 +1054,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-rx:
         specifier: ^4.2.3
         version: 4.2.3(react@19.2.7)(rxjs@7.8.2)
@@ -1110,7 +1106,7 @@ importers:
         version: link:../sanity-plugin-async-list
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
       h3:
         specifier: ^1.15.11
         version: 1.15.11
@@ -1159,7 +1155,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@vis.gl/react-google-maps':
         specifier: 'catalog:'
         version: 1.9.0(react-dom@19.2.7)(react@19.2.7)
@@ -1220,7 +1216,7 @@ importers:
         version: 6.5.0(@types/react@19.2.17)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -1269,7 +1265,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-rx:
         specifier: 'catalog:'
         version: 4.2.3(react@19.2.7)(rxjs@7.8.2)
@@ -1333,7 +1329,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lexorank:
         specifier: 'catalog:'
         version: 1.0.5
@@ -1382,7 +1378,7 @@ importers:
         version: link:../studio-secrets
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
       '@sanity/uuid':
         specifier: 'catalog:'
         version: 3.0.3
@@ -1489,7 +1485,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       date-fns:
         specifier: 'catalog:'
         version: 4.4.0
@@ -1538,7 +1534,7 @@ importers:
         version: link:../studio-secrets
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -1584,7 +1580,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       sanity-plugin-internationalized-array:
         specifier: ^4.0.0 || ^5.0.0
         version: link:../../sanity-plugin-internationalized-array
@@ -1627,7 +1623,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-rx:
         specifier: 'catalog:'
         version: 4.2.3(react@19.2.7)(rxjs@7.8.2)
@@ -1685,7 +1681,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid':
         specifier: 'catalog:'
         version: 3.0.3
@@ -1734,7 +1730,7 @@ importers:
         version: 4.1.0(@sanity/client@7.24.0)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
     devDependencies:
       '@sanity/client':
         specifier: 'catalog:'
@@ -1829,7 +1825,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
     devDependencies:
       '@sanity/tsconfig':
         specifier: 'catalog:'
@@ -1866,7 +1862,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -1912,7 +1908,7 @@ importers:
         version: 5.4.0(react-dom@19.2.7)(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       video.js:
         specifier: 'catalog:'
         version: 7.21.7
@@ -1967,7 +1963,7 @@ importers:
         version: link:../@sanity/studio-secrets
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       nanoid:
         specifier: 'catalog:'
         version: 6.0.0
@@ -2007,7 +2003,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -2053,7 +2049,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
@@ -2102,7 +2098,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid':
         specifier: 'catalog:'
         version: 3.0.3
@@ -2175,7 +2171,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -2230,7 +2226,7 @@ importers:
     dependencies:
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       styled-components:
         specifier: npm:@sanity/styled-components@latest
         version: '@sanity/styled-components@6.1.24(react-dom@19.2.7)(react@19.2.7)'
@@ -2270,7 +2266,7 @@ importers:
         version: 3.0.6
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       bezier-easing:
         specifier: ^2.1.0
         version: 2.1.0
@@ -2328,7 +2324,7 @@ importers:
         version: 2.1.1
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -2386,7 +2382,7 @@ importers:
         version: 4.1.0(@sanity/client@7.24.0)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       motion:
         specifier: 'catalog:'
         version: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
@@ -2438,7 +2434,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -2536,7 +2532,7 @@ importers:
         version: 7.24.0
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-simplemde-editor:
         specifier: ^5.2.0
         version: 5.2.0(easymde@2.21.0)(react-dom@19.2.7)(react@19.2.7)
@@ -2591,7 +2587,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid':
         specifier: 'catalog:'
         version: 3.0.3
@@ -2718,7 +2714,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid':
         specifier: 'catalog:'
         version: 3.0.3
@@ -2806,7 +2802,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       axios:
         specifier: ^1.18.1
         version: 1.18.1(supports-color@8.1.1)
@@ -2950,7 +2946,7 @@ importers:
         version: 2.1.1
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-fast-compare:
         specifier: 'catalog:'
         version: 3.2.2
@@ -2999,7 +2995,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@tanstack/react-virtual':
         specifier: ^3.14.7
         version: 3.14.7(react-dom@19.2.7)(react@19.2.7)
@@ -3054,7 +3050,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       react-is:
         specifier: 'catalog:'
         version: 19.2.7
@@ -3103,7 +3099,7 @@ importers:
         version: 5.2.0(react@19.2.7)
       '@sanity/ui':
         specifier: 'catalog:'
-        version: 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+        version: 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util':
         specifier: 'catalog:'
         version: 6.5.0(@types/react@19.2.17)
@@ -6054,6 +6050,10 @@ packages:
     resolution: {integrity: sha512-2TjYEvOftD0v7ukx3Csdh9QIu44P2z7NDJtlC3qITJRYV36J7R6Vfd3trVhFnN77/7CZrGjqngrtohv8VqO5nw==}
     engines: {node: '>=18.0.0'}
 
+  '@sanity/color@3.0.7':
+    resolution: {integrity: sha512-cFy8VlD4yfosgyFI0zL+SSPvc0r8oLxw0EoykmT8AgUDqJoHan6rewva5RdQura+GDKZNJE4W16cbLeROmo3Ag==}
+    engines: {node: '>=18.0.0'}
+
   '@sanity/comlink@4.0.1':
     resolution: {integrity: sha512-vdGOd6sxNjqTo2H3Q3L2/Gepy+cDBiQ1mr9ck7c/A9o4NnmBLoDliifsNHIwgNwBUz37oH4+EIz/lIjNy8hSew==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -6091,6 +6091,12 @@ packages:
 
   '@sanity/icons@5.2.0':
     resolution: {integrity: sha512-Mu552fC2QljfHHy3dvPBJLol3HpQLr9RPAvJdfu9UloPoSaOT1dYTFUPbrDVpUUWtDZSRPvwvoPkiMSKUyeSvA==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@sanity/icons@5.2.1':
+    resolution: {integrity: sha512-P5gY1HRungh4RgCcypdIpu/SKoTwRBTttpbHntZjdW1MO3MK6xEOs+pbAzSARyhh22OcN9PkBBEYk2FL34BvfQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^18 || ^19
@@ -6242,8 +6248,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
 
-  '@sanity/ui@3.4.0':
-    resolution: {integrity: sha512-Fn9+sRUHsOsGELU34l9XZ/MeGaPAvm0uV48/Qd7GpRQY/lDmEQfMORSujWZri9krbUQv9+JFcokAXJpB1qU6qA==}
+  '@sanity/ui@3.4.3':
+    resolution: {integrity: sha512-NJvU9Y0Xuguo5XEurkaiVL4HBOx0R18lWlRM87WajEFfQFLBcIbZ4y9JNMnmYv7lYFO8JVbr5a3Xhruo0sO4og==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^18 || >=19.0.0-0
@@ -14400,6 +14406,8 @@ snapshots:
 
   '@sanity/color@3.0.6': {}
 
+  '@sanity/color@3.0.7': {}
+
   '@sanity/comlink@4.0.1':
     dependencies:
       rxjs: 7.8.2
@@ -14451,6 +14459,10 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  '@sanity/icons@5.2.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
   '@sanity/id-utils@1.0.0':
     dependencies:
       '@sanity/uuid': 3.0.3
@@ -14484,7 +14496,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       lodash-es: 4.18.1
       react: 19.2.7
       react-is: 19.2.7
@@ -14497,7 +14509,7 @@ snapshots:
     dependencies:
       '@sanity/icons': 5.2.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
       lodash-es: 4.18.1
       react: 19.2.7
       react-is: 19.2.7
@@ -14793,12 +14805,12 @@ snapshots:
       '@sanity/media-library-types': 1.6.0
       '@types/react': 19.2.17
 
-  '@sanity/ui@3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)':
+  '@sanity/ui@3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7)(react@19.2.7)
       '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 5.2.0(react@19.2.7)
+      '@sanity/color': 3.0.7
+      '@sanity/icons': 5.2.1(react@19.2.7)
       csstype: 3.2.3
       motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
       react: 19.2.7
@@ -14811,12 +14823,12 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
-  '@sanity/ui@3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)':
+  '@sanity/ui@3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)':
     dependencies:
       '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7)(react@19.2.7)
       '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 5.2.0(react@19.2.7)
+      '@sanity/color': 3.0.7
+      '@sanity/icons': 5.2.1(react@19.2.7)
       csstype: 3.2.3
       motion: 12.42.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react@19.2.7)
       react: 19.2.7
@@ -14893,7 +14905,7 @@ snapshots:
       '@sanity/color': 3.0.6
       '@sanity/icons': 5.2.0(react@19.2.7)
       '@sanity/lezer-groq': 1.0.4
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/uuid': 3.0.3
       '@uiw/react-codemirror': 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@19.2.7)(react@19.2.7)
       '@vanilla-extract/dynamic': 2.1.5
@@ -18921,7 +18933,7 @@ snapshots:
       '@sanity/sdk': 2.17.0(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util': 6.5.0(@types/react@19.2.17)
       '@sanity/uuid': 3.0.3
       '@sentry/react': 10.66.0(react@19.2.7)
@@ -19068,7 +19080,7 @@ snapshots:
       '@sanity/sdk': 2.17.0(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(@sanity/styled-components@6.1.24)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)
       '@sanity/util': 6.5.0(@types/react@19.2.17)
       '@sanity/uuid': 3.0.3
       '@sentry/react': 10.66.0(react@19.2.7)
@@ -19215,7 +19227,7 @@ snapshots:
       '@sanity/sdk': 2.17.0(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0)(xstate@5.32.5)
       '@sanity/telemetry': 1.1.0(react@19.2.7)
       '@sanity/types': 6.5.0(@types/react@19.2.17)
-      '@sanity/ui': 3.4.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
+      '@sanity/ui': 3.4.3(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.7)(react-is@19.2.7)(react@19.2.7)(styled-components@6.4.4)
       '@sanity/util': 6.5.0(@types/react@19.2.17)
       '@sanity/uuid': 3.0.3
       '@sentry/react': 10.66.0(react@19.2.7)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalog:
   '@sanity/telemetry': '^1.1.0'
   '@sanity/tsconfig': ^2.2.1
   '@sanity/tsdown-config': ^0.19.6
-  '@sanity/ui': ^3.4.0
+  '@sanity/ui': ^3.4.3
   '@sanity/util': ^6.5.0
   '@sanity/uuid': ^3.0.3
   '@sanity/vanilla-extract-vite-plugin': ^0.2.5


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the pnpm catalog `@sanity/ui` range from `^3.4.0` to `^3.4.3` (lockfile resolves to `3.4.3`) and adds a patch changeset covering all published plugins that depend on it via `catalog:`.

### Why
`@sanity/ui@3.4.3` removes side-effect `displayName` assignments so unused UI components can tree-shake correctly in consumer bundles (plus transitive icon/color patch updates from 3.4.1–3.4.2).

### Changes
- `pnpm-workspace.yaml`: catalog `@sanity/ui` → `^3.4.3`
- `pnpm-lock.yaml`: resolve `@sanity/ui@3.4.3`
- `.changeset/deps-sanity-ui-bump-3-4-3.md`: patch bump for 42 published plugins

### Notes
Follows the consolidated multi-package changeset pattern from #1684 for identical dependency bumps across plugins.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8de2-2f7f-7175-b08f-6d2f6919f3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8de2-2f7f-7175-b08f-6d2f6919f3da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

