### PR TITLE
fix(sanity-plugin-media): preserve folder reference when saving asset metadata (closes #1900)

### DIFF
--- a/.changeset/media-preserve-folder-on-metadata-save.md
+++ b/.changeset/media-preserve-folder-on-metadata-save.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Fix folder reference being lost when saving asset metadata (title, alt text, description, tags)

--- a/plugins/sanity-plugin-media/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogAssetEdit/DialogAssetEdit.test.tsx
@@ -315,6 +315,50 @@ describe('DialogAssetEdit', () => {
     })
   })
 
+  it('preserves the folder reference when saving other metadata fields', async () => {
+    const user = userEvent.setup()
+    const folderRef = {_ref: 'folder.products', _type: 'reference' as const, _weak: true}
+    const assetInFolder = {
+      ...asset,
+      opt: {media: {folder: folderRef}},
+    } as ImageAsset
+    const {store} = renderAssetDialog(
+      {
+        id: 'dlg-1',
+        type: 'assetEdit',
+        assetId: 'a1',
+      },
+      {
+        preloaded: {
+          assets: {
+            ...assetsPreloaded,
+            byIds: {
+              a1: {_type: 'asset', asset: assetInFolder, picked: false, updating: false},
+            },
+          },
+        },
+      },
+    )
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+    const dlg = withinDialog(/asset details/i, screen)
+
+    await user.type(inputByName(/asset details/i, screen, 'title'), 'New title')
+    await user.click(dlg.getByRole('button', {name: /save and close/i}))
+
+    await waitFor(() => {
+      let updateAction
+      for (const call of dispatchSpy.mock.calls) {
+        const action = call[0]
+        if (assetsActions.updateRequest.match(action)) {
+          updateAction = action
+          break
+        }
+      }
+      expect(updateAction).toBeDefined()
+      expect(updateAction?.payload.formData['opt'].media.folder).toEqual(folderRef)
+    })
+  })
+
   it('removes the current folder from the details view', async () => {
     const user = userEvent.setup()
     const assetInFolder = {

--- a/plugins/sanity-plugin-media/src/components/DialogAssetEdit/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/DialogAssetEdit/index.tsx
@@ -285,13 +285,16 @@ const DialogAssetEdit = (props: Props) => {
                     _type: 'reference',
                     _weak: true,
                   })) || null,
+                // Preserve the folder reference — it is managed separately and must
+                // not be wiped when patching opt.media via .set().
+                ...(currentAsset?.opt?.media?.folder && {folder: currentAsset.opt.media.folder}),
               },
             },
           },
         }),
       )
     },
-    [assetItem?.asset, dispatch],
+    [assetItem?.asset, currentAsset, dispatch],
   )
 
   // Listen for asset mutations and update snapshot


### PR DESCRIPTION
### Description

Fixes a bug where an asset's folder reference (`opt.media.folder`) was silently cleared whenever the asset's metadata (title, alt text, description, or tags) was saved.
The root cause: `DialogAssetEdit` builds form state with only `tags` under `opt.media` — the folder is managed separately and never tracked in the form. On submit, the Sanity patch calls .`set({opt: {media: {tags: [...]}}})`, which replaces the entire opt key, wiping any existing folder reference.
Fix: preserve the folder reference from the current asset when constructing the patch payload.
Closes #1900

### What to review

- `plugins/sanity-plugin-media/src/components/DialogAssetEdit/index.tsx` — the `onSubmit` handler now spreads `currentAsset.opt.media.folder` back into the `opt.media` patch object
- `DialogAssetEdit.test.tsx` — new test: "preserves the folder reference when saving other metadata fields"

### Testing
A regression test was added that renders the dialog with an asset already assigned to a folder, edits the title, submits, and asserts the dispatched `updateRequest` action still carries the original folder reference in `formData.opt.media.folder`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix to patch payload construction in the media plugin; folder moves/removals still use separate flows.
> 
> **Overview**
> Fixes a bug where saving asset metadata (title, alt text, description, tags) in the asset edit dialog **cleared** `opt.media.folder` even when the asset stayed in the same folder.
> 
> **Cause:** Submit builds `formData` with only `tags` under `opt.media` (folder is handled elsewhere). The update patch uses `.set(formData)`, which replaces the whole `opt` object and drops the folder reference.
> 
> **Change:** In `DialogAssetEdit` `onSubmit`, when a folder exists on `currentAsset`, it is merged back into `formData.opt.media` before dispatch. `onSubmit` now depends on `currentAsset` as well as `assetItem?.asset`.
> 
> A regression test edits the title on a foldered asset and asserts `updateRequest` still includes the original folder reference. Patch changeset for `sanity-plugin-media`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f0f4ff6218a778858843b7b6312e29a9678e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->