### PR TITLE
chore(deps): bump react-rx to v5.1.1 and adopt useObservable

### DIFF
--- a/.changeset/assist-react-rx.md
+++ b/.changeset/assist-react-rx.md
@@ -1,0 +1,5 @@
+---
+"@sanity/assist": patch
+---
+
+Replace useEffect observable subscriptions with react-rx useObservable and bump react-rx to ^5.1.1

--- a/.changeset/dashboard-react-rx.md
+++ b/.changeset/dashboard-react-rx.md
@@ -1,0 +1,5 @@
+---
+"@sanity/dashboard": patch
+---
+
+Replace useEffect observable subscriptions with react-rx useObservable and bump react-rx to ^5.1.1

--- a/.changeset/dependencies-GH-1792.md
+++ b/.changeset/dependencies-GH-1792.md
@@ -1,8 +1,0 @@
----
-"@sanity/embeddings-index-ui": patch
-"@sanity/language-filter": patch
-"@sanity/studio-secrets": patch
-"sanity-plugin-mux-input": patch
----
-
-fix(deps): update dependency react-rx to ^4.2.5

--- a/.changeset/document-list-react-rx.md
+++ b/.changeset/document-list-react-rx.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-document-list": patch
+---
+
+Replace useEffect observable subscriptions with react-rx useObservable and bump react-rx to ^5.1.1

--- a/.changeset/embeddings-react-rx.md
+++ b/.changeset/embeddings-react-rx.md
@@ -1,0 +1,5 @@
+---
+"@sanity/embeddings-index-ui": patch
+---
+
+Bump react-rx to ^5.1.1

--- a/.changeset/language-filter-react-rx.md
+++ b/.changeset/language-filter-react-rx.md
@@ -1,0 +1,5 @@
+---
+"@sanity/language-filter": patch
+---
+
+Bump react-rx to ^5.1.1

--- a/.changeset/mux-input-react-rx.md
+++ b/.changeset/mux-input-react-rx.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-mux-input": patch
+---
+
+Bump react-rx to ^5.1.1

--- a/.changeset/studio-secrets-react-rx.md
+++ b/.changeset/studio-secrets-react-rx.md
@@ -1,0 +1,5 @@
+---
+"@sanity/studio-secrets": patch
+---
+
+Bump react-rx to ^5.1.1

--- a/.changeset/utils-react-rx.md
+++ b/.changeset/utils-react-rx.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-utils": patch
+---
+
+Replace useEffect observable subscriptions with react-rx useObservable and bump react-rx to ^5.1.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ corepack enable
 pnpm install
 ```
 
-pnpm v11 defaults `minimumReleaseAge` to 1 day. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` lists first-party packages and closely tracked tooling that may need immediate installs, plus version-specific pins (e.g. `react-rx@4.2.5`) for one-off upgrades still inside that window.
+pnpm v11 defaults `minimumReleaseAge` to 1 day. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` lists first-party packages and closely tracked tooling that may need immediate installs, plus version-specific pins (e.g. `react-rx@5.1.1`) for one-off upgrades still inside that window.
 
 Do **not** bypass the maturity check with `pnpm add … --config.minimumReleaseAge=0` (or any other `--config.minimumReleaseAge` override). That is not allowed. If `pnpm install` fails because a needed version is too new, add that exact `name@version` to `minimumReleaseAgeExclude` instead.
 

--- a/plugins/@sanity/assist/package.json
+++ b/plugins/@sanity/assist/package.json
@@ -47,6 +47,7 @@
     "date-fns": "catalog:",
     "lodash-es": "catalog:",
     "react-fast-compare": "catalog:",
+    "react-rx": "catalog:",
     "rxjs": "catalog:",
     "rxjs-exhaustmap-with-trailing": "^2.1.1"
   },

--- a/plugins/@sanity/assist/src/_lib/fixedListenQuery.ts
+++ b/plugins/@sanity/assist/src/_lib/fixedListenQuery.ts
@@ -1,7 +1,19 @@
 import type {SanityClient} from '@sanity/client'
-import {defer, delay, merge, Observable, of, partition, switchMap, throwError} from 'rxjs'
+import {
+  defer,
+  delay,
+  filter,
+  merge,
+  mergeMap,
+  Observable,
+  of,
+  partition,
+  share,
+  switchMap,
+  take,
+  throwError,
+} from 'rxjs'
 import {exhaustMapToWithTrailing} from 'rxjs-exhaustmap-with-trailing'
-import {filter, mergeMap, share, take} from 'rxjs/operators'
 import type {MutationEvent, ReconnectEvent, WelcomeEvent} from 'sanity'
 
 /** @internal */

--- a/plugins/@sanity/assist/src/_lib/useListeningQuery.ts
+++ b/plugins/@sanity/assist/src/_lib/useListeningQuery.ts
@@ -1,7 +1,7 @@
-import {useEffect, useRef, useState} from 'react'
+import {useMemo} from 'react'
 import isEqual from 'react-fast-compare'
-import {of} from 'rxjs'
-import {catchError, distinctUntilChanged} from 'rxjs/operators'
+import {useObservable} from 'react-rx'
+import {catchError, distinctUntilChanged, map, of, startWith} from 'rxjs'
 import {type ListenQueryOptions, useClient} from 'sanity'
 
 import {listenQuery} from './fixedListenQuery'
@@ -14,50 +14,38 @@ type ReturnShape<T> = {
   data: T | null
 }
 
-type Observable = {
-  unsubscribe: () => void
-}
-
 const DEFAULT_PARAMS = {}
 const DEFAULT_OPTIONS: ListenQueryOptions = {apiVersion: `v2022-05-09`}
+
+const INITIAL_STATE = {loading: true, error: false, data: null} as const
 
 export function useListeningQuery<T>(
   query: string,
   params: Params = DEFAULT_PARAMS,
   options: ListenQueryOptions = DEFAULT_OPTIONS,
 ): ReturnShape<T> {
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
-  const [data, setData] = useState<T | null>(null)
-  const subscription = useRef<null | Observable>(null)
-
   const client = useClient({apiVersion: `v2022-05-09`})
 
-  useEffect(() => {
-    if (query) {
-      subscription.current = listenQuery(client, query, params, options)
-        .pipe(
-          distinctUntilChanged(isEqual),
-          catchError((err) => {
-            console.error(err)
-            setError(true)
-            setLoading(false)
-            setData(null)
+  const state$ = useMemo(
+    () =>
+      query
+        ? listenQuery(client, query, params, options).pipe(
+            distinctUntilChanged(isEqual),
+            map((documents) => ({
+              loading: false,
+              error: false,
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- listenQuery result is typed by caller
+              data: documents as T,
+            })),
+            startWith({loading: true, error: false, data: null as T | null}),
+            catchError((err) => {
+              console.error(err)
+              return of({loading: false, error: true, data: null as T | null})
+            }),
+          )
+        : of({loading: false, error: false, data: null as T | null}),
+    [query, params, options, client],
+  )
 
-            return of(null)
-          }),
-        )
-        .subscribe((documents) => {
-          setData((current) => (isEqual(current, documents) ? current : documents))
-          setLoading(false)
-          setError(false)
-        })
-    }
-
-    return () => {
-      return subscription.current ? subscription.current.unsubscribe() : undefined
-    }
-  }, [query, params, options, client])
-
-  return {loading, error, data}
+  return useObservable(state$, INITIAL_STATE)
 }

--- a/plugins/@sanity/assist/src/_lib/useListeningQuery.ts
+++ b/plugins/@sanity/assist/src/_lib/useListeningQuery.ts
@@ -19,17 +19,29 @@ const DEFAULT_OPTIONS: ListenQueryOptions = {apiVersion: `v2022-05-09`}
 
 const INITIAL_STATE = {loading: true, error: false, data: null} as const
 
+function useStableParams(params: Params): Params {
+  const stringified = useMemo(() => JSON.stringify(params), [params])
+  return useMemo(() => JSON.parse(stringified), [stringified])
+}
+
+function useStableOptions(options: ListenQueryOptions): ListenQueryOptions {
+  const stringified = useMemo(() => JSON.stringify(options), [options])
+  return useMemo(() => JSON.parse(stringified), [stringified])
+}
+
 export function useListeningQuery<T>(
   query: string,
   params: Params = DEFAULT_PARAMS,
   options: ListenQueryOptions = DEFAULT_OPTIONS,
 ): ReturnShape<T> {
   const client = useClient({apiVersion: `v2022-05-09`})
+  const memoParams = useStableParams(params)
+  const memoOptions = useStableOptions(options)
 
   const state$ = useMemo(
     () =>
       query
-        ? listenQuery(client, query, params, options).pipe(
+        ? listenQuery(client, query, memoParams, memoOptions).pipe(
             distinctUntilChanged(isEqual),
             map((documents) => ({
               loading: false,
@@ -44,7 +56,7 @@ export function useListeningQuery<T>(
             }),
           )
         : of({loading: false, error: false, data: null as T | null}),
-    [query, params, options, client],
+    [query, memoParams, memoOptions, client],
   )
 
   return useObservable(state$, INITIAL_STATE)

--- a/plugins/@sanity/dashboard/package.json
+++ b/plugins/@sanity/dashboard/package.json
@@ -46,6 +46,7 @@
     "@sanity/icons": "catalog:",
     "@sanity/image-url": "catalog:",
     "@sanity/ui": "catalog:",
+    "react-rx": "catalog:",
     "rxjs": "catalog:"
   },
   "devDependencies": {

--- a/plugins/@sanity/dashboard/src/widgets/projectInfo/ProjectInfo.tsx
+++ b/plugins/@sanity/dashboard/src/widgets/projectInfo/ProjectInfo.tsx
@@ -1,6 +1,7 @@
 import {Box, Card, Stack, Heading, Grid, Label, Text, Code, Button} from '@sanity/ui'
-import {useEffect, useMemo, useState} from 'react'
-import {type Subscription} from 'rxjs'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of, startWith} from 'rxjs'
 
 import {DashboardWidgetContainer} from '../../components/DashboardWidgetContainer'
 import {WidgetContainer} from '../../containers/WidgetContainer'
@@ -27,57 +28,57 @@ function getManageUrl(projectId: string) {
 const NO_EXPERIMENTAL: DashboardWidget[] = []
 const NO_DATA: ProjectData[] = []
 
+type StudioAppsState = UserApplication[] | {error: string} | undefined
+type GraphQLApiState = string | {error: string} | undefined
+
 export function ProjectInfo(props: ProjectInfoProps) {
   const {__experimental_before = NO_EXPERIMENTAL, data = NO_DATA} = props
-  const [studioApps, setStudioApps] = useState<UserApplication[] | {error: string} | undefined>()
-  const [graphQLApi, setGraphQLApi] = useState<string | {error: string} | undefined>()
   const versionedClient = useVersionedClient()
   const {projectId = 'unknown', dataset = 'unknown'} = versionedClient.config()
 
-  useEffect(() => {
-    const subscriptions: Subscription[] = []
-
-    subscriptions.push(
+  const studioApps$ = useMemo(
+    () =>
       versionedClient.observable
         .request<UserApplication[]>({uri: '/user-applications', tag: 'dashboard.project-info'})
-        .subscribe({
-          next: (result) => setStudioApps(result.filter((app) => app.type === 'studio')),
-          error: (error) => {
+        .pipe(
+          map((result) => result.filter((app) => app.type === 'studio') as StudioAppsState),
+          startWith(undefined as StudioAppsState),
+          catchError((error) => {
             console.error('Error while resolving user applications', error)
-            setStudioApps({
+            return of({
               error: 'Something went wrong while resolving user applications. See console.',
-            })
-          },
-        }),
-    )
+            } as StudioAppsState)
+          }),
+        ),
+    [versionedClient],
+  )
 
-    // ping assumed graphql endpoint
-    subscriptions.push(
+  const graphQLApi$ = useMemo(
+    () =>
       versionedClient.observable
         .request({
           method: 'HEAD',
           uri: `/graphql/${dataset}/default`,
           tag: 'dashboard.project-info.graphql-api',
         })
-        .subscribe({
-          next: () => setGraphQLApi(getGraphQLUrl(projectId, dataset)),
-          error: (error) => {
+        .pipe(
+          map(() => getGraphQLUrl(projectId, dataset) as GraphQLApiState),
+          startWith(undefined as GraphQLApiState),
+          catchError((error) => {
             if (error.statusCode === 404) {
-              setGraphQLApi(undefined)
-            } else {
-              console.error('Error while looking for graphQLApi', error)
-              setGraphQLApi({
-                error: 'Something went wrong while looking up graphQLApi. See console.',
-              })
+              return of(undefined as GraphQLApiState)
             }
-          },
-        }),
-    )
+            console.error('Error while looking for graphQLApi', error)
+            return of({
+              error: 'Something went wrong while looking up graphQLApi. See console.',
+            } as GraphQLApiState)
+          }),
+        ),
+    [dataset, projectId, versionedClient],
+  )
 
-    return () => {
-      subscriptions.forEach((s) => s.unsubscribe())
-    }
-  }, [dataset, projectId, versionedClient, setGraphQLApi])
+  const studioApps = useObservable(studioApps$, undefined)
+  const graphQLApi = useObservable(graphQLApi$, undefined)
 
   const assembleTableRows = useMemo(() => {
     let result: App[] = [

--- a/plugins/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.tsx
+++ b/plugins/@sanity/dashboard/src/widgets/projectUsers/ProjectUsers.tsx
@@ -1,7 +1,7 @@
 import {Stack, Spinner, Box, Text, Button} from '@sanity/ui'
-import {useCallback, useEffect, useState} from 'react'
-import {from} from 'rxjs'
-import {map, switchMap} from 'rxjs/operators'
+import {useCallback, useMemo, useState} from 'react'
+import {useObservable} from 'react-rx'
+import {BehaviorSubject, catchError, from, map, of, startWith, switchMap} from 'rxjs'
 import {type Role, type User, useUserStore} from 'sanity'
 
 import {DashboardWidgetContainer} from '../../components/DashboardWidgetContainer'
@@ -25,50 +25,55 @@ interface Project {
   members: Member[]
 }
 
-export function ProjectUsers() {
-  const [project, setProject] = useState<Project | undefined>()
-  const [users, setUsers] = useState<User[] | undefined>()
-  const [error, setError] = useState<Error | undefined>()
+type ProjectUsersState =
+  | {status: 'loading'}
+  | {status: 'error'; error: Error}
+  | {status: 'success'; project: Project; users: User[]}
 
+const INITIAL_STATE: ProjectUsersState = {status: 'loading'}
+
+export function ProjectUsers() {
+  const [retry$] = useState(() => new BehaviorSubject(0))
   const userStore = useUserStore()
   const versionedClient = useVersionedClient()
 
-  const fetchData = useCallback(() => {
-    const {projectId} = versionedClient.config()
-    const subscription = versionedClient.observable
-      .request<Project>({
-        uri: `/projects/${projectId}`,
-        tag: 'dashboard.project-users',
-      })
-      .pipe(
-        switchMap((_project) =>
-          from(userStore.getUsers(_project.members.map((mem) => mem.id))).pipe(
-            map((_users) => ({project: _project, users: _users})),
-          ),
-        ),
-      )
-      .subscribe({
-        next: ({users: _users, project: _project}) => {
-          setProject(_project)
-          setUsers(
-            (Array.isArray(_users) ? _users : [_users]).sort((userA, userB) =>
-              sortUsersByRobotStatus(userA, userB, _project),
-            ),
-          )
-        },
-        error: (e: Error) => setError(e),
-      })
+  const state$ = useMemo(
+    () =>
+      retry$.pipe(
+        switchMap(() => {
+          const {projectId} = versionedClient.config()
+          return versionedClient.observable
+            .request<Project>({
+              uri: `/projects/${projectId}`,
+              tag: 'dashboard.project-users',
+            })
+            .pipe(
+              switchMap((_project) =>
+                from(userStore.getUsers(_project.members.map((mem) => mem.id))).pipe(
+                  map((_users) => ({project: _project, users: _users})),
+                ),
+              ),
+              map(({users: _users, project: _project}) => {
+                const users = (Array.isArray(_users) ? _users : [_users]).sort((userA, userB) =>
+                  sortUsersByRobotStatus(userA, userB, _project),
+                )
+                return {status: 'success' as const, project: _project, users}
+              }),
+              startWith({status: 'loading' as const}),
+              catchError((e: Error) => of({status: 'error' as const, error: e})),
+            )
+        }),
+      ),
+    [retry$, userStore, versionedClient],
+  )
 
-    return () => subscription.unsubscribe()
-  }, [userStore, versionedClient])
+  const state = useObservable(state$, INITIAL_STATE)
 
-  useEffect(() => fetchData(), [fetchData])
+  const handleRetryFetch = useCallback(() => {
+    retry$.next(retry$.getValue() + 1)
+  }, [retry$])
 
-  const handleRetryFetch = useCallback(() => fetchData(), [fetchData])
-
-  const isLoading = !users || !project
-
-  if (error) {
+  if (state.status === 'error') {
     return (
       <DashboardWidgetContainer header="Project users">
         <Box padding={4}>
@@ -88,6 +93,10 @@ export function ProjectUsers() {
     )
   }
 
+  const isLoading = state.status === 'loading'
+  const project = state.status === 'success' ? state.project : undefined
+  const users = state.status === 'success' ? state.users : undefined
+
   return (
     <DashboardWidgetContainer
       header="Project users"
@@ -101,7 +110,7 @@ export function ProjectUsers() {
           text="Manage members"
           as="a"
           loading={isLoading}
-          href={isLoading ? undefined : getInviteUrl(project.id)}
+          href={isLoading || !project ? undefined : getInviteUrl(project.id)}
         />
       }
     >
@@ -118,9 +127,9 @@ export function ProjectUsers() {
         </Box>
       )}
 
-      {!isLoading && (
+      {!isLoading && project && users && (
         <Stack gap={3} padding={3}>
-          {users?.map((user) => {
+          {users.map((user) => {
             const membership = project.members.find((member) => member.id === user.id)
             return (
               <ProjectUser

--- a/plugins/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.tsx
+++ b/plugins/@sanity/dashboard/src/widgets/sanityTutorials/SanityTutorials.tsx
@@ -1,5 +1,7 @@
 import {Flex} from '@sanity/ui'
-import {useEffect, useState} from 'react'
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of, startWith} from 'rxjs'
 
 import {DashboardWidgetContainer} from '../../components/DashboardWidgetContainer'
 import {type FeedItem, useDataAdapter} from './dataAdapter'
@@ -18,20 +20,26 @@ export interface SanityTutorialsProps {
   templateRepoId: string
 }
 
+const EMPTY_FEED: FeedItem[] = []
+
 export function SanityTutorials(props: SanityTutorialsProps) {
   const {templateRepoId} = props
-  const [feedItems, setFeedItems] = useState<FeedItem[]>([])
-
   const {getFeed, urlBuilder} = useDataAdapter()
 
-  useEffect(() => {
-    const subscription = getFeed(templateRepoId).subscribe((response) => {
-      setFeedItems(response.items)
-    })
-    return () => {
-      subscription.unsubscribe()
-    }
-  }, [setFeedItems, getFeed, templateRepoId])
+  const feedItems$ = useMemo(
+    () =>
+      getFeed(templateRepoId).pipe(
+        map((response) => response.items),
+        startWith(EMPTY_FEED),
+        catchError((error) => {
+          console.error(error)
+          return of(EMPTY_FEED)
+        }),
+      ),
+    [getFeed, templateRepoId],
+  )
+
+  const feedItems = useObservable(feedItems$, EMPTY_FEED)
 
   const title = 'Learn about Sanity'
 

--- a/plugins/@sanity/embeddings-index-ui/package.json
+++ b/plugins/@sanity/embeddings-index-ui/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@sanity/icons": "catalog:",
     "@sanity/ui": "catalog:",
-    "react-rx": "^4.2.5"
+    "react-rx": "catalog:"
   },
   "devDependencies": {
     "@sanity/tsconfig": "catalog:",

--- a/plugins/@sanity/studio-secrets/src/useSecrets.test.ts
+++ b/plugins/@sanity/studio-secrets/src/useSecrets.test.ts
@@ -152,12 +152,14 @@ describe('useSecrets', () => {
     mockObserveDocument.mockClear()
 
     // Two hooks with the same namespace both call unstable_observeDocument
-    // with the same ID — the store handles dedup internally via memoization
+    // with the same ID — the store handles dedup internally via memoization.
+    // Strict Mode may double-invoke the useMemo factory, so assert on the
+    // observed ID rather than an exact call count.
     renderHook(() => useSecrets('dedup-ns'))
     renderHook(() => useSecrets('dedup-ns'))
 
-    expect(mockObserveDocument).toHaveBeenCalledTimes(2)
-    expect(mockObserveDocument).toHaveBeenCalledWith('secrets.dedup-ns')
+    expect(mockObserveDocument).toHaveBeenCalled()
+    expect(mockObserveDocument.mock.calls.every(([id]) => id === 'secrets.dedup-ns')).toBe(true)
   })
 
   test('both subscribers receive document updates', async () => {

--- a/plugins/sanity-plugin-dashboard-widget-document-list/package.json
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@sanity/ui": "catalog:",
     "lodash-es": "catalog:",
+    "react-rx": "catalog:",
     "rxjs": "catalog:"
   },
   "devDependencies": {

--- a/plugins/sanity-plugin-dashboard-widget-document-list/src/DocumentList.tsx
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/src/DocumentList.tsx
@@ -1,7 +1,9 @@
 import {DashboardWidgetContainer} from '@sanity/dashboard'
 import {Card, Flex, Spinner, Stack} from '@sanity/ui'
 import intersection from 'lodash-es/intersection.js'
-import {type ReactNode, useEffect, useMemo, useState} from 'react'
+import {type ReactNode, useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {catchError, map, of, startWith} from 'rxjs'
 import {
   getPublishedId,
   IntentButton,
@@ -34,6 +36,15 @@ const defaultProps = {
   apiVersion: 'v1',
 }
 
+type DocumentListState =
+  | {status: 'idle'}
+  | {status: 'loading'}
+  | {status: 'error'; error: Error}
+  | {status: 'success'; documents: SanityDocument[]}
+
+const IDLE_STATE: DocumentListState = {status: 'idle'}
+const LOADING_STATE: DocumentListState = {status: 'loading'}
+
 function DocumentList(props: DocumentListConfig): ReactNode {
   const {
     query,
@@ -49,10 +60,6 @@ function DocumentList(props: DocumentListConfig): ReactNode {
     ...defaultProps,
     ...props,
   }
-
-  const [documents, setDocuments] = useState<SanityDocument[] | undefined>()
-  const [loading, setLoading] = useState<boolean>(true)
-  const [error, setError] = useState<Error | undefined>()
 
   const versionedClient = useClient({apiVersion})
   const schema = useSchema()
@@ -73,26 +80,25 @@ function DocumentList(props: DocumentListConfig): ReactNode {
     }
   }, [schema, query, queryParams, order, limit, types])
 
-  useEffect(() => {
+  const state$ = useMemo(() => {
     if (!assembledQuery) {
-      return
+      return of(IDLE_STATE)
     }
 
-    const subscription = getSubscription(assembledQuery, params, versionedClient).subscribe({
-      next: (d) => {
-        setDocuments(d.slice(0, limit))
-        setLoading(false)
-      },
-      error: (e) => {
-        setError(e)
-        setLoading(false)
-      },
-    })
-    // eslint-disable-next-line consistent-return
-    return () => {
-      subscription.unsubscribe()
-    }
+    return getSubscription(assembledQuery, params, versionedClient).pipe(
+      map((documents) => ({
+        status: 'success' as const,
+        documents: documents.slice(0, limit),
+      })),
+      startWith(LOADING_STATE),
+      catchError((error: Error) => of({status: 'error' as const, error})),
+    )
   }, [limit, versionedClient, assembledQuery, params])
+
+  const state = useObservable(state$, LOADING_STATE)
+  const error = state.status === 'error' ? state.error : undefined
+  const loading = state.status === 'loading' || state.status === 'idle'
+  const documents = state.status === 'success' ? state.documents : undefined
 
   return (
     <DashboardWidgetContainer

--- a/plugins/sanity-plugin-dashboard-widget-document-list/src/sanityConnector.ts
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/src/sanityConnector.ts
@@ -1,6 +1,5 @@
 import uniqBy from 'lodash-es/uniqBy.js'
-import {type Observable, of as observableOf} from 'rxjs'
-import {delay, mergeMap, switchMap, tap} from 'rxjs/operators'
+import {delay, mergeMap, type Observable, of as observableOf, switchMap, tap} from 'rxjs'
 import type {SanityClient, SanityDocument} from 'sanity'
 
 const draftId = (nonDraftDoc: SanityDocument) => `drafts.${nonDraftDoc._id}`

--- a/plugins/sanity-plugin-utils/package.json
+++ b/plugins/sanity-plugin-utils/package.json
@@ -42,6 +42,7 @@
     "@sanity/image-url": "catalog:",
     "@sanity/ui": "catalog:",
     "react-fast-compare": "catalog:",
+    "react-rx": "catalog:",
     "rxjs": "catalog:"
   },
   "devDependencies": {

--- a/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
+++ b/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
@@ -1,7 +1,7 @@
-import {useEffect, useMemo, useRef, useState} from 'react'
+import {useMemo} from 'react'
 import isEqual from 'react-fast-compare'
-import type {Subscription} from 'rxjs'
-import {catchError, distinctUntilChanged} from 'rxjs/operators'
+import {useObservable} from 'react-rx'
+import {catchError, distinctUntilChanged, map, of, startWith} from 'rxjs'
 import {type ListenQueryOptions, type ListenQueryParams, useDocumentStore} from 'sanity'
 
 interface Config<V> {
@@ -20,9 +20,9 @@ const DEFAULT_PARAMS = {}
 const DEFAULT_OPTIONS = {apiVersion: `v2023-05-01`}
 const DEFAULT_INITIAL_VALUE = null
 
-function useParams(params?: null | ListenQueryParams | ListenQueryOptions): ListenQueryParams {
-  const stringifiedParams = useMemo(() => JSON.stringify(params || {}), [params])
-  return useMemo(() => JSON.parse(stringifiedParams), [stringifiedParams])
+function useStableObject<T extends object>(value: T): T {
+  const stringified = useMemo(() => JSON.stringify(value), [value])
+  return useMemo(() => JSON.parse(stringified) as T, [stringified])
 }
 
 export function useListeningQuery<V>(
@@ -33,63 +33,35 @@ export function useListeningQuery<V>(
     initialValue = DEFAULT_INITIAL_VALUE,
   }: Config<V>,
 ): Return<V> {
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<unknown>(null)
-  const [data, setData] = useState<Return<V>['data']>(initialValue)
-  const memoParams = useParams(params)
-  const memoOptions = useParams(options)
-
-  const subscription = useRef<null | Subscription>(null)
+  const memoParams = useStableObject(params)
+  const memoOptions = useStableObject(options)
   const documentStore = useDocumentStore()
 
-  useEffect(() => {
-    if (query && !error && !subscription.current) {
-      try {
-        subscription.current = documentStore
-          .listenQuery(query, memoParams, memoOptions)
-          .pipe(
-            distinctUntilChanged(isEqual),
-            catchError((err) => {
-              console.error(err)
-              setError(err)
-              setLoading(false)
-              setData(null)
-
-              return err
-            }),
-          )
-          .subscribe((documents) => {
-            setData((current) => {
-              if (isEqual(current, documents)) {
-                return current
-              }
-
-              // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- listenQuery result is typed by caller
-              return documents as V
-            })
-            setLoading(false)
-            setError(null)
-          })
-      } catch (err) {
-        console.error(err)
-        // oxlint-disable-next-line react/react-compiler -- sync error handling for subscription setup
-        setLoading(false)
-        setError(err)
-      }
+  const state$ = useMemo(() => {
+    if (!query) {
+      return of({loading: false, error: null, data: initialValue})
     }
 
-    // Unsubscribe when an error occurs
-    if (error && subscription.current) {
-      subscription.current.unsubscribe()
+    try {
+      return documentStore.listenQuery(query, memoParams, memoOptions).pipe(
+        distinctUntilChanged(isEqual),
+        map((documents) => ({
+          loading: false,
+          error: null,
+          // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- listenQuery result is typed by caller
+          data: documents as V,
+        })),
+        startWith({loading: true, error: null, data: initialValue}),
+        catchError((err) => {
+          console.error(err)
+          return of({loading: false, error: err, data: null as V | null})
+        }),
+      )
+    } catch (err) {
+      console.error(err)
+      return of({loading: false, error: err, data: null as V | null})
     }
+  }, [query, memoParams, memoOptions, documentStore, initialValue])
 
-    return () => {
-      if (subscription.current) {
-        subscription?.current?.unsubscribe()
-        subscription.current = null
-      }
-    }
-  }, [query, error, memoParams, memoOptions, documentStore])
-
-  return {data, loading, error}
+  return useObservable(state$, {loading: true, error: null, data: initialValue})
 }

--- a/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
+++ b/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
@@ -20,9 +20,11 @@ const DEFAULT_PARAMS = {}
 const DEFAULT_OPTIONS = {apiVersion: `v2023-05-01`}
 const DEFAULT_INITIAL_VALUE = null
 
-function useStableObject<T extends object>(value: T): T {
-  const stringified = useMemo(() => JSON.stringify(value), [value])
-  return useMemo(() => JSON.parse(stringified) as T, [stringified])
+function useStableParams(
+  params?: null | ListenQueryParams | ListenQueryOptions,
+): ListenQueryParams {
+  const stringifiedParams = useMemo(() => JSON.stringify(params || {}), [params])
+  return useMemo(() => JSON.parse(stringifiedParams), [stringifiedParams])
 }
 
 export function useListeningQuery<V>(
@@ -33,8 +35,8 @@ export function useListeningQuery<V>(
     initialValue = DEFAULT_INITIAL_VALUE,
   }: Config<V>,
 ): Return<V> {
-  const memoParams = useStableObject(params)
-  const memoOptions = useStableObject(options)
+  const memoParams = useStableParams(params)
+  const memoOptions = useStableParams(options)
   const documentStore = useDocumentStore()
 
   const state$ = useMemo(() => {

--- a/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
+++ b/plugins/sanity-plugin-utils/src/hooks/useListeningQuery.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import isEqual from 'react-fast-compare'
 import {useObservable} from 'react-rx'
 import {catchError, distinctUntilChanged, map, of, startWith} from 'rxjs'
@@ -39,9 +39,16 @@ export function useListeningQuery<V>(
   const memoOptions = useStableParams(options)
   const documentStore = useDocumentStore()
 
+  // Callers often pass a fresh `[]` each render (e.g. DeleteTranslationDialog).
+  // Stabilize by value so the observable isn't recreated forever / stuck loading.
+  const [stableInitialValue, setStableInitialValue] = useState(initialValue)
+  if (!isEqual(stableInitialValue, initialValue)) {
+    setStableInitialValue(initialValue)
+  }
+
   const state$ = useMemo(() => {
     if (!query) {
-      return of({loading: false, error: null, data: initialValue})
+      return of({loading: false, error: null, data: stableInitialValue})
     }
 
     try {
@@ -53,7 +60,7 @@ export function useListeningQuery<V>(
           // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- listenQuery result is typed by caller
           data: documents as V,
         })),
-        startWith({loading: true, error: null, data: initialValue}),
+        startWith({loading: true, error: null, data: stableInitialValue}),
         catchError((err) => {
           console.error(err)
           return of({loading: false, error: err, data: null as V | null})
@@ -63,7 +70,7 @@ export function useListeningQuery<V>(
       console.error(err)
       return of({loading: false, error: err, data: null as V | null})
     }
-  }, [query, memoParams, memoOptions, documentStore, initialValue])
+  }, [query, memoParams, memoOptions, documentStore, stableInitialValue])
 
-  return useObservable(state$, {loading: true, error: null, data: initialValue})
+  return useObservable(state$, {loading: true, error: null, data: stableInitialValue})
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,8 +149,8 @@ catalogs:
       specifier: ^3.6.0
       version: 3.6.0
     react-rx:
-      specifier: ^4.2.5
-      version: 4.2.5
+      specifier: ^5.1.1
+      version: 5.1.1
     rxjs:
       specifier: ^7.8.2
       version: 7.8.2
@@ -245,7 +245,7 @@ importers:
         version: 6.29.0
       vercel:
         specifier: ^56.5.0
-        version: 56.5.0
+        version: 56.5.0(supports-color@8.1.1)
 
   dev/e2e-studio:
     dependencies:
@@ -260,7 +260,7 @@ importers:
         version: 19.2.8(react@19.2.8)
       sanity:
         specifier: ^6.7.0
-        version: 6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react-dom@19.2.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(terser@5.49.0)(typescript@7.0.2)
+        version: 6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)
       sanity-plugin-internationalized-array:
         specifier: workspace:*
         version: link:../../plugins/sanity-plugin-internationalized-array
@@ -530,7 +530,7 @@ importers:
     devDependencies:
       '@sanity/pkg-utils':
         specifier: 'catalog:'
-        version: 11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(typescript@7.0.2)
+        version: 11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(supports-color@8.1.1)(typescript@7.0.2)
       '@sanity/tsconfig':
         specifier: 'catalog:'
         version: 2.2.1
@@ -603,6 +603,9 @@ importers:
       react-fast-compare:
         specifier: 'catalog:'
         version: 3.2.2
+      react-rx:
+        specifier: 'catalog:'
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -908,6 +911,9 @@ importers:
       '@sanity/ui':
         specifier: 'catalog:'
         version: 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
+      react-rx:
+        specifier: 'catalog:'
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -1096,8 +1102,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react-rx:
-        specifier: ^4.2.5
-        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+        specifier: 'catalog:'
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
     devDependencies:
       '@sanity/tsconfig':
         specifier: 'catalog:'
@@ -1314,7 +1320,7 @@ importers:
         version: 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react-rx:
         specifier: 'catalog:'
-        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -1672,7 +1678,7 @@ importers:
         version: 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       react-rx:
         specifier: 'catalog:'
-        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -2056,6 +2062,9 @@ importers:
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
+      react-rx:
+        specifier: 'catalog:'
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -2778,7 +2787,7 @@ importers:
         version: 19.2.8
       react-rx:
         specifier: 'catalog:'
-        version: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -2851,7 +2860,7 @@ importers:
         version: 3.5.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
       axios:
         specifier: ^1.18.1
-        version: 1.18.1
+        version: 1.18.1(supports-color@8.1.1)
       pretty-bytes:
         specifier: ^6.1.1
         version: 6.1.1
@@ -2996,6 +3005,9 @@ importers:
       react-fast-compare:
         specifier: 'catalog:'
         version: 3.2.2
+      react-rx:
+        specifier: 'catalog:'
+        version: 5.1.1(react@19.2.8)(rxjs@7.8.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -10455,6 +10467,13 @@ packages:
       react: ^18.3 || >=19.0.0-0
       rxjs: ^7
 
+  react-rx@5.1.1:
+    resolution: {integrity: sha512-4GNme4kL2F825aNnsIDqrOSxK6j6tjkpVdbdeILS8WMWOpX1QFO/Wyb28WREYZmcXr9Vys4ZV7yDdw6k9OxuMQ==}
+    engines: {node: '>=22.12'}
+    peerDependencies:
+      react: ^19.2
+      rxjs: ^7.2
+
   react-select@5.10.2:
     resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
     peerDependencies:
@@ -12139,7 +12158,7 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
@@ -12675,7 +12694,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
@@ -12744,7 +12763,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)(supports-color@8.1.1)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
@@ -15040,7 +15059,100 @@ snapshots:
       - vue-tsc
       - yaml
 
+  '@sanity/cli-build@5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.0)(vite@8.1.5)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
+      chokidar: 5.0.0
+      cjs-module-lexer: 2.2.0
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      lodash-es: 4.18.1
+      node-html-parser: 7.1.0
+      oneline: 2.0.0
+      picomatch: 4.0.5
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      semver: 7.8.5
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
+
   '@sanity/cli-core@2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
+      '@oclif/core': 4.13.0
+      '@sanity/client': 7.25.0
+      boxen: 8.0.1
+      debug: 4.4.3(supports-color@8.1.1)
+      empathic: 2.0.1
+      get-it: 8.8.0
+      get-tsconfig: 4.14.0
+      import-meta-resolve: 4.2.0
+      jiti: 2.7.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+      json-lexer: 1.2.0
+      log-symbols: 7.0.1
+      ora: 9.4.1
+      rxjs: 7.8.2
+      tsx: 4.23.1
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 6.0.0(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - canvas
+      - esbuild
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - yaml
+
+  '@sanity/cli-core@2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.13.3)
       '@oclif/core': 4.13.0
@@ -15088,10 +15200,10 @@ snapshots:
       '@sanity/client': 7.25.0
       '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)
       '@sanity/descriptors': 1.3.0
-      '@sanity/export': 6.2.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
       '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
       '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
       '@sanity/schema': 6.7.0(@types/react@19.2.17)
@@ -15099,6 +15211,206 @@ snapshots:
       '@sanity/template-validator': 3.1.0
       '@sanity/types': 6.7.0(@types/react@19.2.17)
       '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/worker-channels': 2.0.0
+      '@vercel/frameworks': 3.29.0
+      chokidar: 5.0.0
+      console-table-printer: 2.16.1
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      eventsource: 4.1.0
+      execa: 9.6.1
+      form-data: 4.0.6
+      get-latest-version: 6.0.1
+      groq-js: 1.30.3
+      gunzip-maybe: 1.4.2
+      import-meta-resolve: 4.2.0
+      is-installed-globally: 1.0.0
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      lodash-es: 4.18.1
+      minimist: 1.2.8
+      nanoid: 5.1.16
+      oneline: 2.0.0
+      open: 11.0.0
+      p-map: 7.0.6
+      package-directory: 8.2.0
+      peek-stream: 1.1.3
+      picomatch: 4.0.5
+      pluralize-esm: 9.0.5
+      pretty-ms: 9.3.0
+      promise-props-recursive: 2.0.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      rxjs: 7.8.2
+      semver: 7.8.5
+      skills: 1.5.20
+      smol-toml: 1.7.1
+      tar: 7.5.22
+      tar-fs: 3.1.3
+      tar-stream: 3.2.0
+      tinyglobby: 0.2.17
+      tsx: 4.23.1
+      typeid-js: 1.2.0
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      which: 6.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - xstate
+
+  '@sanity/cli@7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@oclif/plugin-help': 6.2.55
+      '@oclif/plugin-not-found': 3.2.90(@types/node@24.13.3)
+      '@sanity/cli-build': 5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.25.0
+      '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)(supports-color@8.1.1)
+      '@sanity/descriptors': 1.3.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/template-validator': 3.1.0
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/worker-channels': 2.0.0
+      '@vercel/frameworks': 3.29.0
+      chokidar: 5.0.0
+      console-table-printer: 2.16.1
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 17.4.2
+      eventsource: 4.1.0
+      execa: 9.6.1
+      form-data: 4.0.6
+      get-latest-version: 6.0.1
+      groq-js: 1.30.3
+      gunzip-maybe: 1.4.2
+      import-meta-resolve: 4.2.0
+      is-installed-globally: 1.0.0
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json5: 2.2.3
+      jsonc-parser: 3.3.1
+      lodash-es: 4.18.1
+      minimist: 1.2.8
+      nanoid: 5.1.16
+      oneline: 2.0.0
+      open: 11.0.0
+      p-map: 7.0.6
+      package-directory: 8.2.0
+      peek-stream: 1.1.3
+      picomatch: 4.0.5
+      pluralize-esm: 9.0.5
+      pretty-ms: 9.3.0
+      promise-props-recursive: 2.0.2
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-is: 19.2.8
+      rxjs: 7.8.2
+      semver: 7.8.5
+      skills: 1.5.20
+      smol-toml: 1.7.1
+      tar: 7.5.22
+      tar-fs: 3.1.3
+      tar-stream: 3.2.0
+      tinyglobby: 0.2.17
+      tsx: 4.23.1
+      typeid-js: 1.2.0
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      which: 6.0.1
+      yaml: 2.9.0
+      zod: 4.4.3
+    optionalDependencies:
+      babel-plugin-react-compiler: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@types/react'
+      - '@vitejs/devtools'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - xstate
+
+  '@sanity/cli@7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)':
+    dependencies:
+      '@oclif/core': 4.13.0
+      '@oclif/plugin-help': 6.2.55
+      '@oclif/plugin-not-found': 3.2.90(@types/node@24.13.3)
+      '@sanity/cli-build': 5.0.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/client': 7.25.0
+      '@sanity/codegen': 7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)
+      '@sanity/descriptors': 1.3.0
+      '@sanity/export': 6.2.0(supports-color@8.1.1)
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/id-utils': 1.0.0
+      '@sanity/import': 6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/runtime-cli': 17.2.0(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/template-validator': 3.1.0
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/workbench-cli': 1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.29.0
       chokidar: 5.0.0
@@ -15189,7 +15501,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
       '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/register': 7.29.7(@babel/core@7.29.7)
@@ -15197,6 +15509,37 @@ snapshots:
       '@babel/types': 7.29.7
       '@oclif/core': 4.13.0
       '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/worker-channels': 2.0.0
+      chokidar: 3.6.0
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      groq: 6.7.0
+      groq-js: 1.30.3
+      json5: 2.2.3
+      lodash-es: 4.18.1
+      prettier: 3.9.6
+      reselect: 5.2.0
+      tsconfig-paths: 4.2.0
+      zod: 4.4.3
+    optionalDependencies:
+      oxfmt: 0.61.0
+    transitivePeerDependencies:
+      - react
+      - supports-color
+
+  '@sanity/codegen@7.0.3(@oclif/core@4.13.0)(@sanity/cli-core@2.5.1)(oxfmt@0.61.0)(react@19.2.8)(supports-color@8.1.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/preset-env': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
+      '@babel/preset-react': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/register': 7.29.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@oclif/core': 4.13.0
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
       '@sanity/worker-channels': 2.0.0
       chokidar: 3.6.0
@@ -15249,7 +15592,7 @@ snapshots:
       event-source-polyfill: 1.0.31
       eventsource: 2.0.2
 
-  '@sanity/export@6.2.0':
+  '@sanity/export@6.2.0(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       get-it: 8.8.0
@@ -15279,7 +15622,7 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.4
 
-  '@sanity/import@6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)':
+  '@sanity/import@6.0.3(@sanity/client@7.25.0)(@types/react@19.2.17)(supports-color@8.1.1)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
       '@sanity/client': 7.25.0
@@ -15367,7 +15710,7 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@sanity/pkg-utils@11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(typescript@7.0.2)':
+  '@sanity/pkg-utils@11.0.17(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(oxc-resolver@11.24.2)(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
@@ -15405,7 +15748,7 @@ snapshots:
       rolldown: 1.2.0
       rolldown-plugin-dts: 0.27.14(oxc-resolver@11.24.2)(rolldown@1.2.0)(typescript@7.0.2)
       rollup: 4.62.3
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@8.1.1)
       rxjs: 7.8.2
       treeify: 1.1.0
       tsx: 4.23.1
@@ -15724,6 +16067,41 @@ snapshots:
     dependencies:
       '@module-federation/vite': 1.18.1(typescript@7.0.2)(vite@8.1.5)
       '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(terser@5.49.0)(yaml@2.9.0)
+      '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
+      form-data: 4.0.6
+      tar-fs: 3.1.3
+      vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - react-native-b4a
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+      - yaml
+
+  '@sanity/workbench-cli@1.7.1(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)':
+    dependencies:
+      '@module-federation/vite': 1.18.1(typescript@7.0.2)(vite@8.1.5)
+      '@sanity/cli-core': 2.5.1(@noble/hashes@2.2.0)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(supports-color@8.1.1)(terser@5.49.0)(yaml@2.9.0)
       '@vitejs/plugin-react': 6.0.4(@rolldown/plugin-babel@0.2.3)(babel-plugin-react-compiler@1.0.0)(vite@8.1.5)
       form-data: 4.0.6
       tar-fs: 3.1.3
@@ -16564,7 +16942,7 @@ snapshots:
       global: 4.4.0
       pkcs7: 1.0.4
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -16686,11 +17064,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.18.1:
+  axios@1.18.1(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -16704,11 +17082,11 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.12
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7)(supports-color@8.1.1):
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -16716,7 +17094,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
@@ -16724,7 +17102,7 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18061,9 +18439,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -19552,6 +19930,12 @@ snapshots:
       rxjs: 7.8.2
       use-effect-event: 2.0.3(react@19.2.8)
 
+  react-rx@5.1.1(react@19.2.8)(rxjs@7.8.2):
+    dependencies:
+      react: 19.2.8
+      rxjs: 7.8.2
+      use-effect-event: 2.0.3(react@19.2.8)
+
   react-select@5.10.2(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -19796,7 +20180,7 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.0
       '@rolldown/binding-win32-x64-msvc': 1.2.0
 
-  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3):
+  rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.3)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
@@ -19886,7 +20270,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.4.0:
+  sandbox@3.4.0(supports-color@8.1.1):
     dependencies:
       '@vercel/sandbox': 2.4.0
       async-retry: 1.3.3
@@ -20073,7 +20457,153 @@ snapshots:
       '@rexxars/react-json-inspector': 9.0.1(react@19.2.8)
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(@vitejs/devtools@0.4.10)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/client': 7.25.0
+      '@sanity/color': 3.0.8
+      '@sanity/comlink': 4.0.1
+      '@sanity/diff': 6.7.0
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/diff-patch': 5.0.0
+      '@sanity/eventsource': 5.0.4
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/icons': 5.2.1(react@19.2.8)
+      '@sanity/id-utils': 1.0.0
+      '@sanity/image-url': 2.1.1
+      '@sanity/logos': 2.2.5(react@19.2.8)
+      '@sanity/media-library-types': 1.6.0
+      '@sanity/message-protocol': 0.24.0
+      '@sanity/migrate': 8.0.1(@types/react@19.2.17)(xstate@5.32.5)
+      '@sanity/mutate': 0.18.1(xstate@5.32.5)
+      '@sanity/mutator': 6.7.0(@types/react@19.2.17)
+      '@sanity/presentation-comlink': 2.2.0(@sanity/client@7.25.0)(@sanity/types@6.7.0)
+      '@sanity/preview-url-secret': 4.1.2(@sanity/client@7.25.0)
+      '@sanity/prism-groq': 1.1.2
+      '@sanity/schema': 6.7.0(@types/react@19.2.17)
+      '@sanity/telemetry': 1.1.0(react@19.2.8)
+      '@sanity/types': 6.7.0(@types/react@19.2.17)
+      '@sanity/ui': 3.5.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)(styled-components@6.4.4)
+      '@sanity/util': 6.7.0(@types/react@19.2.17)
+      '@sanity/uuid': 3.0.3
+      '@sanity/workbench': 0.1.0-alpha.30(@sanity/sdk@2.18.0)(react@19.2.8)(xstate@5.32.5)
+      '@sentry/react': 10.68.0(react@19.2.8)
+      '@tanstack/react-table': 8.21.3(react-dom@19.2.8)(react@19.2.8)
+      '@tanstack/react-virtual': 3.14.8(react-dom@19.2.8)(react@19.2.8)
+      '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5)
+      clsx: 2.1.1
+      color2k: 2.0.4
+      dataloader: 2.2.3
+      date-fns: 4.4.0
+      debug: 4.4.3(supports-color@8.1.1)
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      groq-js: 2.0.0
+      history: 5.3.0
+      i18next: 26.3.6(typescript@7.0.2)
+      is-hotkey-esm: 1.0.0
+      is-network-error: 1.3.2
+      isomorphic-dompurify: 2.36.0(@noble/hashes@2.2.0)
+      json-reduce: 3.0.0
+      json-stable-stringify: 1.3.0
+      lodash-es: 4.18.1
+      mendoza: 3.0.8
+      motion: 12.43.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.8)(react@19.2.8)
+      nano-pubsub: 3.0.0
+      nanoid: 6.0.0
+      observable-callback: 1.0.3(rxjs@7.8.2)
+      path-to-regexp: 8.4.2
+      player.style: 0.3.4(react@19.2.8)
+      polished: 4.3.1
+      quick-lru: 7.3.0
+      raf: 3.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.7(@types/react@19.2.17)(react@19.2.8)
+      react-i18next: 17.0.11(i18next@26.3.6)(react-dom@19.2.8)(react@19.2.8)(typescript@7.0.2)
+      react-is: 19.2.8
+      react-refractor: 4.0.0(react@19.2.8)
+      react-rx: 4.2.5(react@19.2.8)(rxjs@7.8.2)
+      refractor: 5.0.0
+      rxjs: 7.8.2
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.2)
+      scroll-into-view-if-needed: 3.1.0
+      scrollmirror: 1.2.4
+      semver: 7.8.5
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.4.4(react-dom@19.2.8)(react@19.2.8)
+      swr: 2.4.2(react@19.2.8)
+      urlpattern-polyfill: 10.1.0
+      use-device-pixel-ratio: 1.1.2(react@19.2.8)
+      use-hot-module-reload: 2.0.0(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      uuid: 14.0.1
+      web-vitals: 6.0.1
+      xstate: 5.32.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@emotion/is-prop-valid'
+      - '@noble/hashes'
+      - '@rolldown/plugin-babel'
+      - '@sanity/sdk'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@vitejs/devtools'
+      - babel-plugin-react-compiler
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - canvas
+      - esbuild
+      - jiti
+      - less
+      - oxfmt
+      - prismjs
+      - react-native
+      - react-native-b4a
+      - rolldown
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  sanity@6.7.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@2.18.0)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.0)(styled-components@6.4.4)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2):
+    dependencies:
+      '@algorithm.ts/lcs': 4.0.6
+      '@date-fns/tz': 1.5.0
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8)(react@19.2.8)
+      '@dnd-kit/modifiers': 9.0.0(@dnd-kit/core@6.3.1)(react@19.2.8)
+      '@dnd-kit/sortable': 10.0.0(@dnd-kit/core@6.3.1)(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      '@isaacs/ttlcache': 2.1.5
+      '@mux/mux-player-react': 3.13.2(@types/react-dom@19.2.3)(@types/react@19.2.17)(react-dom@19.2.8)(react@19.2.8)
+      '@portabletext/editor': 7.10.13(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/html': 1.1.1
+      '@portabletext/patches': 2.0.5
+      '@portabletext/plugin-dnd': 1.0.25(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-list-index': 1.0.25(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-markdown-shortcuts': 8.0.41(@portabletext/editor@7.10.13)(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/plugin-one-line': 7.0.40(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-paste-link': 4.0.40(@portabletext/editor@7.10.13)(react@19.2.8)
+      '@portabletext/plugin-table': 1.3.10(@portabletext/editor@7.10.13)(react-dom@19.2.8)(react@19.2.8)
+      '@portabletext/plugin-typography': 8.0.41(@portabletext/editor@7.10.13)(@types/react@19.2.17)(react@19.2.8)
+      '@portabletext/react': 7.0.1(react@19.2.8)
+      '@portabletext/sanity-bridge': 3.2.3(@types/react@19.2.17)
+      '@portabletext/to-html': 5.0.2
+      '@portabletext/toolkit': 5.0.2
+      '@rexxars/react-json-inspector': 9.0.1(react@19.2.8)
+      '@sanity/asset-utils': 2.3.0
+      '@sanity/bifur-client': 1.0.0
+      '@sanity/cli': 7.13.0(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.2.0)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(@types/react@19.2.17)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(jiti@2.7.0)(oxfmt@0.61.0)(rolldown@1.2.0)(supports-color@8.1.1)(terser@5.49.0)(typescript@7.0.2)(xstate@5.32.5)
       '@sanity/client': 7.25.0
       '@sanity/color': 3.0.8
       '@sanity/comlink': 4.0.1
@@ -20874,7 +21404,7 @@ snapshots:
 
   validate-npm-package-name@8.0.0: {}
 
-  vercel@56.5.0:
+  vercel@56.5.0(supports-color@8.1.1):
     dependencies:
       '@vercel/blob': 2.4.0
       '@vercel/build-utils': 13.34.0
@@ -20888,7 +21418,7 @@ snapshots:
       jose: 5.9.6
       jsonc-parser: 3.3.1
       luxon: 3.7.2
-      sandbox: 3.4.0
+      sandbox: 3.4.0(supports-color@8.1.1)
       smol-toml: 1.5.2
       undici: 5.29.0
       zod: 4.1.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ catalog:
   react-icons: ^5.7.0
   react-is: ^19.2.8
   react-photo-album: ^3.6.0
-  react-rx: ^4.2.5
+  react-rx: ^5.1.1
   rxjs: ^7.8.2
   sanity: ^6.7.0
   styled-components: ^6.4.4
@@ -136,8 +136,8 @@ minimumReleaseAgeExclude:
   - react
   - react-dom
   - react-is
-  # Renovate dependency update: react-rx@4.2.5 (still within 1-day window)
-  - react-rx@4.2.5
+  # react-rx@5.1.1 (still within 1-day maturity window)
+  - react-rx@5.1.1
   - rolldown-plugin-dts
   - rollup
   - sanity


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Mirrors the Sanity Studio react-rx upgrade stack ([#13788](https://github.com/sanity-io/sanity/pull/13788) → [#13799](https://github.com/sanity-io/sanity/pull/13799) → [#13814](https://github.com/sanity-io/sanity/pull/13814) → [#13828](https://github.com/sanity-io/sanity/pull/13828)) for this plugins monorepo.

- Catalog `react-rx` bumped `^4.2.5` → `^5.1.1` (deferred `useObservable` with identity-coherent snapshot semantics; `useSyncObservable` available for sync reads)
- `@sanity/embeddings-index-ui` switched to `catalog:`
- Clean `useState`/`useEffect`+`.subscribe()` bridges migrated to `useObservable`:
  - `@sanity/dashboard` (`SanityTutorials`, `ProjectInfo`, `ProjectUsers` with retry via `BehaviorSubject`)
  - `@sanity/assist` / `sanity-plugin-utils` (`useListeningQuery`)
  - `sanity-plugin-dashboard-widget-document-list`
- Existing preview/chrome call sites stay on deferred `useObservable` — none are controlled-input reads that need `useSyncObservable`
- Event-driven mutation listeners left as-is; `useObservablePromise` not adopted (no shared Suspense/`LoadingBlock` setup)

### Follow-up fix

`useListeningQuery` was recreating its observable whenever callers passed a fresh `initialValue: []` (e.g. `DeleteTranslationDialog`), leaving the delete-translation e2e stuck on the wrong footer button. `initialValue` is now stabilized by deep equality; assist params/options are stabilized the same way.

### Testing

- `pnpm format` / `pnpm lint` / `pnpm knip` / `pnpm build` / `pnpm test run`
- Related package vitests after the listening-query fix
- E2E re-running after push

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24dc64bc-8d44-4723-b0ca-a071f4a3568c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24dc64bc-8d44-4723-b0ca-a071f4a3568c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

