### PR TITLE
fix(deps): update sanity monorepo to ^6.10.0

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,19 +30,19 @@ catalog:
   '@sanity/color': ^3.0.8
   '@sanity/icons': ^5.2.1
   '@sanity/image-url': ^2.1.1
-  '@sanity/mutator': ^6.9.2
+  '@sanity/mutator': ^6.10.0
   '@sanity/pkg-utils': ^12.1.0
   '@sanity/preview-url-secret': ^4.1.4
-  '@sanity/schema': ^6.9.2
+  '@sanity/schema': ^6.10.0
   '@sanity/telemetry': '^1.1.0'
   '@sanity/tsconfig': ^2.2.1
   '@sanity/tsdown-config': ^0.24.1
-  '@sanity/types': ^6.9.2
+  '@sanity/types': ^6.10.0
   '@sanity/ui': ^4.0.3
-  '@sanity/util': ^6.9.2
+  '@sanity/util': ^6.10.0
   '@sanity/uuid': ^3.0.3
   '@sanity/vanilla-extract-vite-plugin': ^0.2.13
-  '@sanity/vision': ^6.9.2
+  '@sanity/vision': ^6.10.0
   '@testing-library/jest-dom': ^7.0.1
   '@testing-library/react': ^16.3.2
   '@types/lodash-es': ^4.17.12
@@ -57,7 +57,7 @@ catalog:
   '@vitest/coverage-v8': ^4.1.10
   babel-plugin-react-compiler: ^1.0.0
   date-fns: ^4.4.0
-  groq: ^6.9.2
+  groq: ^6.10.0
   jsdom: ^29.1.1
   lexorank: ^1.0.5
   lodash-es: ^4.18.1
@@ -75,7 +75,7 @@ catalog:
   react-photo-album: ^3.6.0
   react-rx: ^4.2.5
   rxjs: ^7.8.2
-  sanity: ^6.9.2
+  sanity: ^6.10.0
   styled-components: ^6.5.3
   suspend-react: ^0.1.3
   tsdown: ^0.22.14


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the pnpm catalog lockstep for the Sanity Studio monorepo from `^6.9.2` to `^6.10.0`.

## Packages

| Package | Change |
| --- | --- |
| `sanity` | `^6.9.2` → `^6.10.0` |
| `@sanity/vision` | `^6.9.2` → `^6.10.0` |
| `@sanity/mutator` | `^6.9.2` → `^6.10.0` |
| `@sanity/schema` | `^6.9.2` → `^6.10.0` |
| `@sanity/types` | `^6.9.2` → `^6.10.0` |
| `@sanity/util` | `^6.9.2` → `^6.10.0` |
| `groq` | `^6.9.2` → `^6.10.0` |

These are updated together so dts emit and transitive deps cannot leave a second major.minor of `@sanity/types` / mutator / schema / util / groq in the lockfile.

## Notes

- `pnpm-workspace.yaml` overrides still pin `sanity`, `@sanity/vision`, `@sanity/mutator`, `@sanity/schema`, `@sanity/types`, `@sanity/util`, and `groq` to the `next` dist-tag for compatibility testing. The lockfile therefore stays on the currently resolved `6.10.0-next.53` snapshot (single version of each package).
- No published plugin `package.json` or runtime code changed, so this PR has no changesets. Plugin peers remain `catalog:peer` (`^5 || ^6.0.0-0`).
- [Sanity Studio v6.10.0](https://github.com/sanity-io/sanity/blob/v6.10.0/packages/sanity/CHANGELOG.md#6100-2026-08-18) is a feature/bugfix release (access-ui request screen, SDK studio context, embedded form export, structure/variants fixes). No new document-operation disable reasons needed mapping in this repo.

## Verification

Local checks passed:

- `pnpm format`
- `pnpm lint`
- `pnpm knip`
- `pnpm build` (52 packages)
- `pnpm test run` — 211 files, 1283 tests passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15795677-8118-4c25-a7f4-0b3c5db095b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15795677-8118-4c25-a7f4-0b3c5db095b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

