### PR TITLE
chore: rely on pnpm v11 default minimumReleaseAge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Use the **latest LTS** release of Node.js.
 
 ### pnpm Version
 
-The exact pnpm version is managed via the `packageManager` field in root `package.json`. You only need pnpm **v10 or later** installed globally—corepack or pnpm itself will auto-install the exact version specified.
+The exact pnpm version is managed via the `packageManager` field in root `package.json`. You only need pnpm **v11 or later** installed globally—corepack or pnpm itself will auto-install the exact version specified.
 
 ```bash
 # Enable corepack to automatically use the correct pnpm version
@@ -36,6 +36,8 @@ corepack enable
 # Install all dependencies
 pnpm install
 ```
+
+pnpm v11 defaults `minimumReleaseAge` to 1 day. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` lists first-party packages and closely tracked tooling that may need immediate installs. For a one-off third-party upgrade of a version still inside that window, use `pnpm add … --config.minimumReleaseAge=0` (or a version-specific exclude) rather than permanently exempting the package.
 
 ## Before Submitting a PR
 
@@ -519,7 +521,7 @@ Run `pnpm build` first—some packages need to be built for type information to 
 
 ### "Command not found: pnpm"
 
-Ensure you have pnpm v10+ installed, then run:
+Ensure you have pnpm v11+ installed, then run:
 
 ```bash
 corepack enable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,9 @@ corepack enable
 pnpm install
 ```
 
-pnpm v11 defaults `minimumReleaseAge` to 1 day. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` lists first-party packages and closely tracked tooling that may need immediate installs. For a one-off third-party upgrade of a version still inside that window, use `pnpm add … --config.minimumReleaseAge=0` (or a version-specific exclude) rather than permanently exempting the package.
+pnpm v11 defaults `minimumReleaseAge` to 1 day. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` lists first-party packages and closely tracked tooling that may need immediate installs, plus version-specific pins (e.g. `react-rx@4.2.5`) for one-off upgrades still inside that window.
+
+Do **not** bypass the maturity check with `pnpm add … --config.minimumReleaseAge=0` (or any other `--config.minimumReleaseAge` override). That is not allowed. If `pnpm install` fails because a needed version is too new, add that exact `name@version` to `minimumReleaseAgeExclude` instead.
 
 ## Before Submitting a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thank you for your interest in contributing to the Sanity Plugins monorepo! This
 ### Prerequisites
 
 - Node.js (latest LTS)
-- [pnpm](https://pnpm.io/) v10 or later — the exact version is managed via `packageManager` in root `package.json`
+- [pnpm](https://pnpm.io/) v11 or later — the exact version is managed via `packageManager` in root `package.json`
 
 ### Initial Setup
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The packages folder contains two types of packages:
 ### Prerequisites
 
 - Node.js (latest LTS)
-- [pnpm](https://pnpm.io/) v10 or later (managed via corepack)
+- [pnpm](https://pnpm.io/) v11 or later (managed via corepack)
 
 ### Installation
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,14 +97,16 @@ dedupeDirectDeps: true
 dedupePeers: true
 linkWorkspacePackages: deep
 
-# Matches the pnpm v11 default (1 day)
-minimumReleaseAge: 1440
-
+# minimumReleaseAge defaults to 1440 (1 day) in pnpm v11 — do not set it
+# explicitly unless overriding the default.
+#
+# Keep this list to first-party packages and closely tracked tooling that may
+# need immediate installs. Prefer `pnpm add … --config.minimumReleaseAge=0` (or
+# a version-specific exclude) for one-off third-party upgrades; avoid permanent
+# third-party package excludes solely to land a fresh release.
 minimumReleaseAgeExclude:
   - '@changesets/cli'
-  - '@csstools/*'
   - '@devframes/*'
-  - '@oclif/*'
   - '@oxfmt/*'
   - '@oxlint/*'
   - '@oxlint-tsgolint/*'
@@ -119,10 +121,9 @@ minimumReleaseAgeExclude:
   - '@vitejs/devtools-kit'
   - '@vitejs/plugin-react'
   - '@vitest/*'
-  - '@vercel/stega'
-  - baseline-browser-mapping
-  - brace-expansion
-  - csstype
+  - '@yuku-codegen/*'
+  - '@yuku-parser/*'
+  - '@yuku-toolchain/*'
   - devframe
   - get-it
   - groq
@@ -130,51 +131,19 @@ minimumReleaseAgeExclude:
   - oxfmt
   - oxlint
   - oxlint-tsgolint
+  - publint
   - react
   - react-dom
   - react-is
-  - html-parse-stringify
-  - mdurl
-  - publint
-  # Renovate dependency update: styled-components@6.4.4
-  - styled-components@6.4.4
+  - rolldown-plugin-dts
   - rollup
   - sanity
+  - tsdown
+  - verkit
   - vite
   - vitest
-  # Renovate security update: lodash-es@4.17.23
-  - lodash-es@4.17.23
-  # Renovate security update: uuid@14.0.0
-  - uuid@14.0.0
-  # Renovate security update: turbo@2.9.14
-  - turbo@2.9.14
-  # tsdown can select a newly released rolldown-plugin-dts version.
-  - tsdown
-  - rolldown-plugin-dts
-  # tsdown transitive dependency can be newly published.
-  - verkit
-  # pkg-utils / tsdown-config / vanilla-extract plugins depend on lightningcss ^1.33.0
-  - lightningcss@1.33.0
-  - lightningcss-android-arm64@1.33.0
-  - lightningcss-darwin-arm64@1.33.0
-  - lightningcss-darwin-x64@1.33.0
-  - lightningcss-freebsd-x64@1.33.0
-  - lightningcss-linux-arm-gnueabihf@1.33.0
-  - lightningcss-linux-arm64-gnu@1.33.0
-  - lightningcss-linux-arm64-musl@1.33.0
-  - lightningcss-linux-x64-gnu@1.33.0
-  - lightningcss-linux-x64-musl@1.33.0
-  - lightningcss-win32-arm64-msvc@1.33.0
-  - lightningcss-win32-x64-msvc@1.33.0
-  # Renovate dependency update: @sanity/vanilla-extract-tsdown-plugin@0.2.8
-  - '@sanity/vanilla-extract-tsdown-plugin@0.2.8'
-  # Renovate dependency update: @sanity/vanilla-extract-rolldown-plugin@0.3.2
-  - '@sanity/vanilla-extract-rolldown-plugin@0.3.2'
-  - '@yuku-codegen/*'
-  - '@yuku-parser/*'
-  - '@yuku-toolchain/*'
-  - yuku-codegen
   - yuku-ast
+  - yuku-codegen
   - yuku-parser
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,9 +101,10 @@ linkWorkspacePackages: deep
 # explicitly unless overriding the default.
 #
 # Keep this list to first-party packages and closely tracked tooling that may
-# need immediate installs. Prefer `pnpm add … --config.minimumReleaseAge=0` (or
-# a version-specific exclude) for one-off third-party upgrades; avoid permanent
-# third-party package excludes solely to land a fresh release.
+# need immediate installs. For one-off upgrades still inside the maturity
+# window, add exact `name@version` entries (do not bypass with
+# `--config.minimumReleaseAge=0` — that is not allowed). Avoid permanent
+# third-party package-name excludes solely to land a fresh release.
 minimumReleaseAgeExclude:
   - '@changesets/cli'
   - '@devframes/*'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

pnpm is already on **v11.13.1** via `packageManager`. This PR leans into v11’s built-in supply-chain defaults and cleans up accumulated release-age exemptions.

### Changes

- **Drop explicit `minimumReleaseAge: 1440`** — pnpm v11 already defaults to 1 day; verified that unset config skips packages younger than 24h (e.g. resolves `baseline-browser-mapping@2.11.5` while `2.11.6` is ~16h old).
- **Prune `minimumReleaseAgeExclude`**:
  - Removed stale Renovate version pins (`lodash-es@4.17.23`, `uuid@14.0.0`, `turbo@2.9.14`, `styled-components@6.4.4`, `lightningcss@1.33.0` + platform packages, vanilla-extract plugin pins) — all well past the 1-day window (and several no longer in the lockfile).
  - Removed one-off third-party package excludes (`@csstools/*`, `@oclif/*`, `@vercel/stega`, `baseline-browser-mapping`, `brace-expansion`, `csstype`, `html-parse-stringify`, `mdurl`) that were added to land a single upgrade and permanently weakened the maturity check.
  - Kept first-party / closely tracked tooling (`@sanity/*`, oxlint/oxfmt, vite/vitest, tsdown/rolldown-plugin-dts + yuku/devframe companions, react, etc.).
  - Kept a temporary `react-rx@4.2.5` pin from main (still within the 1-day window); drop once it ages past maturity.
- **Docs**: AGENTS.md / CONTRIBUTING.md / README.md now say pnpm **v11+**. AGENTS.md (and the `pnpm-workspace.yaml` comment) explicitly **disallow** `pnpm add … --config.minimumReleaseAge=0`; when a needed version is too new, add the exact `name@version` to `minimumReleaseAgeExclude` instead.

No lockfile or dependency version changes from this PR itself (lockfile updates came in via merge from `main`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe234c61-620c-4bdb-a43f-a10d25f32b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe234c61-620c-4bdb-a43f-a10d25f32b68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

