### PR TITLE
fix: unbreak pnpm lint after tsdown-config 0.26

### DIFF
--- a/.agents/skills/migrate-styled-components-to-vanilla-extract/SKILL.md
+++ b/.agents/skills/migrate-styled-components-to-vanilla-extract/SKILL.md
@@ -162,7 +162,7 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>
 ```
 
 The integration extracts all `.css.ts` rules into `dist/bundle.css` at build time, auto-imports it

--- a/.agents/skills/sanity-plugin-best-practices/references/styling.md
+++ b/.agents/skills/sanity-plugin-best-practices/references/styling.md
@@ -175,7 +175,7 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>
 ```
 
 This also wires up the `./bundle.css` export in `package.json` automatically, keeping it in sync on

--- a/.changeset/orderable-document-list-status-indicator.md
+++ b/.changeset/orderable-document-list-status-indicator.md
@@ -1,0 +1,5 @@
+---
+"@sanity/orderable-document-list": patch
+---
+
+Use `DocumentVersionsStatusIndicator` instead of the deprecated `DocumentStatusIndicator`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -543,6 +543,10 @@ Declarations are generated with tsgo (tsdown enables dts generation automaticall
 
 Run `pnpm build` first—some packages need to be built for type information to be available.
 
+### `tsdown.config.ts`: `Promise<UserConfig[]>` does not satisfy `Promise<UserConfig>`
+
+`@sanity/tsdown-config` overloads `defineConfig` so `reactCompiler.reactServer: true` returns `Promise<UserConfig[]>` (dual client / `react-server` builds) and every other call returns `Promise<UserConfig>`. Annotate plugin configs with `satisfies Promise<UserConfig | UserConfig[]>` so both overloads type-check — do not use `satisfies Promise<UserConfig>` alone. The generator template already uses the union.
+
 ### "Command not found: pnpm"
 
 Ensure you have pnpm v11+ installed, then run:

--- a/plugins/@sanity/assist/tsdown.config.ts
+++ b/plugins/@sanity/assist/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/block-insert-picker/tsdown.config.ts
+++ b/plugins/@sanity/block-insert-picker/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/code-input/tsdown.config.ts
+++ b/plugins/@sanity/code-input/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/color-input/tsdown.config.ts
+++ b/plugins/@sanity/color-input/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/cross-dataset-duplicator/tsdown.config.ts
+++ b/plugins/@sanity/cross-dataset-duplicator/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/dashboard/tsdown.config.ts
+++ b/plugins/@sanity/dashboard/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
+++ b/plugins/@sanity/debug-live-sync-tags/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/debug-preview-url-secret-plugin/tsdown.config.ts
+++ b/plugins/@sanity/debug-preview-url-secret-plugin/tsdown.config.ts
@@ -1,4 +1,4 @@
 import {defineConfig} from '@sanity/tsdown-config'
 import type {UserConfig} from 'tsdown'
 
-export default defineConfig() satisfies Promise<UserConfig>
+export default defineConfig() satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/document-internationalization/tsdown.config.ts
+++ b/plugins/@sanity/document-internationalization/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/embeddings-index-ui/tsdown.config.ts
+++ b/plugins/@sanity/embeddings-index-ui/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/form-toolkit/tsdown.config.ts
+++ b/plugins/@sanity/form-toolkit/tsdown.config.ts
@@ -10,4 +10,4 @@ export default defineConfig({
     './src/form-renderer/index.ts',
   ],
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/google-maps-input/tsdown.config.ts
+++ b/plugins/@sanity/google-maps-input/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/hierarchical-document-list/tsdown.config.ts
+++ b/plugins/@sanity/hierarchical-document-list/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/language-filter/tsdown.config.ts
+++ b/plugins/@sanity/language-filter/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -8,9 +8,11 @@ import {
   useSchema,
   PreviewCard,
   Preview,
-  DocumentStatusIndicator,
+  DocumentVersionsStatusIndicator,
   DocumentStatus,
   useDocumentVersionInfo,
+  useDocumentVersions,
+  getPublishedId,
 } from 'sanity'
 import {usePaneRouter} from 'sanity/structure'
 
@@ -44,8 +46,9 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util
+  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util for the DocumentStatus tooltip
   const versionsInfo = useDocumentVersionInfo(doc._id)
+  const {versions} = useDocumentVersions({documentId: getPublishedId(doc._id)})
 
   const {ChildLink, groupIndex, routerPanesState} = router
 
@@ -112,11 +115,7 @@ export function Document({
 
             <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
               <Flex align="center" style={{flexShrink: 0}}>
-                <DocumentStatusIndicator
-                  draft={versionsInfo.draft}
-                  published={versionsInfo.published}
-                  versions={versionsInfo.versions}
-                />
+                <DocumentVersionsStatusIndicator documentVersions={versions} />
               </Flex>
             </Tooltip>
           </Flex>

--- a/plugins/@sanity/orderable-document-list/tsdown.config.ts
+++ b/plugins/@sanity/orderable-document-list/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/personalization-plugin/tsdown.config.ts
+++ b/plugins/@sanity/personalization-plugin/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   entry: ['./src/index.ts', './src/launchDarkly/index.ts', './src/growthbook/index.ts'],
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/presets/tsdown.config.ts
+++ b/plugins/@sanity/presets/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/rich-date-input/tsdown.config.ts
+++ b/plugins/@sanity/rich-date-input/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/sanity-plugin-async-list/tsdown.config.ts
+++ b/plugins/@sanity/sanity-plugin-async-list/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/sfcc/tsdown.config.ts
+++ b/plugins/@sanity/sfcc/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/studio-secrets/tsdown.config.ts
+++ b/plugins/@sanity/studio-secrets/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/table/tsdown.config.ts
+++ b/plugins/@sanity/table/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/@sanity/vercel-protection-bypass/tsdown.config.ts
+++ b/plugins/@sanity/vercel-protection-bypass/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-naive-html-serializer/tsdown.config.ts
+++ b/plugins/sanity-naive-html-serializer/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-aprimo/tsdown.config.ts
+++ b/plugins/sanity-plugin-aprimo/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-asset-source-unsplash/tsdown.config.ts
+++ b/plugins/sanity-plugin-asset-source-unsplash/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-bynder-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-bynder-input/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-cloudinary/tsdown.config.ts
+++ b/plugins/sanity-plugin-cloudinary/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-dashboard-widget-document-list/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-document-list/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-dashboard-widget-netlify/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-netlify/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-dashboard-widget-vercel/tsdown.config.ts
+++ b/plugins/sanity-plugin-dashboard-widget-vercel/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-documents-pane/tsdown.config.ts
+++ b/plugins/sanity-plugin-documents-pane/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-google-translate/tsdown.config.ts
+++ b/plugins/sanity-plugin-google-translate/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-graph-view/tsdown.config.ts
+++ b/plugins/sanity-plugin-graph-view/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-hotspot-array/tsdown.config.ts
+++ b/plugins/sanity-plugin-hotspot-array/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-iframe-pane/tsdown.config.ts
+++ b/plugins/sanity-plugin-iframe-pane/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-internationalized-array/tsdown.config.ts
+++ b/plugins/sanity-plugin-internationalized-array/tsdown.config.ts
@@ -7,4 +7,4 @@ export default defineConfig({
     'migrations/index': './migrations/index.ts',
   },
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-latex-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-latex-input/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-markdown/tsdown.config.ts
+++ b/plugins/sanity-plugin-markdown/tsdown.config.ts
@@ -8,4 +8,4 @@ export default defineConfig({
   },
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-media/tsdown.config.ts
+++ b/plugins/sanity-plugin-media/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-mux-input/tsdown.config.ts
+++ b/plugins/sanity-plugin-mux-input/tsdown.config.ts
@@ -8,4 +8,4 @@ export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
   define: {__PKG_VERSION__: JSON.stringify(pkg.version)},
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-shopify-assets/tsdown.config.ts
+++ b/plugins/sanity-plugin-shopify-assets/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-studio-smartling/tsdown.config.ts
+++ b/plugins/sanity-plugin-studio-smartling/tsdown.config.ts
@@ -3,4 +3,4 @@ import type {UserConfig} from 'tsdown'
 
 export default defineConfig({
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-transifex/tsdown.config.ts
+++ b/plugins/sanity-plugin-transifex/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-utils/tsdown.config.ts
+++ b/plugins/sanity-plugin-utils/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-workflow/tsdown.config.ts
+++ b/plugins/sanity-plugin-workflow/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   reactCompiler: true,
   vanillaExtract: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-plugin-workspace-home/tsdown.config.ts
+++ b/plugins/sanity-plugin-workspace-home/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/plugins/sanity-translations-tab/tsdown.config.ts
+++ b/plugins/sanity-translations-tab/tsdown.config.ts
@@ -4,4 +4,4 @@ import type {UserConfig} from 'tsdown'
 export default defineConfig({
   styledComponents: true,
   reactCompiler: true,
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>

--- a/turbo/generators/templates/tsdown.config.ts.hbs
+++ b/turbo/generators/templates/tsdown.config.ts.hbs
@@ -9,4 +9,4 @@ export default defineConfig({
 {{#if hasVanillaExtract}}
   vanillaExtract: true,
 {{/if}}
-}) satisfies Promise<UserConfig>
+}) satisfies Promise<UserConfig | UserConfig[]>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`pnpm lint` is failing on `main` after `@sanity/tsdown-config@0.26.0` and the Sanity deprecation cleanup landed.

**Cause**
1. `defineConfig` is now overloaded: `reactCompiler.reactServer: true` returns `Promise<UserConfig[]>`, everything else returns `Promise<UserConfig>`. Plugin configs used `satisfies Promise<UserConfig>`, so oxlint type-checking failed on every `reactCompiler: true` config.
2. `DocumentStatusIndicator` is deprecated; `@sanity/orderable-document-list` still used it.

**Fix**
- Annotate plugin `tsdown.config.ts` files (and the generator template) with `satisfies Promise<UserConfig | UserConfig[]>`.
- Switch orderable-document-list to `DocumentVersionsStatusIndicator` + `useDocumentVersions`.
- Document the satisfies union in `AGENTS.md`.

No lockfile changes — this was a type annotation + deprecation migration, not a duplicate-package issue.

**Verification**
- `pnpm lint` passes locally (0 errors).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95a10bad-8be3-4ced-804c-4391b070a7b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95a10bad-8be3-4ced-804c-4391b070a7b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

