### PR TITLE
feat(test-studio): enable React profiling on Vercel preview builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,7 +354,7 @@ How it works:
 
 ### React production profiling on Vercel previews
 
-`dev/test-studio/sanity.cli.ts` enables React production profiling when `VERCEL_ENV === "preview"` (Vercel PR deployments): it aliases `react-dom/client` → `react-dom/profiling`, emits production source maps, and disables identifier mangling so React DevTools can profile and show readable component names. Production builds (including `plugins-studio.sanity.dev` via `sanity deploy`, where `VERCEL_ENV` is unset) skip this path to avoid the profiling overhead. `VERCEL_ENV` is listed in `dev/test-studio/turbo.jsonc` so Turbo cache keys differ between preview and production.
+`dev/test-studio/sanity.cli.ts` enables React production profiling when `VERCEL_ENV === "preview"` (Vercel PR deployments): it aliases `react-dom/client` → `react-dom/profiling`, emits production source maps, and disables identifier mangling so React DevTools can profile and show readable component names. It also sets `deployment.autoUpdates: false` on those previews, because auto-updates vendor builds hardcode `react-dom-client.production.js` and would bypass the profiling alias. Production builds (including `plugins-studio.sanity.dev` via `sanity deploy`, where `VERCEL_ENV` is unset) keep auto-updates on and skip profiling to avoid the overhead. `VERCEL_ENV` is listed in `dev/test-studio/turbo.jsonc` so Turbo cache keys differ between preview and production.
 
 ## Creating a New Plugin
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,10 @@ How it works:
 - The flag is declared in `dev/test-studio/turbo.jsonc` so turbo-cached builds are invalidated when it changes (and so turbo's strict env mode passes it through to `pnpm dev`)
 - Enabling devtools makes `sanity build` noticeably slower; that's why it's opt-in via the env flag
 
+### React production profiling on Vercel previews
+
+`dev/test-studio/sanity.cli.ts` enables React production profiling when `VERCEL_ENV === "preview"` (Vercel PR deployments): it aliases `react-dom/client` → `react-dom/profiling`, emits production source maps, and disables identifier mangling so React DevTools can profile and show readable component names. Production builds (including `plugins-studio.sanity.dev` via `sanity deploy`, where `VERCEL_ENV` is unset) skip this path to avoid the profiling overhead. `VERCEL_ENV` is listed in `dev/test-studio/turbo.jsonc` so Turbo cache keys differ between preview and production.
+
 ## Creating a New Plugin
 
 Use the generator:

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -1,6 +1,11 @@
+import {createRequire} from 'node:module'
+
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {DevTools} from '@vitejs/devtools'
 import {defineCliConfig} from 'sanity/cli'
+import {mergeConfig, type UserConfig} from 'vite'
+
+const require = createRequire(import.meta.url)
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID || 'ppsg7ml5'
 const dataset = process.env.SANITY_STUDIO_DATASET || 'plugins'
@@ -10,6 +15,9 @@ const appId = process.env.SANITY_STUDIO_APP_ID || 'bi1ktslqwmu1cawds5ce3jn6'
 // the DevTools dock in a running `sanity dev` server without restarting it.
 // Usage: `pnpm devtools:test-studio` from the repo root (see AGENTS.md).
 const isViteDevToolsEnabled = process.env.ENABLE_VITE_DEVTOOLS === 'true'
+// Enable React production profiling on Vercel preview deployments (PR builds), but not on
+// production (plugins-studio.sanity.dev) where the react-dom/profiling overhead is unwanted.
+const reactProductionProfiling = process.env.VERCEL_ENV === 'preview'
 
 export default defineCliConfig({
   api: {projectId, dataset},
@@ -22,9 +30,35 @@ export default defineCliConfig({
   // works fine. If you're actively working on styles and need CSS HMR, comment out this line
   // for that session (confirmed fast, sub-10ms HMR with it unset).
   unstable_bundledDev: true,
-  vite: {
-    plugins: [vanillaExtractPlugin(), ...(isViteDevToolsEnabled ? [DevTools()] : [])],
-    // `devtools: {}` makes `sanity build` emit a Rolldown build session that the DevTools dock can inspect
-    build: isViteDevToolsEnabled ? {rolldownOptions: {devtools: {}}} : {},
+  vite(viteConfig, {command}): UserConfig {
+    let nextConfig = mergeConfig(viteConfig, {
+      plugins: [vanillaExtractPlugin(), ...(isViteDevToolsEnabled ? [DevTools()] : [])],
+      // `devtools: {}` makes `sanity build` emit a Rolldown build session that the DevTools dock can inspect
+      build: isViteDevToolsEnabled ? {rolldownOptions: {devtools: {}}} : {},
+    } satisfies UserConfig)
+
+    // Support React Production Profiling on Vercel preview deployments
+    if (reactProductionProfiling && command === 'build') {
+      nextConfig = mergeConfig(nextConfig, {
+        // Aliasing to react-dom/profiling is necessary in the production build, otherwise React
+        // can't run the profiler on the deployed studio
+        resolve: {alias: {'react-dom/client': require.resolve('react-dom/profiling')}},
+        build: {
+          // Enable production source maps to easier debug deployed preview studios
+          sourcemap: true,
+          rolldownOptions: {
+            output: {
+              // Disabling `mangle` (while keeping compression and whitespace removal) ensures that
+              // the React DevTools components inspector has readable component names.
+              // This overrides the `build.minify: 'oxc'` default set by `sanity build`, replacing
+              // `esbuild: {minifyIdentifiers: false}` which the rolldown-powered Vite silently ignores.
+              minify: {compress: true, mangle: false, codegen: true},
+            },
+          },
+        },
+      } satisfies UserConfig)
+    }
+
+    return nextConfig
   },
 })

--- a/dev/test-studio/sanity.cli.ts
+++ b/dev/test-studio/sanity.cli.ts
@@ -17,11 +17,17 @@ const appId = process.env.SANITY_STUDIO_APP_ID || 'bi1ktslqwmu1cawds5ce3jn6'
 const isViteDevToolsEnabled = process.env.ENABLE_VITE_DEVTOOLS === 'true'
 // Enable React production profiling on Vercel preview deployments (PR builds), but not on
 // production (plugins-studio.sanity.dev) where the react-dom/profiling overhead is unwanted.
-const reactProductionProfiling = process.env.VERCEL_ENV === 'preview'
+const isVercelPreview = process.env.VERCEL_ENV === 'preview'
 
 export default defineCliConfig({
   api: {projectId, dataset},
-  deployment: {appId, autoUpdates: true},
+  deployment: {
+    appId,
+    // Auto-updates vendor builds hardcode `react-dom-client.production.js`, which bypasses
+    // the `react-dom/client` → `react-dom/profiling` alias below. Disable on Vercel previews
+    // so profiling can take effect; keep enabled for production / sanity deploy.
+    autoUpdates: !isVercelPreview,
+  },
   reactCompiler: {},
   typegen: {formatGeneratedCode: false},
   // Bundle studio deps in `sanity dev` (required for Structure with client/eventsource alignment).
@@ -38,7 +44,7 @@ export default defineCliConfig({
     } satisfies UserConfig)
 
     // Support React Production Profiling on Vercel preview deployments
-    if (reactProductionProfiling && command === 'build') {
+    if (isVercelPreview && command === 'build') {
       nextConfig = mergeConfig(nextConfig, {
         // Aliasing to react-dom/profiling is necessary in the production build, otherwise React
         // can't run the profiler on the deployed studio

--- a/dev/test-studio/turbo.jsonc
+++ b/dev/test-studio/turbo.jsonc
@@ -6,10 +6,12 @@
     // does not need their dist/. Use transit (not ^build) so Turbo still
     // invalidates this cache when dependency source changes.
     // ENABLE_VITE_DEVTOOLS opts into Vite DevTools (see sanity.cli.ts); declaring it here
-    // invalidates turbo-cached builds when it flips and passes it through in strict env mode
+    // invalidates turbo-cached builds when it flips and passes it through in strict env mode.
+    // VERCEL_ENV gates React production profiling (preview only) — must be declared so turbo
+    // invalidates the cache when preview vs production builds differ.
     "build": {
       "dependsOn": ["transit"],
-      "env": ["ENABLE_VITE_DEVTOOLS"],
+      "env": ["ENABLE_VITE_DEVTOOLS", "VERCEL_ENV"],
     },
     "dev": {
       "env": ["ENABLE_VITE_DEVTOOLS"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables React production profiling for the test studio on Vercel preview (PR) deployments, matching the pattern from [sanity-io/sanity `dev/test-studio/sanity.cli.ts`](https://github.com/sanity-io/sanity/blob/c175fe6e06a442f001ee0f3e8811c33c4e5f6dde/dev/test-studio/sanity.cli.ts#L101-L120).

When `VERCEL_ENV === "preview"` during `sanity build`:
- Sets `deployment.autoUpdates: false` (required so the profiling alias is not bypassed by auto-updates vendor builds that hardcode `react-dom-client.production.js`)
- Aliases `react-dom/client` → `react-dom/profiling`
- Emits production source maps
- Disables identifier mangling so React DevTools shows readable component names

Production builds (including `plugins-studio.sanity.dev` via `sanity deploy`, where `VERCEL_ENV` is unset) keep auto-updates on and skip profiling to avoid that overhead.

## Changes

- `dev/test-studio/sanity.cli.ts` — convert `vite` config to a function; gate profiling + auto-updates on `VERCEL_ENV === "preview"`
- `dev/test-studio/turbo.jsonc` — declare `VERCEL_ENV` so Turbo cache keys differ between preview and production
- `AGENTS.md` — document the preview-only profiling behavior

## Test plan

- [x] `pnpm knip` passes
- [x] Local `sanity build` without `VERCEL_ENV`: auto-updates on, vendor dir present, no source maps, no profiling
- [x] `VERCEL_ENV=preview sanity build`: auto-updates off, source maps present, `react-dom-profiling.profiling.js` in sourcemap sources
- [ ] Confirm a Vercel PR preview deployment can be profiled with React DevTools
- [ ] Confirm production / `plugins-studio.sanity.dev` remains without profiling overhead
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-867ccbeb-0824-4d73-a2c7-7ccd5a7f474b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-867ccbeb-0824-4d73-a2c7-7ccd5a7f474b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

