### PR TITLE
fix(deps): update dependency jsdom to v30

### DIFF
--- a/.changeset/jsdom-v30-block-insert-picker.md
+++ b/.changeset/jsdom-v30-block-insert-picker.md
@@ -1,0 +1,5 @@
+---
+"@sanity/block-insert-picker": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-document-internationalization.md
+++ b/.changeset/jsdom-v30-document-internationalization.md
@@ -1,0 +1,5 @@
+---
+"@sanity/document-internationalization": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-internationalized-array.md
+++ b/.changeset/jsdom-v30-internationalized-array.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-language-filter.md
+++ b/.changeset/jsdom-v30-language-filter.md
@@ -1,0 +1,5 @@
+---
+"@sanity/language-filter": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-media.md
+++ b/.changeset/jsdom-v30-media.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-naive-html-serializer.md
+++ b/.changeset/jsdom-v30-naive-html-serializer.md
@@ -1,0 +1,5 @@
+---
+"sanity-naive-html-serializer": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-presets.md
+++ b/.changeset/jsdom-v30-presets.md
@@ -1,0 +1,5 @@
+---
+"@sanity/presets": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/.changeset/jsdom-v30-studio-secrets.md
+++ b/.changeset/jsdom-v30-studio-secrets.md
@@ -1,0 +1,5 @@
+---
+"@sanity/studio-secrets": patch
+---
+
+fix(deps): update dependency jsdom to v30

--- a/patches/jsdom@30.0.0.patch
+++ b/patches/jsdom@30.0.0.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/jsdom/living/css/helpers/font-sizes.js b/lib/jsdom/living/css/helpers/font-sizes.js
+index 48b90f91b98259bdb5db7e73dda8c3dd68bac285..a5c2abd1611f77df80919031c23fa1caa0c65135 100644
+--- a/lib/jsdom/living/css/helpers/font-sizes.js
++++ b/lib/jsdom/living/css/helpers/font-sizes.js
+@@ -113,8 +113,13 @@ function resolveLengthInPixels(elementImpl, size, dimension, isFontSize) {
+         format: "computedValue"
+       });
+     }
+-    const [, value] = FONT_SIZE_REGEXP.exec(resolvedSize);
+-    return Number(value);
++    const match = FONT_SIZE_REGEXP.exec(resolvedSize);
++    if (match) {
++      const [, value] = match;
++      return Number(value);
++    }
++    // resolveCalc may leave percentage-based calc() unresolved; fall through.
++    return resolvedSize;
+   }
+ 
+   const match = LENGTH_REGEXP.exec(size);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ catalogs:
       specifier: ^4.4.0
       version: 4.4.0
     jsdom:
-      specifier: ^29.1.1
-      version: 29.1.1
+      specifier: ^30.0.0
+      version: 30.0.0
     lexorank:
       specifier: ^1.0.5
       version: 1.0.5
@@ -190,6 +190,9 @@ overrides:
   groq: ^6.6.0
   sanity: ^6.6.0
 
+patchedDependencies:
+  jsdom@30.0.0: 96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b
+
 importers:
 
   .:
@@ -229,7 +232,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0)(vite@8.1.5)
       vitest-package-exports:
         specifier: ^1.2.0
         version: 1.2.0
@@ -685,7 +688,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1058,7 +1061,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1330,7 +1333,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1489,7 +1492,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1688,7 +1691,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1835,7 +1838,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       just-clone:
         specifier: ^6.2.0
         version: 6.2.0
@@ -2505,7 +2508,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -2709,7 +2712,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 'catalog:'
-        version: 29.1.1(@noble/hashes@2.2.0)
+        version: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -3176,7 +3179,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0)(vite@8.1.5)
 
   turbo/generators:
     devDependencies:
@@ -3263,12 +3266,20 @@ packages:
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  '@asamuzakjp/css-color@6.0.5':
+    resolution: {integrity: sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
   '@asamuzakjp/dom-selector@6.8.1':
     resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
 
   '@asamuzakjp/dom-selector@7.1.1':
     resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@asamuzakjp/generational-cache@1.0.1':
     resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
@@ -9262,6 +9273,15 @@ packages:
       canvas:
         optional: true
 
+  jsdom@30.0.0:
+    resolution: {integrity: sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -11262,6 +11282,10 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -11660,6 +11684,10 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -11985,6 +12013,14 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
+  '@asamuzakjp/css-color@6.0.5':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
   '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
@@ -12000,6 +12036,13 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/dom-selector@8.3.0':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@asamuzakjp/generational-cache@1.0.1': {}
 
@@ -16284,7 +16327,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5)
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0)(vite@8.1.5)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -18369,6 +18412,32 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
       whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  jsdom@30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.5
+      '@asamuzakjp/dom-selector': 8.3.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.9.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -20657,6 +20726,8 @@ snapshots:
 
   undici@7.29.0: {}
 
+  undici@8.9.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -20882,7 +20953,7 @@ snapshots:
       find-up-simple: 1.0.1
       pathe: 2.0.3
 
-  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.0)(vite@8.1.5):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.5)
@@ -20907,7 +20978,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      jsdom: 29.1.1(@noble/hashes@2.2.0)
+      jsdom: 30.0.0(patch_hash=96ee997136158d10b6b63dedf5acb1d27968e918f8b61d66224f9e34187c7c0b)(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
 
@@ -20938,6 +21009,14 @@ snapshots:
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@2.2.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       tr46: 6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalog:
   babel-plugin-react-compiler: ^1.0.0
   date-fns: ^4.4.0
   groq: ^6.6.0
-  jsdom: ^29.1.1
+  jsdom: ^30.0.0
   lexorank: ^1.0.5
   lodash-es: ^4.18.1
   motion: ^12.42.2
@@ -222,3 +222,6 @@ trustPolicyExclude:
   - ts-api-utils@2.3.0
   - undici@5.29.0
   - vite@6.4.1
+
+patchedDependencies:
+  jsdom@30.0.0: patches/jsdom@30.0.0.patch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the shared pnpm catalog entry for `jsdom` from `^29.1.1` to `^30.0.0`.

## Why a patch?

jsdom 30’s new `getComputedStyle()` pixel conversion crashes when resolving percentage-based `calc()` values (e.g. `width: calc(100% - 10px)`). `resolveCalc()` leaves those unresolved, then `FONT_SIZE_REGEXP.exec(...)` returns `null` and the destructuring throws:

`TypeError: object null is not iterable`

That path is hit by Testing Library / `dom-accessibility-api` during queries, which broke several plugin test suites on Renovate’s [#1767](https://github.com/sanity-io/plugins/pull/1767).

This PR adds `patches/jsdom@30.0.0.patch` so unresolved calc results fall through instead of crashing. Can be removed once upstream ships a fix.

## Packages

DevDependency bump via catalog for:

- `@sanity/block-insert-picker`
- `@sanity/document-internationalization`
- `@sanity/language-filter`
- `@sanity/presets`
- `@sanity/studio-secrets`
- `sanity-naive-html-serializer`
- `sanity-plugin-internationalized-array`
- `sanity-plugin-media`

Note: jsdom 30 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b73e943-6e1f-4fa3-9b00-2361951c0364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b73e943-6e1f-4fa3-9b00-2361951c0364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

