### PR TITLE
fix(plugin-kit): use react/prefer-function-component instead of import ban

### DIFF
--- a/.changeset/plugin-kit-prefer-function-component.md
+++ b/.changeset/plugin-kit-prefer-function-component.md
@@ -1,0 +1,5 @@
+---
+"@sanity/plugin-kit": patch
+---
+
+Prefer function components via `react/prefer-function-component` (with `allowErrorBoundary`) instead of banning `Component`/`PureComponent` imports

--- a/packages/@sanity/plugin-kit/src/oxlint.ts
+++ b/packages/@sanity/plugin-kit/src/oxlint.ts
@@ -75,11 +75,6 @@ const config: OxlintConfig = {
           },
           {
             name: 'react',
-            importNames: ['Component', 'PureComponent'],
-            message: 'Class components are not allowed. Use function components instead.',
-          },
-          {
-            name: 'react',
             importNames: ['createRef'],
             message: 'createRef is only for class components. Use the useRef hook instead.',
           },
@@ -99,6 +94,9 @@ const config: OxlintConfig = {
         ],
       },
     ],
+
+    // Prefer function components; allow class error boundaries (no hook equivalent yet)
+    'react/prefer-function-component': ['error', {allowErrorBoundary: true}],
 
     // React Compiler checks
     'react/react-compiler': 'error',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the `eslint/no-restricted-imports` ban on `Component` and `PureComponent` from `react` with oxlint's `react/prefer-function-component` rule (`allowErrorBoundary: true`).

This catches class components at the definition site (including ones that don't import those names), while still allowing error boundary classes that need `componentDidCatch` / `getDerivedStateFromError`.

The existing import bans on `createElement`, `createRef`, and `forwardRef` are unchanged.

## Test plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm build`
- [x] `pnpm test` (202 files / 1199 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1d4433a-3f94-42f1-8285-7fd46d74ea72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1d4433a-3f94-42f1-8285-7fd46d74ea72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

