### PR TITLE
feat(deps): update react-hook-form to v8 beta and re-enable React Compiler

### DIFF
--- a/.changeset/media-react-hook-form-v8.md
+++ b/.changeset/media-react-hook-form-v8.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Update react-hook-form to v8 (8.0.0-beta.3), which has first-class React Compiler support, and re-enable React Compiler for the asset details form. Dialog footers (and the confirm dialog header) are no longer declared as inline components, so they no longer remount whenever form state changes.

--- a/.changeset/vercel-widget-react-hook-form-v8.md
+++ b/.changeset/vercel-widget-react-hook-form-v8.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-dashboard-widget-vercel": patch
+---
+
+Update react-hook-form to v8 (8.0.0-beta.3)

--- a/.changeset/vercel-widget-react-hook-form-v8.md
+++ b/.changeset/vercel-widget-react-hook-form-v8.md
@@ -1,5 +1,0 @@
----
-"sanity-plugin-dashboard-widget-vercel": patch
----
-
-Update react-hook-form to v8 (8.0.0-beta.3)

--- a/plugins/sanity-plugin-media/README.md
+++ b/plugins/sanity-plugin-media/README.md
@@ -60,6 +60,19 @@ or
 yarn add sanity-plugin-media
 ```
 
+### Peer dependency warnings
+
+The plugin uses [`react-hook-form`](https://react-hook-form.com/) v8 together with [`@hookform/resolvers`](https://www.npmjs.com/package/@hookform/resolvers), which doesn't declare react-hook-form v8 in its peer dependencies yet (it declares `react-hook-form ^7.55.0`), even though the resolver contract is unchanged and works fine with v8. Until a v8-compatible release is published, tell your package manager to allow it:
+
+- `npm`: install with the `--legacy-peer-deps` flag
+- `pnpm`: set [`peerDependencyRules.allowedVersions`](https://pnpm.io/settings#peerdependencyrulesallowedversions) in `pnpm-workspace.yaml`:
+
+  ```yaml
+  peerDependencyRules:
+    allowedVersions:
+      '@hookform/resolvers>react-hook-form': '8.0.0-beta.3'
+  ```
+
 ## Usage
 
 Add it as a plugin in your `sanity.config.ts` (or .js) file:

--- a/plugins/sanity-plugin-media/package.json
+++ b/plugins/sanity-plugin-media/package.json
@@ -60,7 +60,7 @@
     "pluralize": "^8.0.0",
     "react-dropzone": "^11.7.1",
     "react-file-icon": "^1.6.0",
-    "react-hook-form": "catalog:",
+    "react-hook-form": "catalog:react-hook-form-v8",
     "react-redux": "^9.3.0",
     "react-select": "^5.10.2",
     "react-virtuoso": "^4.18.11",

--- a/plugins/sanity-plugin-media/src/components/DialogAssetEdit/Details.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogAssetEdit/Details.tsx
@@ -64,11 +64,6 @@ export default function Details({
   creditLine,
   locales,
 }: DetailsProps) {
-  'use no memo'
-  // React Compiler memoizes the register() field JSX using asset-derived deps only.
-  // That can leave Save stuck disabled while the DOM still updates (uncontrolled inputs).
-  // Tags work because they use Controller; string fields use register and need this opt-out.
-
   const hasLocales = locales && locales.length > 0
   const [activeLocaleTab, setActiveLocaleTab] = useState(0)
   const folderId = currentAsset?.opt?.media?.folder?._ref

--- a/plugins/sanity-plugin-media/src/components/DialogConfirm/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogConfirm/index.tsx
@@ -37,7 +37,7 @@ const DialogConfirm = (props: Props) => {
     handleClose()
   }
 
-  const Footer = () => (
+  const footer = (
     <Box padding={3}>
       <Flex justify="space-between">
         <Button fontSize={1} mode="bleed" onClick={handleClose} text="Cancel" />
@@ -51,7 +51,7 @@ const DialogConfirm = (props: Props) => {
     </Box>
   )
 
-  const Header = () => (
+  const header = (
     <Flex align="center">
       <Box paddingX={1}>
         <WarningOutlineIcon />
@@ -61,16 +61,7 @@ const DialogConfirm = (props: Props) => {
   )
 
   return (
-    <Dialog
-      animate
-      // oxlint-disable-next-line react/react-compiler
-      footer={<Footer />}
-      // oxlint-disable-next-line react/react-compiler
-      header={<Header />}
-      id="confirm"
-      onClose={handleClose}
-      width={1}
-    >
+    <Dialog animate footer={footer} header={header} id="confirm" onClose={handleClose} width={1}>
       <Box paddingX={4} paddingY={4}>
         <Stack space={3}>
           {dialog?.title && <Text size={1}>{dialog.title}</Text>}

--- a/plugins/sanity-plugin-media/src/components/DialogFolderCreate/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogFolderCreate/index.tsx
@@ -63,7 +63,7 @@ const DialogFolderCreate = (props: Props) => {
     }
   }, [creatingError, setError])
 
-  const Footer = () => (
+  const footer = (
     <Box padding={3}>
       <Flex justify="flex-end">
         <FormSubmitButton
@@ -76,15 +76,7 @@ const DialogFolderCreate = (props: Props) => {
   )
 
   return (
-    <Dialog
-      animate
-      // oxlint-disable-next-line react/react-compiler
-      footer={<Footer />}
-      header="Create Folder"
-      id={id}
-      onClose={handleClose}
-      width={1}
-    >
+    <Dialog animate footer={footer} header="Create Folder" id={id} onClose={handleClose} width={1}>
       <Box as="form" padding={4} onSubmit={handleSubmit(onSubmit)}>
         <button style={{display: 'none'}} tabIndex={-1} type="submit" />
 

--- a/plugins/sanity-plugin-media/src/components/DialogTagCreate/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogTagCreate/index.tsx
@@ -65,7 +65,7 @@ const DialogTagCreate = (props: Props) => {
     }
   }, [creatingError, setError])
 
-  const Footer = () => (
+  const footer = (
     <Box padding={3}>
       <Flex justify="flex-end">
         {/* Submit button */}
@@ -79,15 +79,7 @@ const DialogTagCreate = (props: Props) => {
   )
 
   return (
-    <Dialog
-      animate
-      // oxlint-disable-next-line react/react-compiler
-      footer={<Footer />}
-      header="Create Tag"
-      id={id}
-      onClose={handleClose}
-      width={1}
-    >
+    <Dialog animate footer={footer} header="Create Tag" id={id} onClose={handleClose} width={1}>
       {/* Form fields */}
       <Box as="form" padding={4} onSubmit={handleSubmit(onSubmit)}>
         {/* Hidden button to enable enter key submissions */}

--- a/plugins/sanity-plugin-media/src/components/DialogTagEdit/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogTagEdit/index.tsx
@@ -133,7 +133,7 @@ const DialogTagEdit = (props: Props) => {
     }
   }, [client, handleTagUpdate, tagItem?.tag])
 
-  const Footer = () => (
+  const footer = (
     <Box padding={3}>
       <Flex justify="space-between">
         {/* Delete button */}
@@ -162,15 +162,7 @@ const DialogTagEdit = (props: Props) => {
   }
 
   return (
-    <Dialog
-      animate
-      // oxlint-disable-next-line react/react-compiler
-      footer={<Footer />}
-      header="Edit Tag"
-      id={id}
-      onClose={handleClose}
-      width={1}
-    >
+    <Dialog animate footer={footer} header="Edit Tag" id={id} onClose={handleClose} width={1}>
       {/* Form fields */}
       <Box as="form" padding={4} onSubmit={handleSubmit(onSubmit)}>
         {/* Deleted notification */}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ catalogs:
       specifier: ^3.2.2
       version: 3.2.2
     react-hook-form:
-      specifier: 8.0.0-beta.3
-      version: 8.0.0-beta.3
+      specifier: ^7.84.0
+      version: 7.84.0
     react-icons:
       specifier: ^5.7.0
       version: 5.7.0
@@ -179,6 +179,10 @@ catalogs:
     react:
       specifier: ^19.2
       version: 19.2.8
+  react-hook-form-v8:
+    react-hook-form:
+      specifier: 8.0.0-beta.3
+      version: 8.0.0-beta.3
 
 overrides:
   '@types/node': ^24.13.3
@@ -2148,7 +2152,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: 'catalog:'
-        version: 4.1.3(react-hook-form@8.0.0-beta.3)
+        version: 4.1.3(react-hook-form@7.84.0)
       '@sanity/color':
         specifier: 'catalog:'
         version: 3.0.8
@@ -2172,7 +2176,7 @@ importers:
         version: 3.0.0
       react-hook-form:
         specifier: 'catalog:'
-        version: 8.0.0-beta.3(react@19.2.8)
+        version: 7.84.0(react@19.2.8)
       react-time-ago:
         specifier: ^7.4.4
         version: 7.4.4(react-dom@19.2.8)(react@19.2.8)
@@ -2681,7 +2685,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(react-dom@19.2.8)(react@19.2.8)
       react-hook-form:
-        specifier: 'catalog:'
+        specifier: 'catalog:react-hook-form-v8'
         version: 8.0.0-beta.3(react@19.2.8)
       react-redux:
         specifier: ^9.3.0
@@ -10477,6 +10481,12 @@ packages:
     peerDependencies:
       react: '*'
 
+  react-hook-form@7.84.0:
+    resolution: {integrity: sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-hook-form@8.0.0-beta.3:
     resolution: {integrity: sha512-VyAKK5sXyAK1bkcExoa7ab6nZOd04T+gwv8F4y5xM9vXWw3GVFCJNJgTGt+FYW4jrZkglO12+yhDcQtVLEzZRg==}
     engines: {node: '>=18.0.0'}
@@ -13661,6 +13671,11 @@ snapshots:
       redux: 5.0.1
     transitivePeerDependencies:
       - '@types/react'
+
+  '@hookform/resolvers@4.1.3(react-hook-form@7.84.0)':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.84.0(react@19.2.8)
 
   '@hookform/resolvers@4.1.3(react-hook-form@8.0.0-beta.3)':
     dependencies:
@@ -19733,6 +19748,10 @@ snapshots:
       react-kapsule: 2.6.0(react@19.2.8)
     transitivePeerDependencies:
       - preact-render-to-string
+
+  react-hook-form@7.84.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   react-hook-form@8.0.0-beta.3(react@19.2.8):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ catalogs:
       specifier: ^3.2.2
       version: 3.2.2
     react-hook-form:
-      specifier: ^7.84.0
-      version: 7.84.0
+      specifier: 8.0.0-beta.3
+      version: 8.0.0-beta.3
     react-icons:
       specifier: ^5.7.0
       version: 5.7.0
@@ -2148,7 +2148,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: 'catalog:'
-        version: 4.1.3(react-hook-form@7.84.0)
+        version: 4.1.3(react-hook-form@8.0.0-beta.3)
       '@sanity/color':
         specifier: 'catalog:'
         version: 3.0.8
@@ -2172,7 +2172,7 @@ importers:
         version: 3.0.0
       react-hook-form:
         specifier: 'catalog:'
-        version: 7.84.0(react@19.2.8)
+        version: 8.0.0-beta.3(react@19.2.8)
       react-time-ago:
         specifier: ^7.4.4
         version: 7.4.4(react-dom@19.2.8)(react@19.2.8)
@@ -2631,7 +2631,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: 'catalog:'
-        version: 4.1.3(react-hook-form@7.84.0)
+        version: 4.1.3(react-hook-form@8.0.0-beta.3)
       '@reduxjs/toolkit':
         specifier: ^2.12.0
         version: 2.12.0(react-redux@9.3.0)(react@19.2.8)
@@ -2682,7 +2682,7 @@ importers:
         version: 1.6.0(react-dom@19.2.8)(react@19.2.8)
       react-hook-form:
         specifier: 'catalog:'
-        version: 7.84.0(react@19.2.8)
+        version: 8.0.0-beta.3(react@19.2.8)
       react-redux:
         specifier: ^9.3.0
         version: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
@@ -10477,8 +10477,8 @@ packages:
     peerDependencies:
       react: '*'
 
-  react-hook-form@7.84.0:
-    resolution: {integrity: sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==}
+  react-hook-form@8.0.0-beta.3:
+    resolution: {integrity: sha512-VyAKK5sXyAK1bkcExoa7ab6nZOd04T+gwv8F4y5xM9vXWw3GVFCJNJgTGt+FYW4jrZkglO12+yhDcQtVLEzZRg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -13662,10 +13662,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@hookform/resolvers@4.1.3(react-hook-form@7.84.0)':
+  '@hookform/resolvers@4.1.3(react-hook-form@8.0.0-beta.3)':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.84.0(react@19.2.8)
+      react-hook-form: 8.0.0-beta.3(react@19.2.8)
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -19734,7 +19734,7 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  react-hook-form@7.84.0(react@19.2.8):
+  react-hook-form@8.0.0-beta.3(react@19.2.8):
     dependencies:
       react: 19.2.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalog:
   react: ^19.2.8
   react-dom: ^19.2.8
   react-fast-compare: ^3.2.2
-  react-hook-form: ^7.84.0
+  react-hook-form: 8.0.0-beta.3
   react-icons: ^5.7.0
   react-is: ^19.2.8
   react-photo-album: ^3.6.0
@@ -173,6 +173,9 @@ peerDependencyRules:
     # @bynder/compact-view does not declare react 19 in its peers yet, but works fine with it
     '@bynder/compact-view>react': '19'
     '@bynder/compact-view>react-dom': '19'
+    # @hookform/resolvers has no react-hook-form v8 compatible release yet (peers ^7.0.0);
+    # the resolver contract is unchanged and it works with the v8 beta
+    '@hookform/resolvers>react-hook-form': '8.0.0-beta.3'
 
 publicHoistPattern:
   # Allows setting vite/client in dev/test-studio/tsconfig.json without installing vite

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalog:
   react: ^19.2.8
   react-dom: ^19.2.8
   react-fast-compare: ^3.2.2
-  react-hook-form: 8.0.0-beta.3
+  react-hook-form: ^7.84.0
   react-icons: ^5.7.0
   react-is: ^19.2.8
   react-photo-album: ^3.6.0
@@ -88,6 +88,10 @@ catalogs:
     react-dom: ^19.2
     sanity: ^5 || ^6.0.0-0
     styled-components: ^6.1
+  # react-hook-form v8 beta (first-class React Compiler support), currently only
+  # used by sanity-plugin-media; the default catalog stays on v7 for other plugins.
+  react-hook-form-v8:
+    react-hook-form: 8.0.0-beta.3
 
 # When running `pnpm add`, reuse a dependency's catalog version automatically if
 # it already exists in a catalog, so shared deps stay aligned on a single version.
@@ -174,7 +178,8 @@ peerDependencyRules:
     '@bynder/compact-view>react': '19'
     '@bynder/compact-view>react-dom': '19'
     # @hookform/resolvers has no react-hook-form v8 compatible release yet (peers ^7.0.0);
-    # the resolver contract is unchanged and it works with the v8 beta
+    # the resolver contract is unchanged and it works with the v8 beta (documented in
+    # the sanity-plugin-media README)
     '@hookform/resolvers>react-hook-form': '8.0.0-beta.3'
 
 publicHoistPattern:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-contained alternative to #1841, based directly on `main`. Updates `react-hook-form` to `8.0.0-beta.3` for **`sanity-plugin-media` only** per the [v7 → v8 migration guide](https://react-hook-form.com/migrate-v7-to-v8) and removes the temporary `'use no memo'` compiler opt-out that #1840 shipped, so the plugin builds fully compiled again — without needing #1841's `keepFieldsRef` workaround at all.

The v8 beta lives in a named catalog (`catalog:react-hook-form-v8`); the default catalog stays on `^7.84.0`, so `sanity-plugin-dashboard-widget-vercel` is untouched by this PR.

### Why v8 makes the opt-out unnecessary

The bug behind #1840: `DialogAssetEdit` calls `reset(generateDefaultValues(...))` in an effect (on mount and when the asset is updated elsewhere). v7's `reset()` empties react-hook-form's internal field registry and relies on the render-time `register()` calls re-running on the next render — which React Compiler memoizes away (keyed on the stable `register` reference). Fields stayed unregistered, so typing updated the DOM but never marked the form dirty, and Save stayed disabled. v8 has first-class React Compiler support: the compiled form works with a plain `reset()`. Verified both by an isolated repro harness compiled with `babel-plugin-react-compiler` (fails on v7, passes on v8) and in a real browser (video below).

### Breaking changes audit

Checked every breaking change from the migration guide against the plugin:

| Breaking change | Impact here |
| --- | --- |
| `register` passes the input ref directly (not a partial ref object) | None — the plugin spreads `register()` onto inputs / forwards `ref` as a prop; build + type-aware lint pass unchanged |
| `useFieldArray`: `id` renamed to `key`, `keyName` removed | Not used |
| `<Watch names>` renamed to `name` | Not used |
| `watch(callback)` subscription API removed | Not used |
| `setValue` no longer updates `useFieldArray` fields | Not applicable — the tags field uses `Controller`, not `useFieldArray` |

So no source changes were required by the breaking changes themselves.

### `@hookform/resolvers` peer dependency

No v8-compatible release exists yet (latest `5.7.1` declares `react-hook-form: ^7.55.0`; the `beta`/`next` dist-tags are old v1/v2-era lines). The resolver contract is unchanged and works with the beta (all resolver-based validation tests pass). Handled the same way as the Bynder plugin's React 19 peers:

- allowed in this workspace via `peerDependencyRules.allowedVersions` with an explanatory comment
- documented for consumers in a new "Peer dependency warnings" section in the plugin `README.md` (npm `--legacy-peer-deps` / pnpm `peerDependencyRules.allowedVersions`)

### Also included

- **Remaining inline `Footer`/`Header` dialog components converted to plain JSX** (`DialogTagCreate`, `DialogTagEdit`, `DialogConfirm`, `DialogFolderCreate`), matching what #1840 already did for `DialogAssetEdit`. Inline components get a new identity whenever captured values change, remounting the footer subtree — including the Save button — on every form-state change. This also removes all the `react/react-compiler` lint suppressions that pattern required.

### Notes

- The named catalog pins the exact beta (`8.0.0-beta.3`) rather than a range, so consumers of the published plugin get a deterministic beta version.
- The lockfile was edited surgically to avoid re-resolving unrelated floating tags (`sanity@next`); `pnpm install --frozen-lockfile` passes.

## Test plan

- [x] `pnpm --filter sanity-plugin-media exec vitest run` — 205 tests pass
- [x] `pnpm --filter sanity-plugin-dashboard-widget-vercel exec vitest run` passes (still on v7)
- [x] `pnpm format`, `pnpm lint` (type-aware), `pnpm knip`, `pnpm build`, `pnpm test run` (1281 tests) all pass
- [x] `pnpm peers check` — no peer dependency issues
- [x] Verified installed versions: media resolves `react-hook-form@8.0.0-beta.3`, the Vercel dashboard widget resolves `7.84.0`
- [x] Manual verification in `dev/test-studio` (`pnpm dev`, compiler on, no `'use no memo'`, plain `reset()`): typing enables Save; after an external API update resets the open form, typing re-enables Save and the edit persists — the exact scenario that broke v7 under the compiler:

[v8_demo_save_works_after_external_reset.mp4](https://cursor.com/agents/bc-07dfbb47-def3-41cf-8f3c-03d6bfc71d31/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fv8_demo_save_works_after_external_reset.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07dfbb47-def3-41cf-8f3c-03d6bfc71d31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07dfbb47-def3-41cf-8f3c-03d6bfc71d31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

