### PR TITLE
docs(shopify-assets): update Sanity Connect option name

### DIFF
--- a/plugins/sanity-plugin-shopify-assets/README.md
+++ b/plugins/sanity-plugin-shopify-assets/README.md
@@ -26,7 +26,7 @@ export const defineConfig({
 })
 ```
 
-Simply update the `shopifyDomain` to your store URL. You'll need to install the [Sanity Connect](https://www.sanity.io/docs/sanity-connect-for-shopify) app on your store to handle authorisation. You'll need to ensure the Liquid sync option is enabled within the Sanity Connect app.
+Simply update the `shopifyDomain` to your store URL. You'll need to install the [Sanity Connect](https://www.sanity.io/docs/sanity-connect-for-shopify) app on your store to handle authorisation. You'll need to ensure the Sync content from Sanity to Shopify option is enabled within the Sanity Connect app.
 
 Then you can enable the asset selector on a field:
 


### PR DESCRIPTION
### Description

Updates the `sanity-plugin-shopify-assets` README to use the current Sanity Connect option name, `Sync content from Sanity to Shopify`, instead of the outdated `Liquid sync` label.

### What to review

Verify that the `sanity-plugin-shopify-assets` plugin README references the correct option name.

### Testing

Documentation-only change. No runtime testing required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README wording change with no runtime or security impact.
> 
> **Overview**
> Updates the `sanity-plugin-shopify-assets` README setup step so it matches the current Sanity Connect UI wording.
> 
> The authorisation section now says to enable **Sync content from Sanity to Shopify** in the Sanity Connect app, replacing the outdated **Liquid sync** name. No code or plugin behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f0b910687d83e8996dd63d492a12b6e7a1afa83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->