### PR TITLE
feat(internationalized-array): add restoreOrder opt-out (SAPP-4143)

### DIFF
--- a/.changeset/internationalized-array-restore-order-opt-out.md
+++ b/.changeset/internationalized-array-restore-order-opt-out.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": minor
+---
+
+Add `restoreOrder` plugin option (default `true`) to opt out of automatic language order restoration on document open

--- a/plugins/sanity-plugin-internationalized-array/README.md
+++ b/plugins/sanity-plugin-internationalized-array/README.md
@@ -137,6 +137,10 @@ To control the "Add translation" button titles, configure `languageDisplay`. Thi
 
 The "Add all languages" button can be hidden with `buttonAddAll`.
 
+By default, opening a document reorders internationalized array items to match
+the configured `languages` order. That can create a draft (and a history entry)
+for published documents whose stored order differs. Opt out with `restoreOrder: false`.
+
 ```ts
 import {defineConfig} from 'sanity'
 import {internationalizedArray} from 'sanity-plugin-internationalized-array'
@@ -148,6 +152,7 @@ export default defineConfig({
       // ...other config
       buttonLocations: ['field', 'unstable__fieldAction', 'document'], // default ['field']
       buttonAddAll: false, // default true
+      restoreOrder: false, // default true
       languageDisplay: 'codeOnly', // codeOnly (default) | titleOnly | titleAndCode
     }),
   ],

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -46,6 +46,7 @@ vi.mock('./InternationalizedArrayContext', () => ({
     defaultLanguages: [],
     buttonAddAll: true,
     buttonLocations: ['field'],
+    restoreOrder: true,
     languageDisplay: 'codeOnly',
     apiVersion: '2025-10-15',
     select: {},
@@ -401,6 +402,21 @@ describe('InternationalizedArray', () => {
     const value = createValues(['fr', 'en'])
     // readOnly at the document level (props.readOnly, mapped to documentReadOnly)
     const props = createMockArrayProps({onChange, value, readOnly: true})
+
+    renderInternationalizedArray(props)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-reorder when restoreOrder is false', () => {
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      restoreOrder: false,
+    })
+
+    const onChange = vi.fn()
+    const value = createValues(['fr', 'en'])
+    const props = createMockArrayProps({onChange, value})
 
     renderInternationalizedArray(props)
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -43,8 +43,10 @@ import {MigrationBanner} from './MigrationBanner'
  *   document exists in the dataset (it has a `_rev`), so the effect never
  *   recreates a just-deleted document or creates a draft before the user's
  *   first edit.
- * - **Ordering**: Detects when value items are out of order relative to the
- *   master `languages` list and automatically re-sorts them.
+ * - **Ordering**: When `restoreOrder` is enabled (default), detects when value
+ *   items are out of order relative to the master `languages` list and
+ *   automatically re-sorts them. Set `restoreOrder: false` to keep the stored
+ *   order and avoid silent draft creation on open.
  * - **Validation**: Shows a `<Feedback>` component if the languages
  *   configuration is invalid (e.g. missing `id` or `title`).
  * - **Empty state**: Displays a "no translations" message when the field has
@@ -68,6 +70,7 @@ export default function InternationalizedArray(
     defaultLanguages,
     buttonAddAll,
     buttonLocations,
+    restoreOrder,
     languageFilter: builtInLanguageFilter,
   } = useInternationalizedArrayContext()
 
@@ -262,12 +265,12 @@ export default function InternationalizedArray(
     [languages],
   )
 
-  // Automatically restore order of fields
+  // Automatically restore order of fields (opt out with restoreOrder: false)
   useEffect(() => {
-    if (languagesOutOfOrder.length > 0 && allKeysAreLanguages && !readOnly) {
+    if (restoreOrder && languagesOutOfOrder.length > 0 && allKeysAreLanguages && !readOnly) {
       handleRestoreOrder()
     }
-  }, [languagesOutOfOrder, allKeysAreLanguages, handleRestoreOrder, readOnly])
+  }, [restoreOrder, languagesOutOfOrder, allKeysAreLanguages, handleRestoreOrder, readOnly])
 
   // compare value keys with possible languages
   const allLanguagesArePresent = useMemo(

--- a/plugins/sanity-plugin-internationalized-array/src/constants.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/constants.ts
@@ -39,6 +39,7 @@ export const CONFIG_DEFAULT: Required<PluginConfig> = {
   apiVersion: '2025-10-15',
   buttonLocations: ['field'],
   buttonAddAll: true,
+  restoreOrder: true,
   languageDisplay: 'codeOnly',
   includeForDocumentType: (documentType) => documentType !== 'translation.metadata',
   languageFilter: {

--- a/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/test/helpers.ts
@@ -47,6 +47,7 @@ export const MOCK_INTERNATIONALIZED_ARRAY_CONTEXT: InternationalizedArrayContext
   defaultLanguages: [],
   buttonAddAll: true,
   buttonLocations: ['field'],
+  restoreOrder: true,
   languageDisplay: 'codeOnly' as const,
   apiVersion: '2025-10-15',
   select: {},

--- a/plugins/sanity-plugin-internationalized-array/src/types.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/types.ts
@@ -145,6 +145,17 @@ export type PluginConfig = {
    * */
   buttonAddAll?: boolean
   /**
+   * Automatically reorder array items to match the configured `languages` order
+   * when a document is opened.
+   *
+   * Disable this if you want to preserve a custom item order and avoid the
+   * plugin writing a patch (which creates a draft / history entry) for published
+   * documents whose order differs from the language config.
+   *
+   * @defaultValue true
+   */
+  restoreOrder?: boolean
+  /**
    * How to display the languages on buttons and fields
    * @defaultValue 'code'
    * */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `restoreOrder` plugin config option (default `true`) so studios can opt out of the automatic `handleRestoreOrder` workflow in `sanity-plugin-internationalized-array`.

When language array items are stored in a different order than the configured `languages` list, the plugin currently reorders them on mount. That writes a patch and can silently create drafts / history entries for published documents ([SAPP-4143](https://linear.app/sanity/issue/SAPP-4143/add-opt-out-for-internationalized-array-order-restoration)).

### Usage

```ts
internationalizedArray({
  // ...
  restoreOrder: false, // keep stored order; do not patch on open
})
```

## Test plan

- [x] Unit test: auto-reorder still runs when `restoreOrder` is true (existing)
- [x] Unit test: no `onChange` when `restoreOrder: false` and items are out of order
- [x] Unit test: no reorder when document is read-only (existing)
- [x] `pnpm exec vitest run --project sanity-plugin-internationalized-array` (210 passed)
- [x] Plugin build succeeds; `restoreOrder` present in emitted types

### Evidence

[restore_order_opt_out_tests.log](https://cursor.com/agents/bc-ddd4a65f-e1a4-486f-ba71-4ef7d4e3c14b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frestore_order_opt_out_tests.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddd4a65f-e1a4-486f-ba71-4ef7d4e3c14b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddd4a65f-e1a4-486f-ba71-4ef7d4e3c14b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

