### PR TITLE
chore(deps): drop unused transitive @tanstack/react-table from the install graph

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,7 @@ overrides:
   '@sanity/vision': next
   groq: next
   sanity: next
+  'sanity>@tanstack/react-table': '-'
   tsx: ^4.23.12
 
 importers:
@@ -7719,22 +7720,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   '@tanstack/react-virtual@3.14.9':
     resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -21851,19 +21841,11 @@ snapshots:
       '@tanstack/query-core': 5.101.4
       react: 19.2.8
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8)(react@19.2.8)':
-    dependencies:
-      '@tanstack/table-core': 8.21.3
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8)(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.7
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-
-  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.17.7': {}
 
@@ -28042,7 +28024,6 @@ snapshots:
       '@sanity/uuid': 3.0.3
       '@sanity/workbench': 0.1.0-alpha.36(@sanity/sdk@2.19.0)(react@19.2.8)(xstate@5.32.5)
       '@sentry/react': 10.70.0(react@19.2.8)
-      '@tanstack/react-table': 8.21.3(react-dom@19.2.8)(react@19.2.8)
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8)(react@19.2.8)
       '@xstate/react': 6.1.0(@types/react@19.2.18)(react@19.2.8)(xstate@5.32.5)
       clsx: 2.1.1
@@ -28191,7 +28172,6 @@ snapshots:
       '@sanity/uuid': 3.0.3
       '@sanity/workbench': 0.1.0-alpha.36(@sanity/sdk@2.19.0)(react@19.2.8)(xstate@5.32.5)
       '@sentry/react': 10.70.0(react@19.2.8)
-      '@tanstack/react-table': 8.21.3(react-dom@19.2.8)(react@19.2.8)
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8)(react@19.2.8)
       '@xstate/react': 6.1.0(@types/react@19.2.18)(react@19.2.8)(xstate@5.32.5)
       clsx: 2.1.1
@@ -28340,7 +28320,6 @@ snapshots:
       '@sanity/uuid': 3.0.3
       '@sanity/workbench': 0.1.0-alpha.36(@sanity/sdk@2.19.0)(react@19.2.8)(xstate@5.32.5)
       '@sentry/react': 10.70.0(react@19.2.8)
-      '@tanstack/react-table': 8.21.3(react-dom@19.2.8)(react@19.2.8)
       '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8)(react@19.2.8)
       '@xstate/react': 6.1.0(@types/react@19.2.18)(react@19.2.8)(xstate@5.32.5)
       clsx: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -174,6 +174,12 @@ overrides:
   '@sanity/vision': next
   groq: next
   sanity: next
+  # `sanity` still declares `@tanstack/react-table` (v8) as a dependency, but nothing
+  # imports it: its only consumer (the sheet list) was removed in sanity-io/sanity#12477
+  # and the dependency itself in sanity-io/sanity#14121. Drop the unused package (v8's
+  # `useReactTable` is also React Compiler-incompatible) from the install graph until the
+  # pinned `next` prerelease ships without it — then delete this override.
+  'sanity>@tanstack/react-table': '-'
   # Keep a single tsx (and thus a single vite types instance) so sanity.cli vite
   # config callbacks type-check cleanly after the catalog tsx bump.
   tsx: 'catalog:'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Started as the `@tanstack/react-table` v8 → v9 upgrade from [sanity-io/sanity#14114](https://github.com/sanity-io/sanity/pull/14114), applied to this monorepo while following the [React Compiler guide](https://tanstack.com/table/latest/docs/framework/react/guide/react-compiler) thoroughly. Working through the guide surfaced that there is nothing to upgrade or migrate here — but there is something to remove.

**Audit results (what the guide asks you to check):**

- No workspace package depends on `@tanstack/react-table`, and no source file references any of its APIs (`useReactTable`, `useTable`, `flexRender`, `createColumnHelper`, `getCoreRowModel`, `TableMeta`, `Subscribe`). `@sanity/table` is a custom implementation, `sanity-plugin-media` renders its table view with `react-virtuoso`.
- The React Compiler is enabled for plugin builds (`reactCompiler: true` in each `tsdown.config.ts`) and enforced via the `react/react-compiler` oxlint rule, so a v8 `useReactTable` consumer here would be a real hazard — v8 is the canonical interior-mutability example in React's [`incompatible-library`](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library) lint docs. The repo's only `'use no memo'` directive (media plugin's asset details form) is a react-hook-form `register()` issue, unrelated to tables.
- The other `@tanstack/*` dependencies in this repo (`react-query` v5 in the Vercel widget, `react-virtual` v3 in workflow) are not covered by the Table v9 rework; `react-virtual` has no store-based, compiler-ready major to move to yet (latest is 3.14.9).
- The **only** copy of table v8 in this workspace is a transitive dependency of `sanity` (pinned to the `next` dist-tag): `pnpm why` shows no other path, and the installed `sanity@6.10.0-next.53` build has zero `react-table` references outside its `package.json` — the sheet-list consumer was removed in [sanity-io/sanity#12477](https://github.com/sanity-io/sanity/pull/12477) and the dependency itself in [sanity-io/sanity#14121](https://github.com/sanity-io/sanity/pull/14121) (merged today).

**The change:** a scoped pnpm removal override, `'sanity>@tanstack/react-table': '-'`, drops the unused package (and `@tanstack/table-core`) from the lockfile and install graph now. Scoping it to the `sanity>` edge means it self-neutralizes once the pinned `next` prerelease ships without the dependency, and it cannot interfere if a plugin ever adopts table v9 directly — at which point the override should be deleted (noted in the comment).

**Why not wait for the upstream release?** `Release @next` in sanity-io/sanity runs on a schedule (~07:17/14:13 UTC); today's second run started before #14121 merged (14:24 UTC), so the current `sanity@next` (`6.10.0-next.87`) still declares `^8.21.3`. Also worth flagging: a plain lockfile re-resolution to `next.87` is currently blocked anyway — it pulls `@sanity/sdk@3.0.0-rc.1`, which fails the workspace `trustPolicy: no-downgrade` check (no provenance on the RC while earlier versions had it). That is a pre-existing condition this PR does not touch; the lockfile was therefore edited surgically (verified: `pnpm install` reports `Already up to date`, and a clean reinstall produces a tree where `sanity`'s virtual-store dirs no longer link `react-table`).

### What to review

- `pnpm-workspace.yaml` — the scoped override and its removal note
- `pnpm-lock.yaml` — removals only: the override mirror, the `@tanstack/react-table@8.21.3` + `@tanstack/table-core@8.21.3` package/snapshot entries, and the three `sanity` snapshot edges

### Testing

No changeset — no published package's `package.json` or runtime code changes (workspace config + lockfile only, same as the dedupe PRs). Verified locally on the branch:

- `pnpm install --frozen-lockfile` from a clean `node_modules` (tree confirmed free of react-table)
- `pnpm format` — no diffs
- `pnpm lint` — pass
- `pnpm knip` — pass
- `pnpm build` — 52/52 tasks
- `pnpm test run` — 211 files, 1283 tests, all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84d75a8a-f965-4b9c-8fba-61a322e99958?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84d75a8a-f965-4b9c-8fba-61a322e99958&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

