### PR TITLE
Bump oxlint to 1.79 and enable all React Compiler rules

### DIFF
--- a/.changeset/plugin-kit-oxlint-1-79.md
+++ b/.changeset/plugin-kit-oxlint-1-79.md
@@ -1,0 +1,5 @@
+---
+"@sanity/plugin-kit": patch
+---
+
+Bump the `oxlint` peer dependency to `^1.79.0`, which ships the React Compiler-powered rules

--- a/.changeset/react-compiler-rule-suppressions.md
+++ b/.changeset/react-compiler-rule-suppressions.md
@@ -1,0 +1,15 @@
+---
+"@sanity/assist": patch
+"@sanity/block-insert-picker": patch
+"@sanity/code-input": patch
+"@sanity/document-internationalization": patch
+"@sanity/embeddings-index-ui": patch
+"@sanity/sanity-plugin-async-list": patch
+"sanity-plugin-cloudinary": patch
+"sanity-plugin-graph-view": patch
+"sanity-plugin-hotspot-array": patch
+"sanity-plugin-media": patch
+"sanity-plugin-mux-input": patch
+---
+
+Suppress new oxlint React Compiler rule violations, pending fixes in a follow-up

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ Note on **knip**: in-file usage keeps an exported type "used" (`ignoreExportsUse
 
 ### Lint Specifics
 
-- **oxlint**: Type-aware linting with `--deny-warnings` (warnings are errors). React Compiler rules run via the react-hooks-js plugin.
+- **oxlint**: Type-aware linting with `--deny-warnings` (warnings are errors). React Compiler rules run natively via the [React Compiler vendored into oxlint](https://oxc.rs/blog/2026-08-18-react-compiler-support.html); the root `oxlint.config.ts` enables all of them (stricter than the plugin-kit preset) since this monorepo builds plugins with React Compiler.
 - **TypeScript type checking** is included in `pnpm lint` via oxlint — no separate `tsc` needed
 - Run `pnpm lint:fix` to auto-fix issues when possible
 
@@ -510,7 +510,7 @@ The formatter settings live in the shared `@sanity/plugin-kit/oxfmt` preset (`pa
 
 ### Linting
 
-We use [oxlint](https://oxc.rs/docs/linter.html) for all linting (type-aware, includes TypeScript type checking and React Compiler rules via the react-hooks-js plugin):
+We use [oxlint](https://oxc.rs/docs/linter.html) for all linting (type-aware, includes TypeScript type checking and [React Compiler rules](https://oxc.rs/blog/2026-08-18-react-compiler-support.html)):
 
 ```bash
 pnpm lint        # Run the linter (includes type checking)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ pnpm format
 
 ### Linting
 
-We use [oxlint](https://oxc.rs/docs/linter.html) for all linting (including React Compiler rules via the react-hooks-js plugin):
+We use [oxlint](https://oxc.rs/docs/linter.html) for all linting (including [React Compiler rules](https://oxc.rs/blog/2026-08-18-react-compiler-support.html)):
 
 ```bash
 # Run the linter

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -17,6 +17,22 @@ export default defineConfig({
     // AILF reference solutions - graded artefacts, not part of the plugins build
     'plugins/**/.ailf/tasks/**/*.reference.ts',
   ],
+  rules: {
+    // This monorepo builds plugins with React Compiler, so unlike the plugin-kit preset
+    // (which mostly relies on category defaults) every React Compiler rule is enabled:
+    // https://oxc.rs/blog/2026-08-18-react-compiler-support.html#oxlint
+    'react/capitalized-calls': 'error',
+    'react/exhaustive-effect-dependencies': 'error',
+    'react/hooks': 'error',
+    'react/invariant': 'error',
+    'react/memo-dependencies': 'error',
+    'react/no-deriving-state-in-effects': 'error',
+    'react/rule-suppression': 'error',
+    'react/syntax': 'error',
+    'react/todo': 'error',
+    'react/unsupported-syntax': 'error',
+    'react/void-use-memo': 'error',
+  },
   overrides: [
     {
       files: ['e2e/**/*.ts'],

--- a/plugins/@sanity/assist/src/assistDocument/components/AssistDocumentForm.tsx
+++ b/plugins/@sanity/assist/src/assistDocument/components/AssistDocumentForm.tsx
@@ -283,6 +283,7 @@ function FieldsInitializer({
     }
     onChange(event)
     initialized.current = true
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [activePath, onChange, pathKey, existingField, missingPresetInstructions])
 
   return null

--- a/plugins/@sanity/assist/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
+++ b/plugins/@sanity/assist/src/assistDocument/hooks/useAssistDocumentContextValue.tsx
@@ -118,6 +118,7 @@ function useSyntheticTasks(assistableDocumentId: string) {
   useEffect(() => {
     // oxlint-disable-next-line react/set-state-in-effect
     setSyntheticTasks([])
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [assistableDocumentId])
 
   return {

--- a/plugins/@sanity/assist/src/fieldActions/customFieldActions.tsx
+++ b/plugins/@sanity/assist/src/fieldActions/customFieldActions.tsx
@@ -217,6 +217,7 @@ export function useCustomFieldActions(
 
   const schemaId = useWorkspaceSchemaId()
   const {push: pushToast} = useToast()
+  // oxlint-disable-next-line react/hooks
   const configActions = fieldActions?.useFieldActions?.({
     ...props,
     schemaId,

--- a/plugins/@sanity/assist/src/useApiClient.ts
+++ b/plugins/@sanity/assist/src/useApiClient.ts
@@ -232,6 +232,7 @@ export function useGetInstructStatus(apiClient: SanityClient) {
     setLoading(true)
 
     const projectId = apiClient.config().projectId
+    // oxlint-disable-next-line react/todo
     try {
       const status = await apiClient.request<InstructStatus>({
         method: 'GET',

--- a/plugins/@sanity/block-insert-picker/src/blockInsertPicker.tsx
+++ b/plugins/@sanity/block-insert-picker/src/blockInsertPicker.tsx
@@ -331,6 +331,7 @@ export function BlockInsertPicker({
         status: 'error',
         title: labels.insertError,
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       insertInFlightRef.current = false
     }
@@ -517,6 +518,7 @@ export function BlockInsertPicker({
 
   useEffect(() => {
     highlightedRowRef.current?.scrollIntoView({block: 'nearest'})
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [highlightedIndex])
 
   // Stable virtual element derived from the captured rect — keeps Popover

--- a/plugins/@sanity/code-input/src/codemirror/CodeMirrorProxy.tsx
+++ b/plugins/@sanity/code-input/src/codemirror/CodeMirrorProxy.tsx
@@ -73,6 +73,7 @@ function CodeMirrorProxy(props: CodeMirrorProps & {ref?: Ref<ReactCodeMirrorRef>
     if (editorView) {
       setHighlightedLines(editorView, highlightLines ?? [])
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [editorView, highlightLines, value])
 
   const [initialState] = useState(() => {

--- a/plugins/@sanity/document-internationalization/src/components/OptimisticallyStrengthen/ReferencePatcher.tsx
+++ b/plugins/@sanity/document-internationalization/src/components/OptimisticallyStrengthen/ReferencePatcher.tsx
@@ -40,6 +40,7 @@ export default function ReferencePatcher(props: ReferencePatcherProps) {
         ]),
       )
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [translation, editState, metadataId, client, onChange])
 
   return null

--- a/plugins/@sanity/embeddings-index-ui/src/referenceInput/SemanticSearchReferenceInput.tsx
+++ b/plugins/@sanity/embeddings-index-ui/src/referenceInput/SemanticSearchReferenceInput.tsx
@@ -115,6 +115,7 @@ function SemanticSearchInput(props: ObjectInputProps & {indexConfig: EmbeddingsI
       autocompleteRef.current?.focus()
     }
     // intentional empty deps — focus once on mount when replacing an existing reference
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps
   }, [])
 

--- a/plugins/@sanity/sanity-plugin-async-list/src/components/async-list.tsx
+++ b/plugins/@sanity/sanity-plugin-async-list/src/components/async-list.tsx
@@ -136,6 +136,7 @@ export function AsyncList(props: AsyncListInputProps): JSX.Element {
 
         console.error('sanity-plugin-async-list fetch error:', errorMessage)
         setError(new Error('Error fetching list, check console for more info'))
+        // oxlint-disable-next-line react/todo
       } finally {
         setLoading(false)
       }

--- a/plugins/sanity-plugin-cloudinary/src/components/CloudinaryReferenceInput.tsx
+++ b/plugins/sanity-plugin-cloudinary/src/components/CloudinaryReferenceInput.tsx
@@ -143,6 +143,7 @@ const CloudinaryReferenceInput = (props: ObjectInputProps) => {
         setPreviewRevision((revision) => revision + 1)
       } catch (err) {
         console.error('Error creating/updating Cloudinary asset:', err)
+        // oxlint-disable-next-line react/todo
       } finally {
         saveInProgressRef.current = false
         setIsLoading(false)

--- a/plugins/sanity-plugin-graph-view/src/tool/GraphView.tsx
+++ b/plugins/sanity-plugin-graph-view/src/tool/GraphView.tsx
@@ -339,6 +339,7 @@ export default function GraphView({
                 const y = node.y + (Math.cos(angle) * distance) / globalScale
 
                 ctx.save()
+                // oxlint-disable-next-line react/todo
                 try {
                   ctx.globalAlpha = fadeEasing(
                     1 -

--- a/plugins/sanity-plugin-hotspot-array/src/useDebouncedCallback.ts
+++ b/plugins/sanity-plugin-hotspot-array/src/useDebouncedCallback.ts
@@ -58,6 +58,7 @@ export function useDebouncedCallback<Fn extends (...args: any[]) => any>(
 
   useEffect(() => {
     cb.current = callback
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps -- deps are provided by the caller via the `deps` argument
   }, deps)
 
@@ -97,6 +98,7 @@ export function useDebouncedCallback<Fn extends (...args: any[]) => any>(
     })
 
     return wrapped
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps -- deps are provided by the caller via the `deps` argument
   }, [delay, maxWait, ...deps])
 }

--- a/plugins/sanity-plugin-hotspot-array/src/useResizeObserver.ts
+++ b/plugins/sanity-plugin-hotspot-array/src/useResizeObserver.ts
@@ -120,6 +120,7 @@ export function useResizeObserver<T extends Element>(
       subscribed = false
       ro.unsubscribe(_tgt, handler)
     }
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps -- callback is kept current via cb.current
   }, [tgt, ro])
 }

--- a/plugins/sanity-plugin-media/src/components/Browser/useBrowserInit.ts
+++ b/plugins/sanity-plugin-media/src/components/Browser/useBrowserInit.ts
@@ -131,5 +131,6 @@ export function useBrowserInit(
         }),
       )
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [tagsFetchCount, hasMediaTags]) // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/plugins/sanity-plugin-mux-input/src/components/AddCaptionDialog.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/AddCaptionDialog.tsx
@@ -268,6 +268,7 @@ export default function AddCaptionDialog({asset, onAdd, onClose}: Props) {
         status: 'error',
         description: extractErrorMessage(error, 'Failed to add caption track'),
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setIsSubmitting(false)
     }

--- a/plugins/sanity-plugin-mux-input/src/components/DraggableWatermark.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/DraggableWatermark.tsx
@@ -460,6 +460,7 @@ export function WatermarkControls({
             imageAspectRatio: undefined,
             overlay_settings: undefined,
           })
+          // oxlint-disable-next-line react/todo
         } finally {
           setIsValidating(false)
         }

--- a/plugins/sanity-plugin-mux-input/src/components/EditCaptionDialog.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/EditCaptionDialog.tsx
@@ -71,6 +71,7 @@ export default function EditCaptionDialog({asset, track, onUpdate, onClose}: Pro
     )
     const foundByName = track.name ? LANGUAGE_OPTIONS.find((opt) => opt.label === track.name) : null
     setSelectedLanguage(foundByCode || foundByName || null)
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies
   }, [track, asset, client])
 
   const handleDownloadCurrentFile = async () => {
@@ -96,6 +97,7 @@ export default function EditCaptionDialog({asset, track, onUpdate, onClose}: Pro
         status: 'error',
         description: errorMessage,
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setDownloading(false)
     }
@@ -263,6 +265,7 @@ export default function EditCaptionDialog({asset, track, onUpdate, onClose}: Pro
 
     try {
       if (!asset.assetId) {
+        // oxlint-disable-next-line react/todo
         throw new Error('Asset ID is required')
       }
 
@@ -327,6 +330,7 @@ export default function EditCaptionDialog({asset, track, onUpdate, onClose}: Pro
         status: 'error',
         description: error instanceof Error ? error.message : 'Please try again',
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setIsSubmitting(false)
     }

--- a/plugins/sanity-plugin-mux-input/src/components/TextTracksManager.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/TextTracksManager.tsx
@@ -463,6 +463,7 @@ export default function TextTracksManager({
         status: 'error',
         description: error instanceof Error ? error.message : 'Please try again',
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setDownloadingTrackId(null)
     }
@@ -476,6 +477,7 @@ export default function TextTracksManager({
     setDeletingTrackId(track.id)
     try {
       if (!asset.assetId) {
+        // oxlint-disable-next-line react/todo
         throw new Error('Asset ID is required')
       }
       await deleteTextTrack(client, asset.assetId, track.id)
@@ -510,6 +512,7 @@ export default function TextTracksManager({
         status: 'error',
         description: error instanceof Error ? error.message : 'Please try again',
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setDeletingTrackId(null)
     }

--- a/plugins/sanity-plugin-mux-input/src/components/UploadConfiguration.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/UploadConfiguration.tsx
@@ -270,6 +270,7 @@ export default function UploadConfiguration({
       })
       startUpload(settings, watermark)
     }
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps -- intentionally mount-only: start upload once with developer-specified config
   }, [])
   if (skipConfig) return null

--- a/plugins/sanity-plugin-mux-input/src/components/VideoThumbnail.tsx
+++ b/plugins/sanity-plugin-mux-input/src/components/VideoThumbnail.tsx
@@ -55,6 +55,7 @@ export default function VideoThumbnail({
         return thumbnail
       },
       (err: Error) => {
+        // oxlint-disable-next-line react/todo
         handleError(err.message)
         return undefined
       },

--- a/plugins/sanity-plugin-mux-input/src/hooks/useMezzanine.ts
+++ b/plugins/sanity-plugin-mux-input/src/hooks/useMezzanine.ts
@@ -119,6 +119,7 @@ export function useMezzanine(asset: VideoAssetDocument): UseMezzanineReturn {
         }
       } catch (error) {
         console.error('Failed to poll mezzanine status:', error)
+        // oxlint-disable-next-line react/todo
       } finally {
         running = false
       }
@@ -147,6 +148,7 @@ export function useMezzanine(asset: VideoAssetDocument): UseMezzanineReturn {
         title: 'Could not enable the mezzanine file',
         description: error instanceof Error ? error.message : 'Please try again',
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setBusy(false)
     }
@@ -175,6 +177,7 @@ export function useMezzanine(asset: VideoAssetDocument): UseMezzanineReturn {
         title: 'Could not download the mezzanine file',
         description: error instanceof Error ? error.message : 'Please try again',
       })
+      // oxlint-disable-next-line react/todo
     } finally {
       setBusy(false)
     }

--- a/plugins/sanity-plugin-mux-input/src/hooks/useMuxAssets.ts
+++ b/plugins/sanity-plugin-mux-input/src/hooks/useMuxAssets.ts
@@ -172,6 +172,7 @@ export default function useMuxAssets({client, enabled}: {client: SanityClient; e
 
     // Unsubscribe on component unmount to prevent memory leaks or fetching unnecessarily
     return () => subscription.unsubscribe()
+    // oxlint-disable-next-line react/rule-suppression
     // oxlint-disable-next-line react/exhaustive-deps -- secrets/pluginConfig are stable for the asset fetch lifecycle once enabled
   }, [enabled])
 

--- a/plugins/sanity-plugin-mux-input/src/hooks/useSaveSecrets.ts
+++ b/plugins/sanity-plugin-mux-input/src/hooks/useSaveSecrets.ts
@@ -29,6 +29,7 @@ export const useSaveSecrets = (client: SanityClient, secrets: Secrets) => {
         )
         const valid = await testSecrets(client)
         if (!valid?.status && token && secretKey) {
+          // oxlint-disable-next-line react/todo
           throw new Error('Invalid secrets')
         }
       } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,7 +122,7 @@ catalogs:
       specifier: ^0.63.0
       version: 0.63.0
     oxlint:
-      specifier: ^1.78.0
+      specifier: ^1.79.0
       version: 1.79.0
     oxlint-tsgolint:
       specifier: ^7.0.2001

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalog:
   motion: ^13.1.0
   nanoid: ^6.0.1
   oxfmt: ^0.63.0
-  oxlint: ^1.78.0
+  oxlint: ^1.79.0
   oxlint-tsgolint: ^7.0.2001
   react: ^19.2.8
   react-dom: ^19.2.8


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump the catalog `oxlint` range from `^1.78.0` to `^1.79.0` — the release that ships the [native React Compiler-powered rules](https://oxc.rs/blog/2026-08-18-react-compiler-support.html) (the lockfile already resolved 1.79.0, so this makes the floor explicit). `oxlint-tsgolint` is already at the latest `7.0.2001`, and there are no eslint plugins anywhere in the dependency tree.
- Enable **all** React Compiler rules in the root `oxlint.config.ts`: 12 rules arrive via the `correctness` category, and the 11 the plugin-kit preset force-disables (`capitalized-calls`, `exhaustive-effect-dependencies`, `hooks`, `invariant`, `memo-dependencies`, `no-deriving-state-in-effects`, `rule-suppression`, `syntax`, `todo`, `unsupported-syntax`, `void-use-memo`) are re-enabled at the repo level, since this monorepo builds plugins with React Compiler.
- Suppress the resulting 32 violations with `// oxlint-disable-next-line` comments, to be fixed in a follow-up: 18 × `react/todo` (mostly `try`/`finally` the compiler can't lower yet), 7 × `react/exhaustive-effect-dependencies`, 6 × `react/rule-suppression` (existing `react/exhaustive-deps` disables, which make the compiler bail), 1 × `react/hooks` (conditional `useFieldActions` call in assist).
- Update stale `AGENTS.md`/`CONTRIBUTING.md` mentions of the `react-hooks-js` plugin — compiler rules now run natively via the React Compiler vendored into oxlint.
- Changesets: `@sanity/plugin-kit` patch for the `oxlint` peer bump to `^1.79.0`, plus one combined patch changeset covering the 11 plugins that received suppression comments.

The plugin-kit preset itself is intentionally untouched in this revision: it keeps relying on category defaults, pending a decision on which React Compiler rules the preset should opt into for standalone consumers.

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — passes with all React Compiler rules enabled
- [x] `pnpm knip` — clean
- [x] `pnpm build` — 52/52 tasks
- [x] `pnpm test run` — 1283 tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bade974a-c0c0-4cec-8ef2-18f94a0ecaec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bade974a-c0c0-4cec-8ef2-18f94a0ecaec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

