### PR TITLE
docs: remove outdated Sanity Studio major version branding

### DIFF
--- a/.agents/skills/plugin-transfer/SKILL.md
+++ b/.agents/skills/plugin-transfer/SKILL.md
@@ -157,7 +157,7 @@ This major release includes several breaking changes as part of the migration to
 - **React Compiler enabled**: ...
 - **ESM-only**: CommonJS support has been removed. The package now ships only ESM
 - **React 19.2+ required**: ...
-- **Sanity Studio v5+ required**: ...
+- **Sanity peer dependency tightened**: Minimum `sanity` peer is now `^5 || ^6`
 - **Node.js 20.19+ required**: ...
 ```
 
@@ -165,7 +165,7 @@ Include additional bullets only when they apply to the plugin—for example:
 
 - **styled-components 6.1+ required** (UI plugins that use styled-components)
 - **react-dom 19.2+ required** (when newly added as a peer dependency)
-- **Dropped Sanity v3/v4 support** (when the previous peer range allowed older Studio versions)
+- **Dropped support for older Sanity majors** (when the previous peer range allowed older Studio versions)
 
 Example for `sanity-naive-html-serializer`:
 
@@ -185,7 +185,7 @@ This major release includes several breaking changes as part of the migration to
 - **ESM-only**: CommonJS support has been removed. The package now ships only ESM
 - **React 19.2+ required**: Minimum React version is now 19.2 (previously ^18.3 || ^19)
 - **react-dom 19.2+ required**: `react-dom` is now a required peer dependency
-- **Sanity Studio v5+ required**: Minimum Sanity version is now v5 (Sanity v3 and v4 are no longer supported)
+- **Sanity peer dependency tightened**: Minimum `sanity` peer is now `^5 || ^6` (older majors no longer supported)
 - **Node.js 20.19+ required**: Minimum Node.js version is now 20.19 (previously >=18)
 ```
 

--- a/.changeset/media-description.md
+++ b/.changeset/media-description.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Remove outdated Sanity Studio v3 wording from the package description

--- a/.changeset/plugin-kit-esm-message.md
+++ b/.changeset/plugin-kit-esm-message.md
@@ -1,0 +1,5 @@
+---
+"@sanity/plugin-kit": patch
+---
+
+Make the ESM-only verify message version-agnostic instead of naming a Studio major

--- a/.changeset/utils-description.md
+++ b/.changeset/utils-description.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-utils": patch
+---
+
+Remove outdated Sanity Studio v3 wording from the package description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,7 +324,7 @@ When moving a plugin to this monorepo the conventions enforced on the repo typic
 
 - enabling React Compiler
 - Dropping CJS
-- Requiring Sanity Studio v5 as the baseline
+- Aligning with the current Sanity Studio peer dependency baseline
 
 ```bash
 pnpm changeset add

--- a/packages/@sanity/plugin-kit/README.md
+++ b/packages/@sanity/plugin-kit/README.md
@@ -470,7 +470,7 @@ Provide a sanityPlugin config in package.json (defaults shown):
 ```
 
 Set `esmOnly` to `false` to allow CommonJS interop (a `require` export condition, or top-level
-`main`/`module` fields). This is discouraged: plugins target Sanity Studio v5+, which is pure ESM, and
+`main`/`module` fields). This is discouraged: plugins target Sanity Studio, which is pure ESM, and
 shipping a parallel CJS build can have unintended side-effects. The supported Node.js versions handle
 `require(esm)`, so a single published format keeps two copies of the plugin's code out of the module
 tree, avoiding bundle bloat and slower builds.

--- a/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
+++ b/packages/@sanity/plugin-kit/src/actions/verify/validations.ts
@@ -189,8 +189,8 @@ function formatExportsPath(segments: string[]): string {
 }
 
 /**
- * Bans CommonJS interop in package.json. The plugin baseline is Sanity Studio v5 or later, which is
- * pure ESM, so there is no reason to publish a parallel CJS build anymore. This flags:
+ * Bans CommonJS interop in package.json. The plugin baseline is Sanity Studio,
+ * which is pure ESM, so there is no reason to publish a parallel CJS build anymore. This flags:
  *
  * - `require` export conditions
  * - the top-level `main` field
@@ -218,7 +218,7 @@ export function validateEsmOnly(packageJson: PackageJson): string[] {
 
   return [
     outdent`
-      package.json ships CommonJS (CJS) output, but Sanity plugins target Sanity Studio v5+, which is pure ESM.
+      package.json ships CommonJS (CJS) output, but Sanity plugins target Sanity Studio, which is pure ESM.
 
       Remove the following so the package stays ESM-only:
       ${offenders.join('\n')}

--- a/packages/@sanity/plugin-kit/test/__snapshots__/verify-package.test.ts.snap
+++ b/packages/@sanity/plugin-kit/test/__snapshots__/verify-package.test.ts.snap
@@ -28,7 +28,7 @@ To skip this validation add the following to your package.json:
 }
 ----------------------------------------------------------
 [error] 
-package.json ships CommonJS (CJS) output, but Sanity plugins target Sanity Studio v5+, which is pure ESM.
+package.json ships CommonJS (CJS) output, but Sanity plugins target Sanity Studio, which is pure ESM.
 
 Remove the following so the package stays ESM-only:
 - the top-level "main" field ("./dist/index.cjs")

--- a/plugins/@sanity/cross-dataset-duplicator/README.md
+++ b/plugins/@sanity/cross-dataset-duplicator/README.md
@@ -31,13 +31,13 @@ This plugin is designed as a convenience for Authors to make small, infrequent c
 
 The **Duplicate** Tool allows you to migrate Documents that are returned from any GROQ query.
 
-![Cross Dataset Duplicator Tool in Sanity Studio v3](./img/cdd-tool.png)
+![Cross Dataset Duplicator Tool in Sanity Studio](./img/cdd-tool.png)
 
 ## Document Action
 
 The **Duplicate to...** Document Action allows you to migrate an individual Document.
 
-![Cross Dataset Duplicator Action in Sanity Studio v3](./img/cdd-action.png)
+![Cross Dataset Duplicator Action in Sanity Studio](./img/cdd-action.png)
 
 ## Required Setup
 

--- a/plugins/@sanity/document-internationalization/docs/00-upgrade-from-v1.md
+++ b/plugins/@sanity/document-internationalization/docs/00-upgrade-from-v1.md
@@ -2,23 +2,23 @@
 
 ## Where you are now:
 
-**I'm on Sanity Studio v3 and upgrading from plugin v1.0.0 and above**
+**I'm upgrading from plugin v1.0.0 and above**
 
 - You will need to perform a content migration to upgrade. See ["Upgrading from v1 to v2"](#upgrading-from-v1-to-v2)
 - Your queries will also need to change, as translation references have moved. See ["Upgrading from v1 to v2"](#upgrading-from-v1-to-v2) below for migration guidance, including query updates.
 
-**I'm on Sanity Studio v3 but will stay with the older plugin for now**
+**I will stay with the older plugin for now**
 
 - Please refer to the [v1 branch](https://github.com/sanity-io/document-internationalization/tree/v1)
 - Install from `v1.0.0` and above
 - This version of the plugin will not be updated with new features
 
-**I'm on Sanity Studio v2**
+**I'm on the legacy Studio v2 line**
 
 - Please refer to the [studio-v2 branch](https://github.com/sanity-io/document-internationalization/tree/studio-v2)
 - Install from `v0.0.0` and above
 - This version of the plugin will not be updated with new features
-- You will not need to perform a content migration to move to Sanity Studio v3, if you install the v1 plugin.
+- You will not need to perform a content migration when moving off Studio v2 if you install the v1 plugin.
 
 ### Upgrading from v1 to v2
 
@@ -32,7 +32,7 @@ We have provided migration scripts and guidance on this page. Please submit an i
 
 ### How v2 is different from v1
 
-A complete rewrite of the original Document Internationalization plugin, exclusively for Sanity Studio v3. Major **benefits** from the previous versions include:
+A complete rewrite of the original Document Internationalization plugin. Major **benefits** from the previous versions include:
 
 - Create new documents in any language and link translated references later
 - Translation references are written to a separate "meta" document

--- a/plugins/@sanity/language-filter/README.md
+++ b/plugins/@sanity/language-filter/README.md
@@ -121,7 +121,7 @@ languages: async (client) => {
 
 `@sanity/language-filter`'s asynchronous language loading does not currently support modifying the query based on a value in the current document.
 
-## Changes in V3
+## Schema options
 
 ### documentTypes
 

--- a/plugins/@sanity/orderable-document-list/README.md
+++ b/plugins/@sanity/orderable-document-list/README.md
@@ -185,9 +185,9 @@ To get this first version out the door there are few configuration settings and 
 
 Feedback and PRs welcome :)
 
-### Breaking change in the v3 version
+### Configuration note
 
-`orderableDocumentListDeskItem` requires context from sanity config now.
+`orderableDocumentListDeskItem` requires context from the Sanity config.
 See the examples above.
 
 ## How it works

--- a/plugins/@sanity/vercel-protection-bypass/README.md
+++ b/plugins/@sanity/vercel-protection-bypass/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/@sanity/vercel-protection-bypass.svg?style=flat-square)](https://www.npmjs.com/package/@sanity/vercel-protection-bypass)
 
 > [!IMPORTANT]  
-> This plugin requires React 19.2 or later, and Sanity Studio v4.
+> This plugin requires React 19.2 or later.
 
 ```sh
 npm install @sanity/vercel-protection-bypass

--- a/plugins/sanity-naive-html-serializer/README.md
+++ b/plugins/sanity-naive-html-serializer/README.md
@@ -6,7 +6,7 @@
 - [What this package does](#what-this-package-does)
 - [Quick start](#quick-start)
 - [Internationalized array formats](#internationalized-array-formats)
-- [v2-to-v3-changes](#v2-to-v3-changes)
+- [schema-access-changes](#schema-access-changes)
 
 ## What this package solves
 
@@ -53,11 +53,11 @@ When serializing and merging with the `internationalizedArray` translation level
 
 Serialized files are identical for both formats (items are identified by their language code), and `BaseDocumentMerger.internationalizedArrayMerge` writes patches in whichever format the target document already uses, preserving existing item keys when replacing.
 
-## v2-to-v3-changes
+## Schema access changes
 
 You likely will not need to make changes to your usage of this package. The biggest change to your codebase will be feeding in the schema to `BaseDocumentSerializer`. `BaseDocumentSerializer` should be the only affected interface.
 
-### In v2
+### Legacy Studio (`part:` imports)
 
 ```javascript
 import schemas from 'part:@sanity/base/schema'
@@ -66,7 +66,7 @@ const serializer = BaseDocumentSerializer(schemas)
 const serialized = serializer.serializeDocument(doc, 'document')
 ```
 
-### In v3
+### Current Studio
 
 If you're in a valid React context:
 

--- a/plugins/sanity-plugin-media/README.md
+++ b/plugins/sanity-plugin-media/README.md
@@ -1,7 +1,7 @@
-# Sanity Media (for Sanity Studio v3)
+# Sanity Media
 
-> This plugin is for **Sanity Studio v3**.  
-> The Sanity Studio v2 version of this plugin is no longer maintained, but still accessible on the [v2 branch](https://github.com/sanity-io/sanity-plugin-media/tree/studio-v2).
+> This plugin is maintained by Sanity.io.  
+> The legacy Studio v2 version is no longer maintained, but still accessible on the [v2 branch](https://github.com/sanity-io/sanity-plugin-media/tree/studio-v2).
 
 ## What is it?
 
@@ -46,7 +46,7 @@ _Individual asset view_
 - Built with the same [UI components Sanity uses](https://www.sanity.io/ui) under the hood
 - Fully responsive and mobile friendly
 
-## Install (Sanity Studio v3)
+## Install
 
 In your Sanity project folder:
 

--- a/plugins/sanity-plugin-media/package.json
+++ b/plugins/sanity-plugin-media/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-plugin-media",
   "version": "6.1.4",
-  "description": "This version of `sanity-plugin-media` is for Sanity Studio V3.",
+  "description": "Browse, manage and refine Sanity assets from within your Studio.",
   "keywords": [
     "asset",
     "browser",

--- a/plugins/sanity-plugin-studio-smartling/README.md
+++ b/plugins/sanity-plugin-studio-smartling/README.md
@@ -149,17 +149,17 @@ To personalize this configuration it's useful to know what arguments go into `Tr
 
 There are several reasons to override these functions. Generally, developers will customize to ensure documents serialize and deserialize correctly. Since the serialization functions are used across all our translation plugins currently, you can find some frequently encountered scenarios at [their repository here](https://github.com/sanity-io/sanity-naive-html-serializer), along with code examples for customized configurations.
 
-## Migrating to Sanity Studio v3
+## Migrating from environment variables
 
-There is one major breaking change in this plugin's migration to Sanity Studio v3: the proxy was set in an environment variable, and now it should be part of the `secrets` document.
+There is one major breaking change from earlier versions of this plugin: the proxy was set in an environment variable, and now it should be part of the `secrets` document.
 
-In v2, you would set the proxy in a `.env` file, like so:
+Previously, you would set the proxy in a `.env` file, like so:
 
 ```env
 SANITY_STUDIO_SMARTLING_PROXY=https://my-proxy-endpoint.com/api/proxy
 ```
 
-In v3, you should set the proxy in the `secrets` document. If you have an existing secrets document, you can patch it like so:
+You should now set the proxy in the `secrets` document. If you have an existing secrets document, you can patch it like so:
 
 ```javascript
 // ./patchSmartlingSecrets.js
@@ -176,13 +176,13 @@ and run the script with `sanity exec patchSmartlingSecrets.js --with-user-token`
 
 Alternatively, you can re-run the `populateSmartlingSecrets` script in [Quickstart](#quickstart) to create a new secrets document with the proxy set.
 
-We apologize for the inconvenience. Because of the new embeddability of the studio, developers may find that their v3 Studio is built and deployed in different ways, with access to different environments. Keeping this setting in `secrets` allows developers to set it in a way that works for their deployment and reduce complexity. You can find more information on our guidance around environment variables [here](https://github.com/sanity-io/sanity/releases/tag/v3.5.0).
+Because of the embeddability of the studio, developers may find that their Studio is built and deployed in different ways, with access to different environments. Keeping this setting in `secrets` allows developers to set it in a way that works for their deployment and reduce complexity. You can find more information on our guidance around environment variables [here](https://www.sanity.io/docs/studio/environment-variables).
 
-Otherwise, you should not have to do anything to migrate to Sanity Studio v3. If you are using the default configs, you should be able to upgrade without any changes. If you are using custom serialization, you may need to update how `BaseDocumentSerializer` receives your schema.
+If you are using the default configs, you should be able to upgrade without any other changes. If you are using custom serialization, you may need to update how `BaseDocumentSerializer` receives your schema.
 
-These are outlined in the serializer README [here](https://github.com/sanity-io/sanity-naive-html-serializer#v2-to-v3-changes).
+These are outlined in the serializer README [here](https://github.com/sanity-io/plugins/tree/main/plugins/sanity-naive-html-serializer#schema-access-changes).
 
-The final change from the v2 to v3 version of the plugin is in how progress in a translation job is calculated. The plugin will now count progress as the percentage of all strings that have reached the final stage of a Smartling workflow.
+The final change from earlier versions of the plugin is in how progress in a translation job is calculated. The plugin will now count progress as the percentage of all strings that have reached the final stage of a Smartling workflow.
 
 ## License
 

--- a/plugins/sanity-plugin-utils/package.json
+++ b/plugins/sanity-plugin-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-plugin-utils",
   "version": "2.0.15",
-  "description": "Handy hooks and clever components for Sanity Studio v3",
+  "description": "Handy hooks and clever components for Sanity Studio",
   "keywords": [
     "sanity",
     "sanity-plugin"

--- a/plugins/sanity-plugin-workflow/README.md
+++ b/plugins/sanity-plugin-workflow/README.md
@@ -93,9 +93,9 @@ With the document now Approved, a user may also return to the document and Publi
 
 Once the Workflow is complete, the metadata can be removed by using the "Complete Workflow" document action.
 
-### Differences from the Sanity Studio v2 Workflow Demo
+### Differences from the legacy Workflow Demo
 
-This plugin is largely based on the original Workflow Demo built into a Sanity Studio v2 project. The major differences are:
+This plugin is largely based on the original Workflow Demo built into a legacy Studio project. The major differences are:
 
 - This plugin is not concerned with nor will modify whether a document is in draft or published.
 - This plugin can be more easily installed and configured.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes consumer-facing “Sanity Studio v3” (and similar major-pinned) wording from READMEs, package descriptions, and agent guidance so docs stay version-agnostic as Studio majors advance.

## Changes

- Rewrote plugin READMEs / upgrade docs that branded the current line as “for Studio v3” or “migrating to Studio v3”
- Softened package descriptions for `sanity-plugin-media` and `sanity-plugin-utils`
- Made `@sanity/plugin-kit` ESM-only verify messaging version-agnostic
- Updated transfer-skill changeset examples to avoid pinning Studio majors in future ports
- Left historical `CHANGELOG.md` entries untouched
- Kept intentional legacy Studio v2 notes where they disambiguate old branches

## Testing

- Grep audit: no remaining Studio v3/v5+/v6 branding outside changelogs and agent “do not say this” guidance (only intentional legacy v2 notes remain)
- `@sanity/plugin-kit` `verify-package` Vitest suite passed (snapshot updated)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baea5a67-86d0-431c-b258-e51d88dd18af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baea5a67-86d0-431c-b258-e51d88dd18af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

