### PR TITLE
chore: enable React Compiler in Vitest for all plugins

### DIFF
--- a/.agents/skills/migrate-styled-components-to-vanilla-extract/SKILL.md
+++ b/.agents/skills/migrate-styled-components-to-vanilla-extract/SKILL.md
@@ -160,7 +160,7 @@ import {defineConfig} from '@sanity/tsdown-config'
 import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
-  reactCompiler: true,
+  reactCompiler: {transform: 'oxc'},
   vanillaExtract: true,
 }) satisfies Promise<UserConfig | UserConfig[]>
 ```
@@ -208,11 +208,14 @@ The package-exports test resolves the workspace `exports` map, whose `.` entry p
 the workspace's `vitest.config.ts`:
 
 ```ts
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Keep React Compiler (matches `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts) and
+  // compose vanilla-extract — do not replace the compiler plugin.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   // ...existing test config
 })
 ```
@@ -282,7 +285,7 @@ Migrate styling from styled-components to vanilla-extract (zero-runtime CSS)
 - [ ] `tsdown.config.ts`: `styledComponents` removed, `vanillaExtract: true` added
 - [ ] `package.json`: vanilla-extract devDeps added; `styled-components` peer removed; `sanity` /
       `@sanity/ui` peer variants verified aligned in `pnpm-lock.yaml`
-- [ ] `vitest.config.ts` registers `vanillaExtractPlugin()`
+- [ ] `vitest.config.ts` registers `vanillaExtractPlugin()` **alongside** the existing React Compiler oxc plugin (`reactCompilerPluginForVitest()`) — do not drop compiler parity
 - [ ] `dist/bundle.css` emitted with all rules; package-exports snapshot updated
 - [ ] `pnpm format` / `pnpm lint` / `pnpm knip` / `pnpm build` / `pnpm test run` all pass
 - [ ] Visual fidelity verified against the pre-migration rendering

--- a/.agents/skills/plugin-test-coverage/SKILL.md
+++ b/.agents/skills/plugin-test-coverage/SKILL.md
@@ -41,7 +41,7 @@ Skip one-off tooling (migrations, banners) unless they are part of the main auth
 - Context/provider tests: mock `useClient` / `useWorkspace` / pane hooks; use `Suspense` + `act` for async `React.use` language resolution; call any module-level `clear()` between tests.
 - Timeouts: `test('name', {timeout: 30_000}, async () => { … })` — options object as second arg.
 - Keep the package-exports snapshot test; update with `pnpm test -u` only when exports intentionally change.
-- React Compiler is on — do not add unnecessary `useMemo` / `useCallback`.
+- React Compiler is on in both build and Vitest — do not add unnecessary `useMemo` / `useCallback`. If `tsdown.config.ts` has `reactCompiler: {transform: 'oxc'}`, `vitest.config.ts` must register `reactCompilerPluginForVitest()` from `@sanity/plugin-kit/vitest`. Generators wire both; compose with other Vitest plugins rather than replacing them. Enforced by `scripts/react-compiler-parity`.
 
 Run a single package:
 

--- a/.agents/skills/plugin-transfer/SKILL.md
+++ b/.agents/skills/plugin-transfer/SKILL.md
@@ -28,6 +28,8 @@ Keep and maintain these monorepo config files in the transferred plugin:
 - `tsconfig.json`
 - `vitest.config.ts`
 
+The copy-plugin generator sets `reactCompiler: {transform: 'oxc'}` in `tsdown.config.ts` and mirrors it in `vitest.config.ts` via `reactCompilerPluginForVitest()` from `@sanity/plugin-kit/vitest`. Keep that Vitest wiring — tests must exercise the same compiled output that ships to npm. See AGENTS.md (“React Compiler Vitest parity”).
+
 Do not copy standalone-repo-only setup such as custom root CI/build/lint/test configs that are already handled by this monorepo.
 
 ## Clean Up the Transferred README

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -173,7 +173,7 @@ import {defineConfig} from '@sanity/tsdown-config'
 import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
-  reactCompiler: true,
+  reactCompiler: {transform: 'oxc'},
   vanillaExtract: true,
 }) satisfies Promise<UserConfig | UserConfig[]>
 ```
@@ -204,11 +204,13 @@ drop-in match:
 
 ```ts
 // plugins/@sanity/google-maps-input/vitest.config.ts
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Keep React Compiler (matches tsdown `reactCompiler: {transform: 'oxc'}`) and compose VE.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   // ...
 })
 ```
@@ -234,11 +236,12 @@ in `setupFiles` (the generator emits it when you opt into styling):
 
 ```ts
 // vitest.config.ts
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   test: {
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],
     // ...

--- a/.changeset/plugin-kit-vitest-react-compiler.md
+++ b/.changeset/plugin-kit-vitest-react-compiler.md
@@ -1,0 +1,5 @@
+---
+"@sanity/plugin-kit": minor
+---
+
+Add `@sanity/plugin-kit/vitest` exporting `reactCompilerPluginForVitest()`, a Vite plugin that runs the oxc React Compiler transform in Vitest so plugin tests exercise the same compiled output as published builds

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,25 @@ Use numeric separators (`30_000` instead of `30000`) for readability.
 - Root Vitest sets `SC_DISABLE_SPEEDY=false` so styled-components keeps its fast CSSOM injection path under jsdom (upstream disables it when `NODE_ENV !== 'production'`, which makes first mounts of styled-heavy trees slow enough to trip default timeouts). Same approach as [sanity#13675](https://github.com/sanity-io/sanity/pull/13675).
 - For plugins that use vanilla-extract: register `vanillaExtractPlugin()` in the plugin’s `vitest.config.ts` (required so `.css.ts` compiles under Vitest) and include `'@vanilla-extract/css/disableRuntimeStyles'` in `setupFiles` (no-op under `node`, skips CSS injection for `jsdom`/`happy-dom` suites; remove only when a test asserts real CSS) — see the `sanity-plugin-best-practices` styling reference (`Disabling runtime styles in tests`)
 
+### React Compiler Vitest parity
+
+If a plugin’s `tsdown.config.ts` has `reactCompiler: {transform: 'oxc'}` (the default from generators), its `vitest.config.ts` **must** register `reactCompilerPluginForVitest()` from `@sanity/plugin-kit/vitest` so unit tests exercise the same compiled output that ships to npm — not uncompiled `src`:
+
+```ts
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  plugins: [reactCompilerPluginForVitest()],
+  // ...
+})
+```
+
+- Do **not** use `@vitejs/plugin-react` `react({compiler: true})` for Vitest — the compiler should always run for plugin code, but that integration never applies in Vitest (it only compiles browser builds, not Vitest’s server-side transform pipeline). The shared plugin calls `oxc-transform-react` directly instead.
+- The shared plugin skips non-JSX modules that do not import `react` (oxc DCE would otherwise drop unused side-effect imports like `@testing-library/jest-dom/vitest` in setup files); `.tsx`/`.jsx` always compile.
+- Generators already wire both `tsdown.config.ts` and `vitest.config.ts`. `@sanity/plugin-kit` resolves through the root devDependency (like `vitest` and `vitest-package-exports`) — do not add it to plugin `devDependencies`; a per-plugin `workspace:^` devDep breaks the `pnpm pack` step of plugin builds. Do not remove the Vitest compiler plugin when adding vanilla-extract or other plugins — compose into `plugins: [...]`.
+- `scripts/react-compiler-parity` enforces this invariant in `pnpm test` (config text **and** a transform through Vitest’s pipeline that must emit `react/compiler-runtime`). Agents who enable or keep `reactCompiler` in tsdown without mirroring Vitest will fail CI.
+
 ## Pull Request Workflow
 
 ### 1. Create as Draft PR First

--- a/packages/@sanity/plugin-kit/package.json
+++ b/packages/@sanity/plugin-kit/package.json
@@ -35,6 +35,7 @@
     ".": "./src/index.ts",
     "./oxfmt": "./src/oxfmt.ts",
     "./oxlint": "./src/oxlint.ts",
+    "./vitest": "./src/vitest.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -42,6 +43,7 @@
       ".": "./dist/index.js",
       "./oxfmt": "./dist/oxfmt.js",
       "./oxlint": "./dist/oxlint.js",
+      "./vitest": "./dist/vitest.js",
       "./package.json": "./package.json"
     }
   },
@@ -59,6 +61,7 @@
     "inquirer": "^14.0.2",
     "meow": "^14.1.0",
     "nodemon": "3.1.14",
+    "oxc-transform-react": "catalog:",
     "validate-npm-package-name": "catalog:",
     "yalc": "1.0.0-pre.53"
   },
@@ -77,18 +80,23 @@
     "sanity": "catalog:",
     "styled-components": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "@sanity/pkg-utils": "catalog:",
     "oxfmt": "catalog:",
-    "oxlint": "catalog:"
+    "oxlint": "catalog:",
+    "vitest": "^4"
   },
   "peerDependenciesMeta": {
     "oxfmt": {
       "optional": true
     },
     "oxlint": {
+      "optional": true
+    },
+    "vitest": {
       "optional": true
     }
   },

--- a/packages/@sanity/plugin-kit/src/index.test.ts
+++ b/packages/@sanity/plugin-kit/src/index.test.ts
@@ -20,6 +20,9 @@ test('package exports', {timeout: 30_000}, async () => {
       "./oxlint": {
         "default": "object",
       },
+      "./vitest": {
+        "reactCompilerPluginForVitest": "function",
+      },
     }
   `)
 })

--- a/packages/@sanity/plugin-kit/src/vitest.ts
+++ b/packages/@sanity/plugin-kit/src/vitest.ts
@@ -1,0 +1,48 @@
+import {transformSync} from 'oxc-transform-react'
+import type {Plugin} from 'vitest/config'
+
+const SCRIPT_FILE_RE = /\.[tj]sx?(?:\?|$)/
+const JSX_FILE_RE = /\.[tj]sx(?:\?|$)/
+const REACT_IMPORT_RE = /(?:from|import)\s*['"]react(?:['"]|\/)/
+
+/**
+ * Runs the oxc React Compiler over plugin sources in Vitest, mirroring
+ * `reactCompiler: {transform: 'oxc'}` in `tsdown.config.ts` so tests exercise
+ * the same compiled output that ships to npm.
+ *
+ * The compiler should always run for plugin code, but `@vitejs/plugin-react`'s
+ * `compiler: true` option never applies in Vitest (Vitest transforms modules
+ * through Vite's server pipeline, which that integration does not compile), so
+ * this plugin calls `oxc-transform-react` directly.
+ */
+export function reactCompilerPluginForVitest(): Plugin {
+  return {
+    name: 'vitest-react-compiler',
+    enforce: 'pre',
+    transform: {
+      filter: {id: {include: SCRIPT_FILE_RE, exclude: /\/node_modules\//}},
+      handler(code, id) {
+        const filename = id.includes('?') ? id.slice(0, id.indexOf('?')) : id
+        // Skip non-JSX modules that do not import React. oxc DCE would otherwise
+        // drop unused side-effect imports (e.g. `@testing-library/jest-dom/vitest`
+        // in a Vitest setup file). `.tsx`/`.jsx` always compile — automatic-runtime
+        // JSX needs no explicit `react` import.
+        if (!JSX_FILE_RE.test(filename) && !REACT_IMPORT_RE.test(code)) {
+          return null
+        }
+        const result = transformSync(filename, code, {
+          jsx: {runtime: 'automatic'},
+          reactCompiler: true,
+          sourcemap: true,
+        })
+        if (result.fatal) {
+          throw new Error(
+            result.errors.map((error) => error.message).join('\n') ||
+              'React Compiler transform failed.',
+          )
+        }
+        return {code: result.code, map: result.map}
+      },
+    },
+  }
+}

--- a/packages/@sanity/plugin-kit/tsdown.config.ts
+++ b/packages/@sanity/plugin-kit/tsdown.config.ts
@@ -3,7 +3,7 @@ import type {UserConfig} from 'tsdown'
 
 const config: UserConfig = {
   ...(await defineConfig({
-    entry: ['./src/index.ts', './src/oxfmt.ts', './src/oxlint.ts'],
+    entry: ['./src/index.ts', './src/oxfmt.ts', './src/oxlint.ts', './src/vitest.ts'],
     platform: 'node',
   })),
   // `platform: 'node'` defaults to `.mjs`/`.d.mts` output; keep the published `.js`/`.d.ts`

--- a/plugins/@sanity/assist/vitest.config.ts
+++ b/plugins/@sanity/assist/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/block-insert-picker/vitest.config.ts
+++ b/plugins/@sanity/block-insert-picker/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     server: {

--- a/plugins/@sanity/code-input/vitest.config.ts
+++ b/plugins/@sanity/code-input/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/color-input/vitest.config.ts
+++ b/plugins/@sanity/color-input/vitest.config.ts
@@ -1,8 +1,10 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   test: {
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],
     server: {

--- a/plugins/@sanity/cross-dataset-duplicator/vitest.config.ts
+++ b/plugins/@sanity/cross-dataset-duplicator/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/dashboard/vitest.config.ts
+++ b/plugins/@sanity/dashboard/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/debug-live-sync-tags/vitest.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/document-internationalization/vitest.config.ts
+++ b/plugins/@sanity/document-internationalization/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/plugins/@sanity/embeddings-index-ui/vitest.config.ts
+++ b/plugins/@sanity/embeddings-index-ui/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/form-toolkit/vitest.config.ts
+++ b/plugins/@sanity/form-toolkit/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     // Component tests opt into jsdom per-file via `// @vitest-environment jsdom`.
     // The default stays `node` so the package-exports test keeps resolving `sanity`

--- a/plugins/@sanity/google-maps-input/vitest.config.ts
+++ b/plugins/@sanity/google-maps-input/vitest.config.ts
@@ -1,8 +1,10 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   test: {
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],
     server: {

--- a/plugins/@sanity/hierarchical-document-list/vitest.config.ts
+++ b/plugins/@sanity/hierarchical-document-list/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/language-filter/vitest.config.ts
+++ b/plugins/@sanity/language-filter/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/plugins/@sanity/orderable-document-list/vitest.config.ts
+++ b/plugins/@sanity/orderable-document-list/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/personalization-plugin/vitest.config.ts
+++ b/plugins/@sanity/personalization-plugin/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/presets/vitest.config.ts
+++ b/plugins/@sanity/presets/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/plugins/@sanity/rich-date-input/vitest.config.ts
+++ b/plugins/@sanity/rich-date-input/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/sanity-plugin-async-list/vitest.config.ts
+++ b/plugins/@sanity/sanity-plugin-async-list/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/sfcc/vitest.config.ts
+++ b/plugins/@sanity/sfcc/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/studio-secrets/vitest.config.ts
+++ b/plugins/@sanity/studio-secrets/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/plugins/@sanity/table/vitest.config.ts
+++ b/plugins/@sanity/table/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/@sanity/vercel-protection-bypass/vitest.config.ts
+++ b/plugins/@sanity/vercel-protection-bypass/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-naive-html-serializer/vitest.config.ts
+++ b/plugins/sanity-naive-html-serializer/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./test/global.setup.ts'],

--- a/plugins/sanity-plugin-aprimo/vitest.config.ts
+++ b/plugins/sanity-plugin-aprimo/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-asset-source-unsplash/vitest.config.ts
+++ b/plugins/sanity-plugin-asset-source-unsplash/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-bynder-input/vitest.config.ts
+++ b/plugins/sanity-plugin-bynder-input/vitest.config.ts
@@ -1,8 +1,10 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   test: {
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],
     server: {

--- a/plugins/sanity-plugin-cloudinary/vitest.config.ts
+++ b/plugins/sanity-plugin-cloudinary/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-dashboard-widget-document-list/vitest.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-dashboard-widget-netlify/vitest.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-netlify/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-dashboard-widget-vercel/vitest.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-documents-pane/vitest.config.ts
+++ b/plugins/sanity-plugin-documents-pane/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-google-translate/vitest.config.ts
+++ b/plugins/sanity-plugin-google-translate/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-graph-view/vitest.config.ts
+++ b/plugins/sanity-plugin-graph-view/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-hotspot-array/vitest.config.ts
+++ b/plugins/sanity-plugin-hotspot-array/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-iframe-pane/vitest.config.ts
+++ b/plugins/sanity-plugin-iframe-pane/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-internationalized-array/vitest.config.ts
+++ b/plugins/sanity-plugin-internationalized-array/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],

--- a/plugins/sanity-plugin-latex-input/vitest.config.ts
+++ b/plugins/sanity-plugin-latex-input/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-markdown/vitest.config.ts
+++ b/plugins/sanity-plugin-markdown/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-media/vitest.config.ts
+++ b/plugins/sanity-plugin-media/vitest.config.ts
@@ -1,9 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  oxc: {
-    jsx: {runtime: 'automatic'},
-  },
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     environment: 'jsdom',
     globals: false,

--- a/plugins/sanity-plugin-mux-input/vitest.config.ts
+++ b/plugins/sanity-plugin-mux-input/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-shopify-assets/vitest.config.ts
+++ b/plugins/sanity-plugin-shopify-assets/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-studio-smartling/vitest.config.ts
+++ b/plugins/sanity-plugin-studio-smartling/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-transifex/vitest.config.ts
+++ b/plugins/sanity-plugin-transifex/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-utils/vitest.config.ts
+++ b/plugins/sanity-plugin-utils/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-plugin-workflow/vitest.config.ts
+++ b/plugins/sanity-plugin-workflow/vitest.config.ts
@@ -1,8 +1,10 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
-  plugins: [vanillaExtractPlugin()],
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest(), vanillaExtractPlugin()],
   test: {
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],
     server: {

--- a/plugins/sanity-plugin-workspace-home/vitest.config.ts
+++ b/plugins/sanity-plugin-workspace-home/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/plugins/sanity-translations-tab/vitest.config.ts
+++ b/plugins/sanity-translations-tab/vitest.config.ts
@@ -1,6 +1,9 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [reactCompilerPluginForVitest()],
   test: {
     server: {
       deps: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       nodemon:
         specifier: 3.1.14
         version: 3.1.14
+      oxc-transform-react:
+        specifier: 'catalog:'
+        version: 0.145.0
       validate-npm-package-name:
         specifier: 'catalog:'
         version: 8.0.0
@@ -584,6 +587,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1)(vite@8.2.1)
 
   plugins/@sanity/assist:
     dependencies:
@@ -3200,6 +3206,24 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.14(@vitejs/devtools@0.4.12)(oxc-resolver@11.24.2)(publint@0.3.23)(tsx@4.23.12)(typescript@7.0.2)
+
+  scripts/react-compiler-parity:
+    devDependencies:
+      '@sanity/plugin-kit':
+        specifier: workspace:^
+        version: link:../../packages/@sanity/plugin-kit
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@24.13.3)(@vitejs/devtools@0.4.12)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1)(vite@8.2.1)
 
   scripts/trigger-triage:
     devDependencies:

--- a/scripts/react-compiler-parity/package.json
+++ b/scripts/react-compiler-parity/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@repo/react-compiler-parity",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@sanity/plugin-kit": "workspace:^",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vite": "^8.2.1",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18"
+  }
+}

--- a/scripts/react-compiler-parity/react-compiler-parity.test.ts
+++ b/scripts/react-compiler-parity/react-compiler-parity.test.ts
@@ -1,0 +1,184 @@
+import {mkdtemp, readdir, readFile, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
+import {createServer, type PluginOption} from 'vite'
+import {expect, test} from 'vitest'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const pluginsRoot = path.join(repoRoot, 'plugins')
+
+const COUNTER_SOURCE = `
+import {useState} from 'react'
+export function Counter() {
+  const [n, setN] = useState(0)
+  return <button type="button" onClick={() => setN(n + 1)}>{n}</button>
+}
+`
+
+const JSX_ONLY_SOURCE = `
+export function Box() {
+  return <div data-testid="box">ok</div>
+}
+`
+
+const SETUP_SOURCE = `import * as _jestDom from '@testing-library/jest-dom/vitest'\n`
+
+/**
+ * Every plugin that enables React Compiler in `tsdown.config.ts` must also
+ * run Vitest through `reactCompilerPluginForVitest()` from
+ * `@sanity/plugin-kit/vitest`, so unit tests exercise the same compiled
+ * output that ships to npm. Generators wire both; this test stops agents
+ * from forgetting one side.
+ *
+ * See AGENTS.md ("React Compiler Vitest parity") and
+ * turbo/generators/templates/vitest.config.ts.hbs.
+ */
+test('plugins with reactCompiler in tsdown also enable it in vitest', async () => {
+  const tsdownConfigs = await findFiles(pluginsRoot, 'tsdown.config.ts')
+
+  const results = await Promise.all(
+    tsdownConfigs.map(async (tsdownPath) => {
+      const tsdownSource = await readFile(tsdownPath, 'utf8')
+      if (!enablesReactCompiler(tsdownSource)) return null
+
+      const pluginDir = path.dirname(tsdownPath)
+      const vitestPath = path.join(pluginDir, 'vitest.config.ts')
+      const relativePlugin = path.relative(repoRoot, pluginDir)
+
+      try {
+        const vitestSource = await readFile(vitestPath, 'utf8')
+        if (!enablesReactCompilerInVitest(vitestSource)) {
+          return `${relativePlugin}: tsdown has reactCompiler but vitest.config.ts does not register reactCompilerPluginForVitest() from @sanity/plugin-kit/vitest`
+        }
+      } catch {
+        return `${relativePlugin}: missing vitest.config.ts (tsdown has reactCompiler)`
+      }
+
+      return null
+    }),
+  )
+
+  const mismatches = results.filter((message): message is string => message !== null)
+
+  expect(
+    mismatches,
+    [
+      'React Compiler must be enabled in both tsdown.config.ts and vitest.config.ts.',
+      'Generators already wire both — see turbo/generators/templates/vitest.config.ts.hbs.',
+      'Documented in AGENTS.md under "React Compiler Vitest parity".',
+      '',
+      ...mismatches,
+    ].join('\n'),
+  ).toEqual([])
+})
+
+test('the plugin compiles a component in Vitest', {timeout: 30_000}, async () => {
+  const unfixed = await transformFixture([])
+  const compiled = await transformFixture([reactCompilerPluginForVitest()])
+
+  expect(unfixed, 'without the plugin the compiler must not run').not.toContain(
+    'react/compiler-runtime',
+  )
+  expect(compiled, 'with the plugin the compiler must run').toContain('react/compiler-runtime')
+})
+
+test('the plugin compiles JSX-only modules without a react import', {timeout: 30_000}, async () => {
+  const compiled = await transformFixture([reactCompilerPluginForVitest()], {
+    fileName: 'Box.tsx',
+    source: JSX_ONLY_SOURCE,
+  })
+  expect(compiled, 'automatic-runtime JSX must compile').toContain('react/compiler-runtime')
+})
+
+test('the plugin skips non-JSX modules that do not import react', () => {
+  const {transform} = reactCompilerPluginForVitest()
+  if (!transform || typeof transform === 'function' || !('handler' in transform)) {
+    throw new Error('expected an object transform hook')
+  }
+  expect(
+    Reflect.apply(transform.handler, undefined, [SETUP_SOURCE, '/virtual/setup.ts']),
+    'setup files must stay untouched so oxc DCE cannot drop jest-dom side-effect imports',
+  ).toBeNull()
+})
+
+test('assist vitest config compiles a component in Vitest', {timeout: 30_000}, async () => {
+  const {default: assistVitestConfig} = await import(
+    path.join(repoRoot, 'plugins/@sanity/assist/vitest.config.ts')
+  )
+  const code = await transformFixture(
+    Array.isArray(assistVitestConfig.plugins)
+      ? assistVitestConfig.plugins
+      : assistVitestConfig.plugins
+        ? [assistVitestConfig.plugins]
+        : [],
+  )
+  expect(code).toContain('react/compiler-runtime')
+})
+
+/**
+ * Transforms a fixture through the same server-side Vite pipeline Vitest uses,
+ * which is exactly where `@vitejs/plugin-react` `compiler: true` never applies.
+ */
+async function transformFixture(
+  plugins: PluginOption[],
+  fixture: {fileName: string; source: string} = {
+    fileName: 'Counter.tsx',
+    source: COUNTER_SOURCE,
+  },
+) {
+  const root = await mkdtemp(path.join(tmpdir(), 'react-compiler-parity-'))
+  await writeFile(path.join(root, fixture.fileName), fixture.source)
+
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'error',
+    plugins,
+    server: {middlewareMode: true},
+    appType: 'custom',
+  })
+
+  try {
+    const result = await server.environments.ssr.transformRequest(`/${fixture.fileName}`)
+    return result?.code ?? ''
+  } finally {
+    await server.close()
+  }
+}
+
+function enablesReactCompiler(tsdownSource: string): boolean {
+  // Match `reactCompiler: true` or `reactCompiler: { ... }` — not `reactCompiler: false`.
+  return /reactCompiler\s*:\s*(?!false\b)/.test(tsdownSource)
+}
+
+function enablesReactCompilerInVitest(vitestSource: string): boolean {
+  return (
+    vitestSource.includes("'@sanity/plugin-kit/vitest'") &&
+    vitestSource.includes('reactCompilerPluginForVitest(')
+  )
+}
+
+async function findFiles(root: string, fileName: string): Promise<string[]> {
+  const results: string[] = []
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, {withFileTypes: true})
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (entry.name === 'node_modules' || entry.name === 'dist') return
+        const fullPath = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+          await walk(fullPath)
+        } else if (entry.name === fileName) {
+          results.push(fullPath)
+        }
+      }),
+    )
+  }
+
+  await walk(root)
+  return results.sort()
+}

--- a/scripts/react-compiler-parity/vitest.config.ts
+++ b/scripts/react-compiler-parity/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/turbo/generators/templates/README.todo.md.hbs
+++ b/turbo/generators/templates/README.todo.md.hbs
@@ -49,6 +49,8 @@ These files are required for monorepo conventions and are scaffolded for you:
 - `tsconfig.json`
 - `vitest.config.ts`
 
+`tsdown.config.ts` enables React Compiler (`reactCompiler: {transform: 'oxc'}`) and `vitest.config.ts` mirrors it with `reactCompilerPluginForVitest()` from `@sanity/plugin-kit/vitest` — keep both in sync so tests exercise the same compiled output that ships to npm.
+
 Do not bring over standalone-repo config that is not used here (for example custom root build/lint/test configs and CI files).
 
 ## 3. Update package.json Dependencies

--- a/turbo/generators/templates/vitest.config.ts.hbs
+++ b/turbo/generators/templates/vitest.config.ts.hbs
@@ -1,12 +1,17 @@
+import {reactCompilerPluginForVitest} from '@sanity/plugin-kit/vitest'
 {{#if hasVanillaExtract}}
 import {vanillaExtractPlugin} from '@sanity/vanilla-extract-vite-plugin'
 {{/if}}
 import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
+  // Match `reactCompiler: {transform: 'oxc'}` in tsdown.config.ts so tests exercise compiled output.
+  plugins: [
+    reactCompilerPluginForVitest(),
 {{#if hasVanillaExtract}}
-  plugins: [vanillaExtractPlugin()],
+    vanillaExtractPlugin(),
 {{/if}}
+  ],
   test: {
 {{#if hasVanillaExtract}}
     setupFiles: ['@vanilla-extract/css/disableRuntimeStyles'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes React Compiler in Vitest a hard invariant with `tsdown.config.ts`, so unit tests exercise the same compiled output as published builds (the gap that forced the late Vitest opt-in in #1841 for `sanity-plugin-media`).

### Changes

1. **`@sanity/plugin-kit/vitest`** — new export with `reactCompilerPluginForVitest()`, a Vite plugin that runs the oxc React Compiler transform over plugin sources in Vitest. The compiler should always run for plugin code, but `@vitejs/plugin-react`'s `compiler: true` never applies in Vitest (it only compiles browser builds, not Vitest's transform pipeline), so the plugin calls `oxc-transform-react` directly. It skips non-JSX modules without a `react` import so oxc DCE cannot drop side-effect imports like `@testing-library/jest-dom/vitest` in setup files; `.tsx`/`.jsx` always compile (automatic-runtime JSX needs no explicit `react` import).
2. **Backfill** — all 47 plugins with React Compiler in tsdown register the shared plugin in `vitest.config.ts` (a 3-line diff per plugin; skipped `@sanity/debug-preview-url-secret-plugin`, which has no RC). The package resolves through the root devDependency like `vitest` / `vitest-package-exports` — per-plugin `workspace:^` devDeps would break the `pnpm pack` step of plugin builds.
3. **Generators** — `vitest.config.ts.hbs` emits the same import, so new plugins get parity for free.
4. **CI enforcement** — `scripts/react-compiler-parity` fails `pnpm test` if the tsdown/Vitest wiring drifts, and transforms fixtures through the same server-side Vite pipeline Vitest uses to assert `react/compiler-runtime` is emitted (hook components, JSX-only modules) and that setup files stay untouched.

Includes a minor changeset for `@sanity/plugin-kit` (new `./vitest` export, published for standalone plugins too). The lockfile diff is intentionally minimal (24 lines) — `sanity` stays at the `6.11.0-next.38` main currently pins.

## Testing

- `pnpm --filter @repo/react-compiler-parity exec vitest run` — 5 passed (parity invariant, compile with/without plugin, JSX-only compile, setup-file skip, assist config)
- `pnpm --filter @sanity/plugin-kit exec vitest run` — 62 passed (includes updated package-exports snapshot)
- `pnpm --filter @sanity/table exec vitest run` — JSX-only icon components compile
- `pnpm --filter @sanity/document-internationalization exec vitest run` — 213 passed, jest-dom matchers still register
- `pnpm --filter @sanity/color-input exec vitest run` — composes with vanilla-extract
- `pnpm build` (52 tasks), `pnpm lint`, `pnpm knip`, `pnpm format` — all pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d166d0d0-21a6-48e9-bf23-6559dd48b3de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d166d0d0-21a6-48e9-bf23-6559dd48b3de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

