### PR TITLE
test(internationalized-array): expand Vitest + Playwright e2e coverage

### DIFF
--- a/.agents/skills/plugin-test-coverage/SKILL.md
+++ b/.agents/skills/plugin-test-coverage/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: plugin-test-coverage
+description: Guides agents through expanding Vitest and Playwright e2e coverage for a monorepo plugin. Use when adding or improving plugin tests, wiring e2e-studio, or following the internationalized-array / document-internationalization coverage playbook.
+---
+
+# Plugin Test Coverage
+
+Use this skill when expanding **Vitest** and/or **Playwright e2e** coverage for a plugin under `plugins/`.
+
+Reference implementations:
+
+- `@sanity/document-internationalization` — Vitest + e2e under `e2e/tests/document-internationalization/`
+- `sanity-plugin-internationalized-array` — Vitest + e2e under `e2e/tests/internationalized-array/`
+
+Also read [`e2e/README.md`](../../../e2e/README.md) before writing Playwright specs.
+
+## When to use
+
+- Filling unit/integration gaps for a published plugin
+- Wiring a plugin into `dev/e2e-studio` and adding Playwright specs
+- Porting the doc-i18n / internationalized-array coverage process to another plugin
+
+## Workflow
+
+1. **Inventory use cases** from README + source (authoring loops, config knobs, integrations).
+2. **Map each use case** to Vitest (pure logic, components with mocks) vs Playwright (studio UX that needs a real form).
+3. **Fill Vitest gaps** co-located under `plugins/<pkg>/src/` — plugin assembly, context/providers, utils, components.
+4. **Wire e2e-studio** — `definePlugin` example file, register in **both** chromium/firefox workspaces.
+5. **Add helpers + specs** — `e2e/helpers/<plugin>/`, `e2e/tests/<plugin>/`.
+6. **Changesets** — separate patch changeset per published package that gained `data-testid`s or runtime changes. Private e2e/studio files need none.
+7. **Verify** — `pnpm format && pnpm lint && pnpm knip && pnpm build && pnpm test` (and targeted e2e when secrets allow).
+8. **PR** — draft, `🤖 bot` label, inventory + e2e test table in the description.
+
+Skip one-off tooling (migrations, banners) unless they are part of the main authoring loop.
+
+## Vitest patterns
+
+- Co-locate `*.test.ts(x)` next to source; use jsdom via the package `vitest.config.ts`.
+- Shared mocks/fixtures in `src/test/helpers.ts` and `src/test/component-helpers.tsx` (`ThemeWrapper` for `@sanity/ui`).
+- Plugin assembly tests: call the plugin factory, assert schema type names, document layout, form input wrappers, nested plugins.
+- Context/provider tests: mock `useClient` / `useWorkspace` / pane hooks; use `Suspense` + `act` for async `React.use` language resolution; call any module-level `clear()` between tests.
+- Timeouts: `test('name', {timeout: 30_000}, async () => { … })` — options object as second arg.
+- Keep the package-exports snapshot test; update with `pnpm test -u` only when exports intentionally change.
+- React Compiler is on — do not add unnecessary `useMemo` / `useCallback`.
+
+Run a single package:
+
+```bash
+pnpm --filter <package-name> test run
+```
+
+## E2e structure
+
+```
+e2e/
+├── tests/
+│   ├── smoke.spec.ts                 # studio-wide only
+│   └── <plugin-name>/
+│       └── <plugin-name>.spec.ts
+└── helpers/
+    └── <plugin-name>/
+        └── <helpers>.ts
+```
+
+Do not dump plugin specs at the top level of `tests/`.
+
+## E2e-studio wiring
+
+1. Add `dev/e2e-studio/src/<example>.ts` with `definePlugin` that registers schema + the plugin under test.
+2. Import and add it to **both** workspaces in `dev/e2e-studio/sanity.config.ts`.
+3. Ensure the workspace `package.json` already depends on the plugin (`workspace:*`).
+4. Update the “Currently wired” list in `e2e/README.md`.
+
+## Hard-won Playwright lessons
+
+- Project `baseURL` must end with a **trailing slash** (`…/chromium/`, `…/firefox/`).
+- Navigate with **relative** intents: `intent/edit/id=…;type=…`. Never host-absolute `/intent/…` (drops workspace basePath → “Workspace not found”).
+- Auth: Playwright `storageState` seeds `__studio_auth_token_<projectId>`; preflight `/users/me`. Never use `SANITY_DEPLOY_TOKEN` for e2e session auth.
+- Local pitfall: stale server on `:3333` + `reuseExistingServer` → signed-out studio. Kill and restart.
+- Prefer accessible role/name locators; add `data-testid` + a **patch** changeset only when selectors are flaky or ambiguous (e.g. duplicate add-button grids).
+- Seed documents via the Content Lake API; always `try/finally` cleanup.
+- Video: `SANITY_E2E_VIDEO=on` when debugging.
+- Document existence matters: some plugins only auto-seed after `_rev` exists — seed empty persisted docs, don’t rely on brand-new unsaved drafts.
+
+## PR checklist
+
+- [ ] Separate changeset per published package touched
+- [ ] Draft PR with `🤖 bot` label
+- [ ] Use-case inventory + e2e test table in the description
+- [ ] `pnpm format` / `lint` / `knip` / `build` / `test` green
+- [ ] CI e2e (chromium + firefox) green when studio wiring changed
+
+## Pointers
+
+- [`e2e/README.md`](../../../e2e/README.md)
+- [`AGENTS.md`](../../../AGENTS.md) — CI commands, changesets, Node version notes
+- Doc-i18n + internationalized-array as living examples

--- a/.changeset/i18n-array-document-add-testid.md
+++ b/.changeset/i18n-array-document-add-testid.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Add a stable `data-testid` on the document-level add-translations panel for e2e coverage

--- a/.claude/skills/plugin-test-coverage
+++ b/.claude/skills/plugin-test-coverage
@@ -1,0 +1,1 @@
+../../.agents/skills/plugin-test-coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,8 @@ pnpm generate "copy plugin"
 
 For agent-specific transfer guidance, use the `plugin-transfer` skill in `.agents/skills/plugin-transfer/SKILL.md`.
 
+For expanding Vitest + Playwright coverage for a plugin, use the `plugin-test-coverage` skill in `.agents/skills/plugin-test-coverage/SKILL.md`.
+
 When migrating a plugin, agents should ensure:
 
 - `README.md` from the original repository is preserved, but cleaned up for the monorepo:

--- a/dev/e2e-studio/sanity.config.ts
+++ b/dev/e2e-studio/sanity.config.ts
@@ -2,6 +2,7 @@ import {defineConfig, defineField, defineType, type WorkspaceOptions} from 'sani
 import {structureTool} from 'sanity/structure'
 
 import {documentInternationalizationExample} from './src/documentInternationalization'
+import {internationalizedArrayExample} from './src/internationalizedArray'
 
 const projectId = process.env.SANITY_E2E_PROJECT_ID || 'a1psl692'
 const fallbackDataset = process.env.SANITY_E2E_DATASET || 'plugins'
@@ -26,7 +27,11 @@ function createWorkspace(name: string, title: string, dataset: string): Workspac
     basePath: `/${name}`,
     projectId,
     dataset,
-    plugins: [structureTool(), documentInternationalizationExample()],
+    plugins: [
+      structureTool(),
+      documentInternationalizationExample(),
+      internationalizedArrayExample(),
+    ],
     schema: {types: [smokeTestDocument]},
   }
 }

--- a/dev/e2e-studio/src/internationalizedArray.ts
+++ b/dev/e2e-studio/src/internationalizedArray.ts
@@ -1,0 +1,48 @@
+import {defineField, definePlugin, defineType} from 'sanity'
+import {internationalizedArray} from 'sanity-plugin-internationalized-array'
+
+/**
+ * Schema + plugin wiring for internationalized-array e2e coverage.
+ * Kept separate from smokeTestDocument so plugin suites stay easy to scan.
+ */
+const i18nPostType = defineType({
+  name: 'i18nPost',
+  title: 'I18n Post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'internationalizedArrayString',
+    }),
+    defineField({
+      name: 'summary',
+      title: 'Summary',
+      type: 'internationalizedArrayString',
+    }),
+  ],
+})
+
+export const internationalizedArrayExample = definePlugin(() => ({
+  schema: {
+    types: [i18nPostType],
+  },
+  plugins: [
+    internationalizedArray({
+      languages: [
+        {id: 'en', title: 'English'},
+        {id: 'es', title: 'Spanish'},
+        {id: 'fr', title: 'French'},
+      ],
+      defaultLanguages: ['en'],
+      fieldTypes: ['string'],
+      buttonLocations: ['field', 'document'],
+      buttonAddAll: true,
+      languageDisplay: 'codeOnly',
+      languageFilter: {
+        documentTypes: ['i18nPost'],
+        defaultLanguages: ['en'],
+      },
+    }),
+  ],
+}))

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,7 +4,7 @@ Playwright smoke tests for the dedicated [e2e studio](../dev/e2e-studio). Auth f
 
 ## The e2e studio
 
-`dev/e2e-studio` is a **bare-bones studio used only for e2e testing** — separate from `dev/test-studio` (normal development work). It has two workspaces, `/chromium` and `/firefox`, each pointed at that browser’s ephemeral dataset. Plugins (and their schema types) are added one by one together with the e2e tests that cover them. Currently wired: `@sanity/document-internationalization` (`lesson` schema) plus a shared `smokeTestDocument` type for the smoke suite.
+`dev/e2e-studio` is a **bare-bones studio used only for e2e testing** — separate from `dev/test-studio` (normal development work). It has two workspaces, `/chromium` and `/firefox`, each pointed at that browser’s ephemeral dataset. Plugins (and their schema types) are added one by one together with the e2e tests that cover them. Currently wired: `@sanity/document-internationalization` (`lesson` schema), `sanity-plugin-internationalized-array` (`i18nPost` schema), plus a shared `smokeTestDocument` type for the smoke suite.
 
 ## Test layout
 
@@ -14,12 +14,16 @@ Each plugin gets **its own folder** under `tests/` (and, when it needs seeding/n
 e2e/
 ├── tests/
 │   ├── smoke.spec.ts                          # studio-wide smoke (auth precheck)
-│   └── document-internationalization/         # one folder per plugin
-│       └── document-internationalization.spec.ts
+│   ├── document-internationalization/         # one folder per plugin
+│   │   └── document-internationalization.spec.ts
+│   └── internationalized-array/
+│       └── internationalized-array.spec.ts
 └── helpers/
     ├── env.ts, e2eClient.ts, …                # shared infrastructure
-    └── document-internationalization/         # plugin-specific helpers
-        └── documentInternationalization.ts
+    ├── document-internationalization/         # plugin-specific helpers
+    │   └── documentInternationalization.ts
+    └── internationalized-array/
+        └── internationalizedArray.ts
 ```
 
 When adding e2e coverage for a new plugin, create `tests/<plugin-name>/` for its specs and `helpers/<plugin-name>/` for its helpers instead of adding loose files at the top level. Top-level files are reserved for studio-wide suites (e.g. `smoke.spec.ts`) and shared infrastructure (`env.ts`, `e2eClient.ts`, `assertStudioAuth.ts`).

--- a/e2e/helpers/internationalized-array/internationalizedArray.ts
+++ b/e2e/helpers/internationalized-array/internationalizedArray.ts
@@ -88,9 +88,12 @@ export async function openI18nPost(page: Page, documentId: string): Promise<void
   await expect(page.getByTestId('form-view').first()).toBeVisible()
 }
 
-/** Language code label rendered beside each internationalized array item. */
-export function languageLabel(page: Page, languageId: string) {
-  return page.getByTestId('form-view').getByText(languageId.toUpperCase(), {exact: true})
+/** Language code Label rendered as the nested value-field title (not add-button text). */
+export function languageLabel(page: Page, languageId: string, fieldName = 'title') {
+  return page
+    .getByTestId(`field-${fieldName}`)
+    .locator('[data-ui="Label"]')
+    .getByText(languageId.toUpperCase(), {exact: true})
 }
 
 export function fieldAddButton(page: Page, languageId: string) {

--- a/e2e/helpers/internationalized-array/internationalizedArray.ts
+++ b/e2e/helpers/internationalized-array/internationalizedArray.ts
@@ -1,0 +1,110 @@
+import {randomUUID} from 'node:crypto'
+
+import {expect, type Page} from '@playwright/test'
+
+import {createE2EClient} from '../e2eClient.js'
+import {loadE2eEnvFiles, resolveE2eEnv} from '../env.js'
+
+loadE2eEnvFiles()
+
+const DOC_TYPE = 'i18nPost'
+const LANGUAGE_FIELD_NAME = 'language'
+
+export type SeededI18nPost = {
+  id: string
+}
+
+export type I18nArrayItem = {
+  _key: string
+  _type: 'internationalizedArrayStringValue'
+  language: string
+  value?: string
+}
+
+function datasetForProject(projectName: string | undefined): string {
+  const env = resolveE2eEnv()
+  if (projectName === 'firefox') return env.datasetFirefox
+  return env.datasetChromium
+}
+
+function item(language: string, value = ''): I18nArrayItem {
+  return {
+    _key: randomUUID(),
+    _type: 'internationalizedArrayStringValue',
+    [LANGUAGE_FIELD_NAME]: language,
+    value,
+  }
+}
+
+/**
+ * Create an i18nPost draft via the Content Lake API.
+ * Pass `title` / `summary` arrays explicitly — use `[]` when testing
+ * `defaultLanguages` seeding (requires a persisted `_rev`).
+ */
+export async function seedI18nPost(
+  projectName: string | undefined,
+  opts: {
+    title?: I18nArrayItem[]
+    summary?: I18nArrayItem[]
+  } = {},
+): Promise<SeededI18nPost> {
+  const client = createE2EClient(datasetForProject(projectName))
+  const id = randomUUID()
+
+  await client.createOrReplace({
+    _id: `drafts.${id}`,
+    _type: DOC_TYPE,
+    title: opts.title ?? [],
+    summary: opts.summary ?? [],
+  })
+
+  return {id}
+}
+
+export function languageItem(language: string, value?: string): I18nArrayItem {
+  return item(language, value)
+}
+
+export async function deleteI18nPost(
+  projectName: string | undefined,
+  documentId: string,
+): Promise<void> {
+  const client = createE2EClient(datasetForProject(projectName))
+  await client
+    .transaction()
+    .delete(documentId)
+    .delete(`drafts.${documentId}`)
+    .commit({visibility: 'async'})
+    .catch(() => undefined)
+}
+
+export async function openI18nPost(page: Page, documentId: string): Promise<void> {
+  // Relative to project baseURL (`…/chromium/` or `…/firefox/`, trailing slash
+  // required). A leading `/` resolves against the host origin and drops the
+  // workspace basePath ("Workspace not found").
+  await page.goto(`intent/edit/id=${documentId};type=${DOC_TYPE}`)
+  await expect(page.getByTestId('studio-navbar')).toBeVisible()
+  await expect(page.getByTestId('document-pane').first()).toBeVisible()
+  await expect(page.getByTestId('form-view').first()).toBeVisible()
+}
+
+/** Language code label rendered beside each internationalized array item. */
+export function languageLabel(page: Page, languageId: string) {
+  return page.getByTestId('form-view').getByText(languageId.toUpperCase(), {exact: true})
+}
+
+export function fieldAddButton(page: Page, languageId: string) {
+  // Field-level add buttons live under the field — exclude the document panel.
+  return page.getByTestId('field-title').getByTestId(`add-${languageId}`)
+}
+
+export function documentAddButton(page: Page, languageId: string) {
+  return page.getByTestId('document-add-buttons').getByTestId(`add-${languageId}`)
+}
+
+export async function openLanguageFilter(page: Page) {
+  const filterButton = page.getByRole('button', {name: /Showing \d+ \/ \d+|Showing all/})
+  await expect(filterButton).toBeVisible()
+  await filterButton.click()
+  return filterButton
+}

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -23,7 +23,7 @@ test.describe('sanity-plugin-internationalized-array', () => {
     try {
       await openI18nPost(page, doc.id)
 
-      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'en')).toBeVisible()
       // EN is present → its field add button is disabled
       await expect(fieldAddButton(page, 'en')).toHaveAttribute('data-disabled', 'true')
     } finally {
@@ -39,10 +39,10 @@ test.describe('sanity-plugin-internationalized-array', () => {
 
     try {
       await openI18nPost(page, doc.id)
-      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'en')).toBeVisible()
 
       await fieldAddButton(page, 'es').click()
-      await expect(languageLabel(page, 'es').first()).toBeVisible()
+      await expect(languageLabel(page, 'es')).toBeVisible()
       await expect(fieldAddButton(page, 'es')).toHaveAttribute('data-disabled', 'true')
     } finally {
       await deleteI18nPost(projectName, doc.id)
@@ -60,9 +60,9 @@ test.describe('sanity-plugin-internationalized-array', () => {
 
       await page.getByTestId('field-title').getByTestId('add-all-languages').click()
 
-      await expect(languageLabel(page, 'en').first()).toBeVisible()
-      await expect(languageLabel(page, 'es').first()).toBeVisible()
-      await expect(languageLabel(page, 'fr').first()).toBeVisible()
+      await expect(languageLabel(page, 'en')).toBeVisible()
+      await expect(languageLabel(page, 'es')).toBeVisible()
+      await expect(languageLabel(page, 'fr')).toBeVisible()
       // All languages present → add-all control is gone or disabled
       await expect(page.getByTestId('field-title').getByTestId('add-all-languages')).toHaveCount(0)
     } finally {
@@ -80,7 +80,7 @@ test.describe('sanity-plugin-internationalized-array', () => {
 
     try {
       await openI18nPost(page, doc.id)
-      await expect(languageLabel(page, 'es').first()).toBeVisible()
+      await expect(languageLabel(page, 'es')).toBeVisible()
 
       const titleField = page.getByTestId('field-title')
       const removeButtons = titleField.locator('[data-sanity-icon="remove-circle"]')
@@ -93,7 +93,7 @@ test.describe('sanity-plugin-internationalized-array', () => {
 
       await removeButtons.nth(1).locator('xpath=ancestor::button[1]').click()
       await expect(languageLabel(page, 'es')).toHaveCount(0)
-      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'en')).toBeVisible()
     } finally {
       await deleteI18nPost(projectName, doc.id)
     }
@@ -115,8 +115,8 @@ test.describe('sanity-plugin-internationalized-array', () => {
       await documentAddButton(page, 'es').click()
 
       // Spanish appears in both root internationalized string fields
-      await expect(page.getByTestId('field-title').getByText('ES', {exact: true})).toBeVisible()
-      await expect(page.getByTestId('field-summary').getByText('ES', {exact: true})).toBeVisible()
+      await expect(languageLabel(page, 'es', 'title')).toBeVisible()
+      await expect(languageLabel(page, 'es', 'summary')).toBeVisible()
     } finally {
       await deleteI18nPost(projectName, doc.id)
     }
@@ -134,15 +134,15 @@ test.describe('sanity-plugin-internationalized-array', () => {
 
     try {
       await openI18nPost(page, doc.id)
-      await expect(languageLabel(page, 'es').first()).toBeVisible()
-      await expect(languageLabel(page, 'fr').first()).toBeVisible()
+      await expect(languageLabel(page, 'es')).toBeVisible()
+      await expect(languageLabel(page, 'fr')).toBeVisible()
 
       await openLanguageFilter(page)
       // Toggle off Spanish and French (English is a default language — always shown)
       await page.getByRole('button', {name: /Spanish/}).click()
       await page.getByRole('button', {name: /French/}).click()
 
-      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'en')).toBeVisible()
       await expect(languageLabel(page, 'es')).toHaveCount(0)
       await expect(languageLabel(page, 'fr')).toHaveCount(0)
     } finally {

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -1,0 +1,152 @@
+import {expect, test} from '@playwright/test'
+
+import {
+  deleteI18nPost,
+  documentAddButton,
+  fieldAddButton,
+  languageItem,
+  languageLabel,
+  openI18nPost,
+  openLanguageFilter,
+  seedI18nPost,
+} from '../../helpers/internationalized-array/internationalizedArray.js'
+
+test.describe('sanity-plugin-internationalized-array', () => {
+  /**
+   * `defaultLanguages` only auto-seeds after the document exists in the
+   * dataset (`_rev`). Opening a persisted empty array must create the EN item.
+   */
+  test('seeds default language on an existing empty document', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {title: [], summary: []})
+
+    try {
+      await openI18nPost(page, doc.id)
+
+      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      // EN is present → its field add button is disabled
+      await expect(fieldAddButton(page, 'en')).toHaveAttribute('data-disabled', 'true')
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('adds Spanish from field add buttons', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {
+      title: [languageItem('en', 'Hello')],
+    })
+
+    try {
+      await openI18nPost(page, doc.id)
+      await expect(languageLabel(page, 'en').first()).toBeVisible()
+
+      await fieldAddButton(page, 'es').click()
+      await expect(languageLabel(page, 'es').first()).toBeVisible()
+      await expect(fieldAddButton(page, 'es')).toHaveAttribute('data-disabled', 'true')
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('adds all missing languages from the field', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {
+      title: [languageItem('en', 'Hello')],
+    })
+
+    try {
+      await openI18nPost(page, doc.id)
+
+      await page.getByTestId('field-title').getByTestId('add-all-languages').click()
+
+      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'es').first()).toBeVisible()
+      await expect(languageLabel(page, 'fr').first()).toBeVisible()
+      // All languages present → add-all control is gone or disabled
+      await expect(page.getByTestId('field-title').getByTestId('add-all-languages')).toHaveCount(0)
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('removes a non-default language and keeps default remove disabled', async ({
+    page,
+  }, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {
+      title: [languageItem('en', 'Hello'), languageItem('es', 'Hola')],
+    })
+
+    try {
+      await openI18nPost(page, doc.id)
+      await expect(languageLabel(page, 'es').first()).toBeVisible()
+
+      const titleField = page.getByTestId('field-title')
+      const removeButtons = titleField.locator('[data-sanity-icon="remove-circle"]')
+      // EN (default) then ES
+      await expect(removeButtons).toHaveCount(2)
+      await expect(removeButtons.nth(0).locator('xpath=ancestor::button[1]')).toHaveAttribute(
+        'data-disabled',
+        'true',
+      )
+
+      await removeButtons.nth(1).locator('xpath=ancestor::button[1]').click()
+      await expect(languageLabel(page, 'es')).toHaveCount(0)
+      await expect(languageLabel(page, 'en').first()).toBeVisible()
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('document-level add buttons insert a missing language across root fields', async ({
+    page,
+  }, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {
+      title: [languageItem('en', 'Title EN')],
+      summary: [languageItem('en', 'Summary EN')],
+    })
+
+    try {
+      await openI18nPost(page, doc.id)
+
+      await expect(page.getByTestId('document-add-buttons')).toBeVisible()
+      await documentAddButton(page, 'es').click()
+
+      // Spanish appears in both root internationalized string fields
+      await expect(page.getByTestId('field-title').getByText('ES', {exact: true})).toBeVisible()
+      await expect(page.getByTestId('field-summary').getByText('ES', {exact: true})).toBeVisible()
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('language filter hides non-selected array items', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {
+      title: [
+        languageItem('en', 'Hello'),
+        languageItem('es', 'Hola'),
+        languageItem('fr', 'Bonjour'),
+      ],
+    })
+
+    try {
+      await openI18nPost(page, doc.id)
+      await expect(languageLabel(page, 'es').first()).toBeVisible()
+      await expect(languageLabel(page, 'fr').first()).toBeVisible()
+
+      await openLanguageFilter(page)
+      // Toggle off Spanish and French (English is a default language — always shown)
+      await page.getByRole('button', {name: /Spanish/}).click()
+      await page.getByRole('button', {name: /French/}).click()
+
+      await expect(languageLabel(page, 'en').first()).toBeVisible()
+      await expect(languageLabel(page, 'es')).toHaveCount(0)
+      await expect(languageLabel(page, 'fr')).toHaveCount(0)
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/cache.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/cache.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {
+  clear,
+  createCacheKey,
+  createOrGetPromise,
+  getFunctionCache,
+  peek,
+  preloadWithKey,
+  setFunctionCache,
+} from './cache'
+import {MOCK_LANGUAGES} from './test/helpers'
+import type {LanguageCallback} from './types'
+
+afterEach(() => {
+  clear()
+})
+
+describe('cache', () => {
+  test('createCacheKey includes selected value and optional workspace id', () => {
+    expect(createCacheKey({market: 'eu'})).toEqual([
+      'v1',
+      'sanity-plugin-internationalized-array',
+      JSON.stringify({market: 'eu'}),
+    ])
+    expect(createCacheKey({}, 'chromium')).toEqual([
+      'v1',
+      'sanity-plugin-internationalized-array',
+      JSON.stringify({}),
+      'chromium',
+    ])
+  })
+
+  test('createOrGetPromise caches by key and reuses the same promise', async () => {
+    let calls = 0
+    const fn = async () => {
+      calls += 1
+      return MOCK_LANGUAGES
+    }
+    const key = createCacheKey({})
+
+    const first = createOrGetPromise(fn, key)
+    const second = createOrGetPromise(fn, key)
+    expect(first).toBe(second)
+
+    await expect(first).resolves.toEqual(MOCK_LANGUAGES)
+    expect(calls).toBe(1)
+  })
+
+  test('preloadWithKey warms the promise cache', async () => {
+    const key = createCacheKey({})
+    preloadWithKey(async () => MOCK_LANGUAGES.slice(0, 1), key)
+
+    const result = await createOrGetPromise(async () => {
+      throw new Error('should not run — cache already warm')
+    }, key)
+
+    expect(result).toEqual([{id: 'en', title: 'English'}])
+  })
+
+  test('clear empties the promise cache so subsequent fetches re-run', async () => {
+    const key = createCacheKey({})
+    let calls = 0
+    const fn = async () => {
+      calls += 1
+      return MOCK_LANGUAGES
+    }
+
+    await createOrGetPromise(fn, key)
+    clear()
+    await createOrGetPromise(fn, key)
+    expect(calls).toBe(2)
+  })
+
+  test('peek returns undefined for unresolved or missing entries', () => {
+    expect(peek({})).toBeUndefined()
+  })
+
+  test('function cache stores and retrieves languages by callback identity', () => {
+    const languagesFn: LanguageCallback = async () => MOCK_LANGUAGES
+    const selected = {market: 'us'}
+
+    expect(getFunctionCache(languagesFn, selected)).toBeUndefined()
+
+    setFunctionCache(languagesFn, selected, MOCK_LANGUAGES, 'ws-1')
+    expect(getFunctionCache(languagesFn, selected, 'ws-1')).toEqual(MOCK_LANGUAGES)
+    expect(getFunctionCache(languagesFn, selected)).toBeUndefined()
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.test.tsx
@@ -77,7 +77,9 @@ describe('DocumentAddButtons', () => {
     mockGetFormValue.mockReturnValue(undefined)
     render(<DocumentAddButtons />, {wrapper: ThemeWrapper})
 
+    expect(screen.getByTestId('document-add-buttons')).toBeInTheDocument()
     expect(screen.getByText('Add translation to internationalized fields')).toBeInTheDocument()
+    expect(screen.getByTestId('add-buttons-grid')).toBeInTheDocument()
     expect(screen.getByTestId('add-fr')).toBeInTheDocument()
     expect(screen.getByTestId('add-en')).toBeInTheDocument()
     expect(screen.getByTestId('add-es')).toBeInTheDocument()

--- a/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/DocumentAddButtons.tsx
@@ -168,7 +168,7 @@ export default function DocumentAddButtons(): ReactElement {
     [getInitialValueForType, onChange, toast, getFormValue, filteredLanguages],
   )
   return (
-    <Stack gap={3}>
+    <Stack gap={3} data-testid="document-add-buttons">
       <Box>
         <Text size={1} weight="semibold">
           Add translation to internationalized fields

--- a/plugins/sanity-plugin-internationalized-array/src/components/Feedback.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/Feedback.test.tsx
@@ -1,0 +1,22 @@
+import {cleanup, render, screen} from '@testing-library/react'
+import {afterEach, describe, expect, test} from 'vitest'
+
+import {ThemeWrapper} from '../test/component-helpers'
+import Feedback from './Feedback'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Feedback', () => {
+  test('renders caution card explaining required languages shape', () => {
+    render(<Feedback />, {wrapper: ThemeWrapper})
+
+    expect(screen.getByText(/array of language objects must be passed/i)).toBeInTheDocument()
+    expect(screen.getByText(/"id"/)).toBeInTheDocument()
+    expect(screen.getByText(/"title"/)).toBeInTheDocument()
+    // Example JSON is shown in a Code block
+    expect(screen.getByText(/English/)).toBeInTheDocument()
+    expect(screen.getByText(/Norsk/)).toBeInTheDocument()
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayContext.test.tsx
@@ -1,0 +1,155 @@
+import {act, cleanup, render, screen} from '@testing-library/react'
+import {Suspense} from 'react'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {clear} from '../cache'
+import {CONFIG_DEFAULT} from '../constants'
+import {ThemeWrapper} from '../test/component-helpers'
+import {MOCK_LANGUAGES} from '../test/helpers'
+import type {PluginConfig} from '../types'
+import {
+  InternationalizedArrayProvider,
+  useInternationalizedArrayContext,
+} from './InternationalizedArrayContext'
+
+const mockClient = {fetch: vi.fn()}
+const mockUseWorkspace = vi.fn(() => ({name: 'default'}))
+const mockUseDocumentPane = vi.fn(() => ({formState: {value: {_type: 'i18nPost'}}}))
+const mockLanguageFilter = vi.fn(() => ({
+  selectedLanguageIds: ['en', 'es', 'fr', 'de'],
+  options: {documentTypes: [] as string[], filterField: () => true},
+}))
+
+vi.mock('sanity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('sanity')>()
+  return {
+    ...actual,
+    useClient: vi.fn(() => mockClient),
+    useWorkspace: () => mockUseWorkspace(),
+  }
+})
+
+vi.mock('sanity/structure', () => ({
+  useDocumentPane: () => mockUseDocumentPane(),
+}))
+
+vi.mock('@sanity/language-filter', () => ({
+  useLanguageFilterStudioContext: () => mockLanguageFilter(),
+}))
+
+function ContextReader() {
+  const ctx = useInternationalizedArrayContext()
+  return (
+    <div>
+      <span data-testid="lang-count">{ctx.languages.length}</span>
+      <span data-testid="first-lang">{ctx.languages[0]?.id ?? 'none'}</span>
+      <span data-testid="filtered-count">{ctx.filteredLanguages.length}</span>
+      <span data-testid="filtered-ids">{ctx.filteredLanguages.map((l) => l.id).join(',')}</span>
+    </div>
+  )
+}
+
+function createConfig(overrides: Partial<Required<PluginConfig>> = {}): Required<PluginConfig> {
+  return {
+    ...CONFIG_DEFAULT,
+    languages: MOCK_LANGUAGES,
+    fieldTypes: ['string'],
+    ...overrides,
+  }
+}
+
+async function renderWithSuspense(config: Required<PluginConfig>, documentType = 'i18nPost') {
+  await act(async () => {
+    render(
+      <Suspense fallback={<div data-testid="loading" />}>
+        <InternationalizedArrayProvider internationalizedArray={config} documentType={documentType}>
+          <ContextReader />
+        </InternationalizedArrayProvider>
+      </Suspense>,
+      {wrapper: ThemeWrapper},
+    )
+  })
+}
+
+describe('InternationalizedArrayProvider', () => {
+  beforeEach(() => {
+    clear()
+    mockUseWorkspace.mockReturnValue({name: 'default'})
+    mockLanguageFilter.mockReturnValue({
+      selectedLanguageIds: ['en', 'es', 'fr', 'de'],
+      options: {documentTypes: [], filterField: () => true},
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clear()
+    vi.clearAllMocks()
+  })
+
+  test('provides sync languages to descendants', () => {
+    render(
+      <InternationalizedArrayProvider
+        internationalizedArray={createConfig()}
+        documentType="i18nPost"
+      >
+        <ContextReader />
+      </InternationalizedArrayProvider>,
+      {wrapper: ThemeWrapper},
+    )
+
+    expect(screen.getByTestId('lang-count')).toHaveTextContent(String(MOCK_LANGUAGES.length))
+    expect(screen.getByTestId('first-lang')).toHaveTextContent('en')
+    expect(screen.getByTestId('filtered-count')).toHaveTextContent(String(MOCK_LANGUAGES.length))
+  })
+
+  test('resolves async languages once and provides them', async () => {
+    const asyncLanguages = vi.fn(async () => MOCK_LANGUAGES.slice(0, 2))
+    mockUseWorkspace.mockReturnValue({name: 'workspace-async-i18n-array'})
+
+    await renderWithSuspense(createConfig({languages: asyncLanguages}))
+
+    expect(await screen.findByTestId('lang-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('first-lang')).toHaveTextContent('en')
+    expect(asyncLanguages).toHaveBeenCalledTimes(1)
+  })
+
+  test('filters languages when language-filter is enabled for the document type', () => {
+    mockLanguageFilter.mockReturnValue({
+      selectedLanguageIds: ['en', 'fr'],
+      options: {documentTypes: ['i18nPost'], filterField: () => true},
+    })
+
+    render(
+      <InternationalizedArrayProvider
+        internationalizedArray={createConfig()}
+        documentType="i18nPost"
+      >
+        <ContextReader />
+      </InternationalizedArrayProvider>,
+      {wrapper: ThemeWrapper},
+    )
+
+    expect(screen.getByTestId('filtered-ids')).toHaveTextContent('en,fr')
+    expect(screen.getByTestId('lang-count')).toHaveTextContent(String(MOCK_LANGUAGES.length))
+  })
+
+  test('does not filter languages when document type is not in languageFilter', () => {
+    mockLanguageFilter.mockReturnValue({
+      selectedLanguageIds: ['en'],
+      options: {documentTypes: ['otherType'], filterField: () => true},
+    })
+
+    render(
+      <InternationalizedArrayProvider
+        internationalizedArray={createConfig()}
+        documentType="i18nPost"
+      >
+        <ContextReader />
+      </InternationalizedArrayProvider>,
+      {wrapper: ThemeWrapper},
+    )
+
+    expect(screen.getByTestId('filtered-count')).toHaveTextContent(String(MOCK_LANGUAGES.length))
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayFormInput.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayFormInput.test.tsx
@@ -1,0 +1,49 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion */
+import {cleanup, render, screen} from '@testing-library/react'
+import type {ObjectInputProps} from 'sanity'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+import {CONFIG_DEFAULT} from '../constants'
+import {ThemeWrapper} from '../test/component-helpers'
+import type {PluginConfig} from '../types'
+import {InternationalizedArrayFormInput} from './InternationalizedArrayFormInput'
+
+vi.mock('./DocumentAddButtons', () => ({
+  default: () => <div data-testid="document-add-buttons" />,
+}))
+
+function createProps(
+  buttonLocations: ('field' | 'document')[],
+): ObjectInputProps & {pluginConfig: Required<PluginConfig>} {
+  return {
+    pluginConfig: {
+      ...CONFIG_DEFAULT,
+      buttonLocations,
+    },
+    renderDefault: () => <div data-testid="default-input" />,
+  } as unknown as ObjectInputProps & {pluginConfig: Required<PluginConfig>}
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('InternationalizedArrayFormInput', () => {
+  test('renders document add buttons when buttonLocations includes document', () => {
+    render(<InternationalizedArrayFormInput {...createProps(['field', 'document'])} />, {
+      wrapper: ThemeWrapper,
+    })
+
+    expect(screen.getByTestId('document-add-buttons')).toBeInTheDocument()
+    expect(screen.getByTestId('default-input')).toBeInTheDocument()
+  })
+
+  test('renders only default input when document buttons are not configured', () => {
+    render(<InternationalizedArrayFormInput {...createProps(['field'])} />, {
+      wrapper: ThemeWrapper,
+    })
+
+    expect(screen.queryByTestId('document-add-buttons')).not.toBeInTheDocument()
+    expect(screen.getByTestId('default-input')).toBeInTheDocument()
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayLayout.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArrayLayout.test.tsx
@@ -1,0 +1,125 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion */
+import {cleanup, render, screen} from '@testing-library/react'
+import type {DocumentLayoutProps} from 'sanity'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {CONFIG_DEFAULT} from '../constants'
+import {MOCK_LANGUAGES} from '../test/helpers'
+import type {PluginConfig} from '../types'
+import {InternationalizedArrayLayout} from './InternationalizedArrayLayout'
+
+const mockUseSchema = vi.fn()
+
+vi.mock('sanity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('sanity')>()
+  return {
+    ...actual,
+    useSchema: () => mockUseSchema(),
+    isDocumentSchemaType: (schemaType: {jsonType?: string}) => schemaType?.jsonType === 'object',
+  }
+})
+
+vi.mock('./InternationalizedArrayContext', () => ({
+  InternationalizedArrayProvider: ({
+    children,
+    documentType,
+  }: {
+    children: React.ReactNode
+    documentType: string
+  }) => (
+    <div data-testid="i18n-provider" data-document-type={documentType}>
+      {children}
+    </div>
+  ),
+}))
+
+function createProps(documentType: string): DocumentLayoutProps & {
+  pluginConfig: Required<PluginConfig>
+} {
+  return {
+    documentType,
+    pluginConfig: {
+      ...CONFIG_DEFAULT,
+      languages: MOCK_LANGUAGES,
+      fieldTypes: ['string'],
+    },
+    renderDefault: () => <div data-testid="default-layout" />,
+  } as unknown as DocumentLayoutProps & {pluginConfig: Required<PluginConfig>}
+}
+
+describe('InternationalizedArrayLayout', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  test('wraps with provider when schema has internationalized array fields', () => {
+    mockUseSchema.mockReturnValue({
+      get: () => ({
+        name: 'i18nPost',
+        jsonType: 'object',
+        fields: [
+          {
+            name: 'title',
+            type: {name: 'internationalizedArrayString', jsonType: 'array', of: []},
+          },
+        ],
+      }),
+    })
+
+    render(<InternationalizedArrayLayout {...createProps('i18nPost')} />)
+
+    expect(screen.getByTestId('i18n-provider')).toHaveAttribute('data-document-type', 'i18nPost')
+    expect(screen.getByTestId('default-layout')).toBeInTheDocument()
+  })
+
+  test('skips provider when schema has no internationalized arrays', () => {
+    mockUseSchema.mockReturnValue({
+      get: () => ({
+        name: 'plainDoc',
+        jsonType: 'object',
+        fields: [{name: 'title', type: {name: 'string', jsonType: 'string'}}],
+      }),
+    })
+
+    render(<InternationalizedArrayLayout {...createProps('plainDoc')} />)
+
+    expect(screen.queryByTestId('i18n-provider')).not.toBeInTheDocument()
+    expect(screen.getByTestId('default-layout')).toBeInTheDocument()
+  })
+
+  test('skips provider when includeForDocumentType returns false', () => {
+    mockUseSchema.mockReturnValue({
+      get: () => ({
+        name: 'translation.metadata',
+        jsonType: 'object',
+        fields: [
+          {
+            name: 'translations',
+            type: {name: 'internationalizedArrayReference', jsonType: 'array', of: []},
+          },
+        ],
+      }),
+    })
+
+    const props = createProps('translation.metadata')
+    render(<InternationalizedArrayLayout {...props} />)
+
+    expect(screen.queryByTestId('i18n-provider')).not.toBeInTheDocument()
+    expect(screen.getByTestId('default-layout')).toBeInTheDocument()
+  })
+
+  test('falls back to default when schema type is missing', () => {
+    mockUseSchema.mockReturnValue({get: () => undefined})
+
+    render(<InternationalizedArrayLayout {...createProps('missing')} />)
+
+    expect(screen.queryByTestId('i18n-provider')).not.toBeInTheDocument()
+    expect(screen.getByTestId('default-layout')).toBeInTheDocument()
+    expect(console.error).toHaveBeenCalled()
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedInput.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedInput.test.tsx
@@ -1,7 +1,9 @@
-import {cleanup, render, screen} from '@testing-library/react'
+import {cleanup, fireEvent, render, screen} from '@testing-library/react'
 import type {ReactNode} from 'react'
+import {set} from 'sanity'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
+import {LANGUAGE_FIELD_NAME} from '../constants'
 import {ThemeWrapper} from '../test/component-helpers'
 import {MOCK_INTERNATIONALIZED_ARRAY_CONTEXT, MOCK_LANGUAGES, createValue} from '../test/helpers'
 import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
@@ -220,5 +222,23 @@ describe('InternationalizedInput', () => {
 
     expect(screen.getByTestId('mock-input')).toBeInTheDocument()
     expect(props.inputProps.renderInput).toHaveBeenCalled()
+  })
+
+  test('Change language menu patches set(language) for an unused language', () => {
+    // Parent only has the invalid key item — ES/DE are free to select
+    mockUseFormValue.mockReturnValue([createValue('xx', {value: 'legacy'})])
+
+    const props = createMockProps('xx')
+
+    render(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedInput {...props} />,
+      {wrapper: ThemeWrapper},
+    )
+
+    fireEvent.click(screen.getByText('Change "xx"'))
+    fireEvent.click(screen.getByRole('menuitem', {name: 'ES'}))
+
+    expect(props.inputProps.onChange).toHaveBeenCalledWith([set('es', [LANGUAGE_FIELD_NAME])])
   })
 })

--- a/plugins/sanity-plugin-internationalized-array/src/components/Preload.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/Preload.test.tsx
@@ -1,0 +1,55 @@
+import {cleanup, render} from '@testing-library/react'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {clear, createCacheKey, createOrGetPromise, peek} from '../cache'
+import {MOCK_LANGUAGES} from '../test/helpers'
+import Preload from './Preload'
+
+const mockClient = {fetch: vi.fn()}
+
+vi.mock('sanity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('sanity')>()
+  return {
+    ...actual,
+    useClient: vi.fn(() => mockClient),
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  clear()
+})
+
+describe('Preload', () => {
+  beforeEach(() => {
+    clear()
+  })
+
+  test('warms the promise cache for async languages', async () => {
+    const languages = vi.fn(async () => MOCK_LANGUAGES)
+
+    render(<Preload apiVersion="2025-10-15" languages={languages} />)
+
+    const key = createCacheKey({})
+    const result = await createOrGetPromise(async () => {
+      throw new Error('should reuse the preloaded promise')
+    }, key)
+
+    expect(result).toEqual(MOCK_LANGUAGES)
+    expect(languages).toHaveBeenCalledWith(mockClient, {})
+  })
+
+  test('does not start a second preload when cache is already warm', async () => {
+    const first = vi.fn(async () => MOCK_LANGUAGES.slice(0, 1))
+    const second = vi.fn(async () => MOCK_LANGUAGES)
+
+    render(<Preload apiVersion="2025-10-15" languages={first} />)
+    await createOrGetPromise(async () => MOCK_LANGUAGES.slice(0, 1), createCacheKey({}))
+
+    render(<Preload apiVersion="2025-10-15" languages={second} />)
+
+    expect(second).not.toHaveBeenCalled()
+    // peek returns undefined until React's promise status fields are set
+    expect(peek({}) === undefined || Array.isArray(peek({}))).toBe(true)
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/plugin.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/plugin.test.tsx
@@ -1,0 +1,167 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion */
+import {languageFilter} from '@sanity/language-filter'
+import type {ObjectInputProps, ObjectSchemaType, SchemaTypeDefinition} from 'sanity'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+import {internationalizedArray} from './plugin'
+import {MOCK_LANGUAGES} from './test/helpers'
+
+vi.mock('@sanity/language-filter', () => ({
+  languageFilter: vi.fn((config: unknown) => ({
+    name: 'mock-language-filter',
+    config,
+  })),
+}))
+
+vi.mock('./components/InternationalizedArrayLayout', () => ({
+  InternationalizedArrayLayout: (props: {renderDefault: (p: unknown) => unknown}) =>
+    props.renderDefault(props),
+}))
+
+vi.mock('./components/InternationalizedArrayFormInput', () => ({
+  InternationalizedArrayFormInput: () => <div data-testid="i18n-form-input" />,
+}))
+
+vi.mock('./components/Preload', () => ({
+  default: () => null,
+}))
+
+type PluginInstance = ReturnType<typeof internationalizedArray>
+type InputComponent = (props: Record<string, unknown>) => unknown
+
+function createPlugin(
+  overrides: Partial<Parameters<typeof internationalizedArray>[0]> = {},
+): PluginInstance {
+  return internationalizedArray({
+    languages: MOCK_LANGUAGES,
+    fieldTypes: ['string', 'text'],
+    ...overrides,
+  })
+}
+
+function getSchemaTypes(plugin: PluginInstance): SchemaTypeDefinition[] {
+  return plugin.schema!.types as unknown as SchemaTypeDefinition[]
+}
+
+describe('internationalizedArray plugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('registers array and value object schema types for each fieldType', () => {
+    const types = getSchemaTypes(createPlugin())
+    const names = types.map((t) => t.name)
+
+    expect(names).toContain('internationalizedArrayString')
+    expect(names).toContain('internationalizedArrayStringValue')
+    expect(names).toContain('internationalizedArrayText')
+    expect(names).toContain('internationalizedArrayTextValue')
+  })
+
+  test('registers document layout wrapper', () => {
+    const plugin = createPlugin()
+    expect(plugin.document?.components?.unstable_layout).toBeTypeOf('function')
+  })
+
+  test('registers form input wrapper for root object inputs', () => {
+    const plugin = createPlugin()
+    expect(plugin.form?.components?.input).toBeTypeOf('function')
+  })
+
+  test('form input renders default when not root', () => {
+    const plugin = createPlugin()
+    const input = plugin.form!.components!.input as unknown as InputComponent
+    const renderDefault = vi.fn(() => <div data-testid="default" />)
+
+    input({
+      id: 'title',
+      renderDefault,
+      schemaType: {name: 'string', jsonType: 'string'},
+    })
+
+    expect(renderDefault).toHaveBeenCalled()
+  })
+
+  test('form input uses InternationalizedArrayFormInput for root docs with i18n arrays', () => {
+    const plugin = createPlugin()
+    const input = plugin.form!.components!.input as unknown as (props: ObjectInputProps) => unknown
+
+    const schemaType = {
+      name: 'i18nPost',
+      jsonType: 'object',
+      fields: [
+        {
+          name: 'title',
+          type: {
+            name: 'internationalizedArrayString',
+            jsonType: 'array',
+            type: {name: 'array', jsonType: 'array'},
+          },
+        },
+      ],
+    } as unknown as ObjectSchemaType
+
+    const result = input({
+      id: 'root',
+      schemaType,
+      renderDefault: () => <div />,
+    } as unknown as ObjectInputProps)
+
+    expect(result).toBeTruthy()
+  })
+
+  test('adds field actions when buttonLocations includes unstable__fieldAction', () => {
+    const plugin = createPlugin({buttonLocations: ['field', 'unstable__fieldAction']})
+    const fieldActions = plugin.document!.unstable_fieldActions
+    expect(fieldActions).toBeTypeOf('function')
+
+    const next = (fieldActions as unknown as (prev: unknown[]) => unknown[])([])
+    expect(next).toHaveLength(1)
+  })
+
+  test('omits field actions when unstable__fieldAction is not configured', () => {
+    const plugin = createPlugin({buttonLocations: ['field']})
+    expect(plugin.document!.unstable_fieldActions).toBeUndefined()
+  })
+
+  test('nests languageFilter plugin when languageFilter.documentTypes is set', () => {
+    createPlugin({
+      languageFilter: {
+        documentTypes: ['i18nPost'],
+        defaultLanguages: ['en'],
+      },
+    })
+
+    expect(languageFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentTypes: ['i18nPost'],
+        supportedLanguages: MOCK_LANGUAGES,
+        defaultLanguages: ['en'],
+      }),
+    )
+  })
+
+  test('does not nest languageFilter when documentTypes is empty', () => {
+    const plugin = createPlugin({
+      languageFilter: {documentTypes: []},
+    })
+    expect(plugin.plugins).toBeUndefined()
+    expect(languageFilter).not.toHaveBeenCalled()
+  })
+
+  test('adds studio layout Preload when languages is a callback', () => {
+    const plugin = createPlugin({
+      languages: async () => MOCK_LANGUAGES,
+    })
+    expect(plugin.studio?.components?.layout).toBeTypeOf('function')
+  })
+
+  test('omits studio layout Preload when languages is a static array', () => {
+    const plugin = createPlugin({languages: MOCK_LANGUAGES})
+    expect(plugin.studio).toBeUndefined()
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/utils/getLanguagesFieldOption.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/getLanguagesFieldOption.test.ts
@@ -1,0 +1,43 @@
+/* oxlint-disable typescript-eslint/no-unsafe-type-assertion */
+import type {SchemaType} from 'sanity'
+import {describe, expect, test} from 'vitest'
+
+import {MOCK_LANGUAGES} from '../test/helpers'
+import {getLanguagesFieldOption} from './getLanguagesFieldOption'
+
+describe('getLanguagesFieldOption', () => {
+  test('returns undefined when schemaType is missing', () => {
+    expect(getLanguagesFieldOption(undefined)).toBeUndefined()
+  })
+
+  test('returns languages from options on the schema type', () => {
+    const schemaType = {
+      name: 'internationalizedArrayString',
+      options: {languages: MOCK_LANGUAGES},
+    } as unknown as SchemaType
+
+    expect(getLanguagesFieldOption(schemaType)).toEqual(MOCK_LANGUAGES)
+  })
+
+  test('walks parent type chain until languages options are found', () => {
+    const parent = {
+      name: 'internationalizedArrayString',
+      options: {languages: MOCK_LANGUAGES.slice(0, 2)},
+    }
+    const schemaType = {
+      name: 'title',
+      type: parent,
+    } as unknown as SchemaType
+
+    expect(getLanguagesFieldOption(schemaType)).toEqual(MOCK_LANGUAGES.slice(0, 2))
+  })
+
+  test('returns undefined when no languages option exists in the chain', () => {
+    const schemaType = {
+      name: 'title',
+      type: {name: 'string'},
+    } as unknown as SchemaType
+
+    expect(getLanguagesFieldOption(schemaType)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands test coverage for `sanity-plugin-internationalized-array` following the same playbook as document-internationalization: fill Vitest gaps, wire Playwright e2e for core field UX, and add a reusable `plugin-test-coverage` agent skill.

**Out of scope:** Migrations / MigrationBanner (Vitest and e2e) — one-off tooling, not part of the main authoring loop.

## Use-case inventory

| Use case | Unit/integration? | E2e? |
| --- | --- | --- |
| Plugin registers array/object types for `fieldTypes` | Vitest plugin test | Indirect via studio |
| Static / async languages + `defaultLanguages` seed | Context/cache/plugin | E2e: persisted empty doc seeds EN |
| Add language / add all missing | Covered | E2e: Add + Add all |
| Remove language (blocked for defaults) | Covered | E2e: remove non-default |
| Language display modes | Covered | Skip |
| Document-level add buttons | Component-tested + testid | E2e: root-field buttons |
| Field actions (`unstable__fieldAction`) | Covered | Skip (unstable) |
| `@sanity/language-filter` integration | Filter util + context | E2e: filter hides/shows items |
| Built-in validation | Schema tests | Skip |
| Complex/aliased object fieldTypes | Schema tests | Skip for v1 |
| Migrations / MigrationBanner | **Out of scope** | **Out of scope** |

## Vitest additions

- `plugin.test.tsx` — schema registration, layout/form wrappers, language-filter nesting, field actions, Preload studio layout
- `cache.test.ts` + `Preload.test.tsx` — promise cache, clear, function cache, preload warming
- `InternationalizedArrayContext.test.tsx` — sync/async languages, language-filter filtering
- `InternationalizedArrayLayout.test.tsx` / `InternationalizedArrayFormInput.test.tsx`
- `Feedback.test.tsx`, `getLanguagesFieldOption.test.ts`
- Change-language menu → `set(language)` in `InternationalizedInput.test.tsx`

## E2e tests

| Test | Covers | Why |
| --- | --- | --- |
| Seeds default language on an existing empty document | Opening persisted `i18nPost` with empty `title: []` shows EN from `defaultLanguages` | Core config guarantee (`_rev` required) |
| Adds Spanish from field add buttons | Click Spanish add → item appears | Main authoring flow |
| Adds all missing languages | Add-all fills remaining langs | Bulk UX |
| Removes a non-default language | Remove Spanish; English remove disabled | Default-language protection |
| Document-level add buttons | Doc panel adds missing language across root i18n fields | Document-button location |
| Language filter hides items | Filter to English hides ES/FR array items | `@sanity/language-filter` integration |

Wired in `dev/e2e-studio` for both chromium/firefox workspaces (`i18nPost`, EN/ES/FR, `buttonLocations: ['field','document']`).

## Other

- Patch changeset for `data-testid="document-add-buttons"`
- New skill: `.agents/skills/plugin-test-coverage/SKILL.md` (+ `.claude/skills` symlink)
- Pointer in `AGENTS.md`; `e2e/README.md` “Currently wired” updated

## Checklist

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm build`
- [x] `pnpm test run`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2a2cfac-a984-4202-b01d-0443f773c071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2a2cfac-a984-4202-b01d-0443f773c071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

