### PR TITLE
fix(code-input): pass missing readOnly prop down inside CodeMirrorProxy

### DIFF
--- a/.changeset/code-input-readonly-proxy.md
+++ b/.changeset/code-input-readonly-proxy.md
@@ -1,0 +1,5 @@
+---
+'@sanity/code-input': patch
+---
+
+Forward the `readOnly` prop from `CodeMirrorProxy` to `CodeMirror` so code fields stay non-editable when Studio marks them as read-only.

--- a/plugins/@sanity/code-input/src/codemirror/CodeMirrorProxy.tsx
+++ b/plugins/@sanity/code-input/src/codemirror/CodeMirrorProxy.tsx
@@ -111,6 +111,7 @@ function CodeMirrorProxy(props: CodeMirrorProps & {ref?: Ref<ReactCodeMirrorRef>
       onCreateEditor={handleCreateEditor}
       initialState={initialState}
       basicSetup={basicSetup}
+      readOnly={readOnly}
     />
   )
 }


### PR DESCRIPTION
### Description

`readOnly` is pulled out of props in CodeMirrorProxy so it can be passed into the `highlightLine` extension, so it was not in `codeMirrorProps` when it gets spread into `<CodeMirror>`. Without an explicit readOnly={readOnly} on `<CodeMirror>`, the editor stayed editable when the field was read-only (schema readOnly, document locked, preview, etc.).
[Issue resolved](https://app.plain.com/workspace/w_01HRQ35CNGKNZHKHA82NPVMAGA/thread/th_01M0CVMNF5C3BHEA8Y9MGCX37C?entryId=t_01M0CVTKMBAN1SMNP4JBJMJZD2-1)

### What to review

Check plugins/@sanity/code-input/src/codemirror/CodeMirrorProxy.tsx: readOnly is destructured, used in highlightLine, and now also forwarded to CodeMirror. Confirm nothing else pulled out of props is missing on the same component (value is already passed explicitly).

In Studio, open a code field and confirm:

- Editable documents: typing still works.
- readOnly on the field, a locked document, or the code preview: the editor does not accept edits; highlight-line behaviour is unchanged.

### Testing

No automated test was added. Verified by passing readOnly through after it was omitted from the spread, and by checking the other explicit props on <CodeMirror>. Manual Studio check of a read-only vs editable was confirmed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-prop wiring fix in the code-input plugin with no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes code fields staying editable** when Studio marks them read-only (schema `readOnly`, locked documents, preview, etc.).
> 
> `CodeMirrorProxy` already destructures `readOnly` for the `highlightLine` extension, so it was excluded from the spread onto `<CodeMirror>`. The proxy now passes **`readOnly={readOnly}`** explicitly, matching how `value` and other props are forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238534b36edf46163063c59b943e89572398ce80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->