### PR TITLE
fix: skip internationalized-array auto-patches while the document is read-only

### DIFF
--- a/.changeset/internationalized-array-readonly-initial-values.md
+++ b/.changeset/internationalized-array-readonly-initial-values.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Wait until the document is writable before auto-adding default languages, so creating a document no longer toasts "Attempted to patch a read-only document" while initial value templates are still resolving

--- a/.changeset/orderable-document-list-versions-status.md
+++ b/.changeset/orderable-document-list-versions-status.md
@@ -1,0 +1,5 @@
+---
+"@sanity/orderable-document-list": patch
+---
+
+Use `DocumentVersionsStatus` instead of the deprecated `DocumentStatus` for the list-item tooltip

--- a/.changeset/orderable-document-list-versions-status.md
+++ b/.changeset/orderable-document-list-versions-status.md
@@ -1,5 +1,0 @@
----
-"@sanity/orderable-document-list": patch
----
-
-Use `DocumentVersionsStatus` instead of the deprecated `DocumentStatus` for the list-item tooltip

--- a/dev/e2e-studio/src/internationalizedArray.ts
+++ b/dev/e2e-studio/src/internationalizedArray.ts
@@ -26,6 +26,32 @@ const i18nPostType = defineType({
 export const internationalizedArrayExample = definePlugin(() => ({
   schema: {
     types: [i18nPostType],
+    templates: (prev) => [
+      ...prev,
+      {
+        id: 'i18nPost-out-of-order',
+        title: 'I18n Post (out of order languages)',
+        schemaType: 'i18nPost',
+        // FR before EN so restoreOrder must patch on create — that is the
+        // SAPP-2921 race against Studio's initial-value read-only lock.
+        value: {
+          title: [
+            {
+              _key: 'title-fr',
+              _type: 'internationalizedArrayStringValue',
+              language: 'fr',
+              value: 'Bonjour',
+            },
+            {
+              _key: 'title-en',
+              _type: 'internationalizedArrayStringValue',
+              language: 'en',
+              value: 'Hello',
+            },
+          ],
+        },
+      },
+    ],
   },
   plugins: [
     internationalizedArray({

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -122,6 +122,21 @@ test.describe('sanity-plugin-internationalized-array', () => {
     }
   })
 
+  /**
+   * Repro for SAPP-2921: creating a document with `defaultLanguages` must not
+   * toast "Attempted to patch a read-only document" while initial value
+   * templates are still resolving.
+   */
+  test('creating a document does not toast a read-only patch error', async ({page}) => {
+    await page.goto('intent/create/template=i18nPost;type=i18nPost')
+    await expect(page.getByTestId('studio-navbar')).toBeVisible()
+    const form = page.getByTestId('form-view').first()
+    await expect(form).toBeVisible()
+    // Wait until Studio has dropped the initial-value read-only lock.
+    await expect(form).not.toHaveAttribute('data-read-only', 'true')
+    await expect(page.getByText('Attempted to patch a read-only document')).toHaveCount(0)
+  })
+
   test('language filter hides non-selected array items', async ({page}, testInfo) => {
     const projectName = testInfo.project.name
     const doc = await seedI18nPost(projectName, {

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -123,18 +123,38 @@ test.describe('sanity-plugin-internationalized-array', () => {
   })
 
   /**
-   * Repro for SAPP-2921: creating a document with `defaultLanguages` must not
-   * toast "Attempted to patch a read-only document" while initial value
-   * templates are still resolving.
+   * Repro for SAPP-2921: the `i18nPost-out-of-order` template seeds FR before
+   * EN, so `restoreOrder` must auto-patch while the new document may still
+   * hold Studio's initial-value read-only lock. A patch during the lock
+   * toasts "Attempted to patch a read-only document" and leaves the array
+   * out of order.
    */
-  test('creating a document does not toast a read-only patch error', async ({page}) => {
-    await page.goto('intent/create/template=i18nPost;type=i18nPost')
+  test('creating a document does not toast a read-only patch error', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    await page.goto('intent/create/template=i18nPost-out-of-order;type=i18nPost')
     await expect(page.getByTestId('studio-navbar')).toBeVisible()
     const form = page.getByTestId('form-view').first()
     await expect(form).toBeVisible()
-    // Wait until Studio has dropped the initial-value read-only lock.
-    await expect(form).not.toHaveAttribute('data-read-only', 'true')
-    await expect(page.getByText('Attempted to patch a read-only document')).toHaveCount(0)
+
+    try {
+      await expect(languageLabel(page, 'en')).toBeVisible()
+      await expect(languageLabel(page, 'fr')).toBeVisible()
+      // Deferred restoreOrder re-sorts FR, EN → EN, FR once the document is writable.
+      const codeLabels = page
+        .getByTestId('field-title')
+        .locator('[data-ui="Label"]')
+        .filter({hasText: /^(EN|FR)$/})
+      await expect(codeLabels.first()).toHaveText('EN')
+      // That patch persists the draft (`_rev`), so defaultLanguages can seed
+      // EN on the untouched summary field.
+      await expect(languageLabel(page, 'en', 'summary')).toBeVisible()
+      await expect(page.getByText('Attempted to patch a read-only document')).toHaveCount(0)
+    } finally {
+      const docId = /(?:id=|i18nPost;)([\w-]+)/.exec(decodeURIComponent(page.url()))?.[1]
+      if (docId && docId !== 'i18nPost' && docId !== 'i18nPost-out-of-order') {
+        await deleteI18nPost(projectName, docId)
+      }
+    }
   })
 
   test('language filter hides non-selected array items', async ({page}, testInfo) => {

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -150,10 +150,12 @@ test.describe('sanity-plugin-internationalized-array', () => {
       await expect(languageLabel(page, 'en', 'summary')).toBeVisible()
       await expect(page.getByText('Attempted to patch a read-only document')).toHaveCount(0)
     } finally {
-      const docId = /(?:id=|i18nPost;)([\w-]+)/.exec(decodeURIComponent(page.url()))?.[1]
-      if (docId && docId !== 'i18nPost' && docId !== 'i18nPost-out-of-order') {
-        await deleteI18nPost(projectName, docId)
-      }
+      // Studio may put a published id or `drafts.<id>` in the URL; a UUID match
+      // ignores the prefix and avoids capturing template/type names.
+      const docId = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.exec(
+        decodeURIComponent(page.url()),
+      )?.[0]
+      if (docId) await deleteI18nPost(projectName, docId)
     }
   })
 

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -8,8 +8,9 @@ import {
   useSchema,
   PreviewCard,
   Preview,
-  DocumentVersionsStatus,
   DocumentVersionsStatusIndicator,
+  DocumentStatus,
+  useDocumentVersionInfo,
   useDocumentVersions,
   getPublishedId,
 } from 'sanity'
@@ -45,8 +46,9 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  const publishedId = getPublishedId(doc._id)
-  const {versions} = useDocumentVersions({documentId: publishedId})
+  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util for the DocumentStatus tooltip
+  const versionsInfo = useDocumentVersionInfo(doc._id)
+  const {versions} = useDocumentVersions({documentId: getPublishedId(doc._id)})
 
   const {ChildLink, groupIndex, routerPanesState} = router
 
@@ -59,7 +61,14 @@ export function Document({
     return null
   }
 
-  const tooltip = <DocumentVersionsStatus documentGroupId={publishedId} />
+  const tooltip = (
+    // oxlint-disable-next-line typescript/no-deprecated -- DocumentVersionsStatus takes documentGroupId; this tooltip still uses draft/published/versions from useDocumentVersionInfo
+    <DocumentStatus
+      draft={versionsInfo.draft}
+      published={versionsInfo.published}
+      versions={versionsInfo.versions}
+    />
+  )
 
   return (
     <PreviewCard

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -8,9 +8,8 @@ import {
   useSchema,
   PreviewCard,
   Preview,
+  DocumentVersionsStatus,
   DocumentVersionsStatusIndicator,
-  DocumentStatus,
-  useDocumentVersionInfo,
   useDocumentVersions,
   getPublishedId,
 } from 'sanity'
@@ -46,9 +45,8 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util for the DocumentStatus tooltip
-  const versionsInfo = useDocumentVersionInfo(doc._id)
-  const {versions} = useDocumentVersions({documentId: getPublishedId(doc._id)})
+  const publishedId = getPublishedId(doc._id)
+  const {versions} = useDocumentVersions({documentId: publishedId})
 
   const {ChildLink, groupIndex, routerPanesState} = router
 
@@ -61,13 +59,7 @@ export function Document({
     return null
   }
 
-  const tooltip = (
-    <DocumentStatus
-      draft={versionsInfo.draft}
-      published={versionsInfo.published}
-      versions={versionsInfo.versions}
-    />
-  )
+  const tooltip = <DocumentVersionsStatus documentGroupId={publishedId} />
 
   return (
     <PreviewCard

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -1,4 +1,4 @@
-import {cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 import {LANGUAGE_FIELD_NAME} from '../constants'
@@ -113,6 +113,7 @@ describe('InternationalizedArray', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -608,6 +609,7 @@ describe('InternationalizedArray', () => {
   })
 
   test('auto-adds default languages after initial value templates resolve', async () => {
+    vi.useFakeTimers()
     vi.mocked(useInternationalizedArrayContext).mockReturnValue({
       ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
       defaultLanguages: ['en'],
@@ -615,34 +617,36 @@ describe('InternationalizedArray', () => {
 
     const onChange = vi.fn()
     const props = createMockArrayProps({onChange, readOnly: false})
+    mockGetFormValue.mockImplementation(() => props.value)
 
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleting: false,
-      isDeleted: false,
-      isInitialValueLoading: true,
-    } as ReturnType<typeof useDocumentPane>)
+    let loading = true
+    vi.mocked(useDocumentPane).mockImplementation(() => {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test pane stub
+      return {
+        isDeleting: false,
+        isDeleted: false,
+        isInitialValueLoading: loading,
+      } as unknown as ReturnType<typeof useDocumentPane>
+    })
 
-    const {unmount} = renderInternationalizedArray(props)
+    const {rerender} = renderInternationalizedArray(props)
 
-    await new Promise((resolve) => setTimeout(resolve, 10))
+    act(() => {
+      vi.runAllTimers()
+    })
     expect(onChange).not.toHaveBeenCalled()
 
-    unmount()
+    // Same mounted instance: the document pane flips loading in place.
+    loading = false
+    rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...props} />,
+    )
 
-    vi.mocked(useFormValue).mockImplementation(() => 'article')
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleting: false,
-      isDeleted: false,
-      isInitialValueLoading: false,
-    } as ReturnType<typeof useDocumentPane>)
-
-    renderInternationalizedArray(props)
-
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalled()
+    act(() => {
+      vi.runAllTimers()
     })
+    expect(onChange).toHaveBeenCalled()
   })
 
   test('does not auto-reorder while initial value templates are loading', () => {

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -102,6 +102,13 @@ describe('InternationalizedArray', () => {
   beforeEach(() => {
     mockToastPush.mockClear()
     mockGetFormValue.mockReset()
+    vi.mocked(useFormValue).mockImplementation(() => 'article')
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: false,
+    } as unknown as ReturnType<typeof useDocumentPane>)
   })
 
   afterEach(() => {
@@ -601,13 +608,6 @@ describe('InternationalizedArray', () => {
   })
 
   test('auto-adds default languages after initial value templates resolve', async () => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleting: false,
-      isDeleted: false,
-      isInitialValueLoading: true,
-    } as ReturnType<typeof useDocumentPane>)
-
     vi.mocked(useInternationalizedArrayContext).mockReturnValue({
       ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
       defaultLanguages: ['en'],
@@ -616,11 +616,21 @@ describe('InternationalizedArray', () => {
     const onChange = vi.fn()
     const props = createMockArrayProps({onChange, readOnly: false})
 
-    const {rerender} = renderInternationalizedArray(props)
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: true,
+    } as ReturnType<typeof useDocumentPane>)
+
+    const {unmount} = renderInternationalizedArray(props)
 
     await new Promise((resolve) => setTimeout(resolve, 10))
     expect(onChange).not.toHaveBeenCalled()
 
+    unmount()
+
+    vi.mocked(useFormValue).mockImplementation(() => 'article')
     // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
     vi.mocked(useDocumentPane).mockReturnValue({
       isDeleting: false,
@@ -628,10 +638,7 @@ describe('InternationalizedArray', () => {
       isInitialValueLoading: false,
     } as ReturnType<typeof useDocumentPane>)
 
-    rerender(
-      // @ts-expect-error - simplified mock props
-      <InternationalizedArray {...props} />,
-    )
+    renderInternationalizedArray(props)
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalled()

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -551,6 +551,114 @@ describe('InternationalizedArray', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  test('does not auto-add default languages while initial value templates are loading', async () => {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: true,
+    } as ReturnType<typeof useDocumentPane>)
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange, readOnly: false})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add when the field is editable but the document form is readOnly', async () => {
+    // The v3.82 race: field `readOnly` is still false while the patch channel
+    // rejects writes because initial values (or another document-level lock)
+    // have not resolved.
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      formState: {readOnly: true},
+    } as ReturnType<typeof useDocumentPane>)
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange, readOnly: false})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('auto-adds default languages after initial value templates resolve', async () => {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: true,
+    } as ReturnType<typeof useDocumentPane>)
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange, readOnly: false})
+
+    const {rerender} = renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onChange).not.toHaveBeenCalled()
+
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: false,
+    } as ReturnType<typeof useDocumentPane>)
+
+    rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...props} />,
+    )
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled()
+    })
+  })
+
+  test('does not auto-reorder while initial value templates are loading', () => {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    vi.mocked(useDocumentPane).mockReturnValue({
+      isDeleting: false,
+      isDeleted: false,
+      isInitialValueLoading: true,
+    } as ReturnType<typeof useDocumentPane>)
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue(
+      MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+    )
+
+    const onChange = vi.fn()
+    const value = createValues(['fr', 'en'])
+    const props = createMockArrayProps({onChange, value, readOnly: false})
+
+    renderInternationalizedArray(props)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   test('hides "Add all languages" button when buttonAddAll is false', () => {
     vi.mocked(useInternationalizedArrayContext).mockReturnValue({
       ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -206,7 +206,7 @@ export default function InternationalizedArray(
         .filter((language) => languages.find((l) => l.id === language))
       // Account for strict mode by scheduling the update.
       const timeout = setTimeout(() => {
-        handleAddLanguages(languagesToAdd)
+        if (!readOnly) handleAddLanguages(languagesToAdd)
       })
       return () => clearTimeout(timeout)
     }

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useMemo, useRef} from 'react'
+import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -142,8 +142,13 @@ export default function InternationalizedArray(
     schemaType.readOnly === true ||
     Boolean(formState?.readOnly) ||
     Boolean(isInitialValueLoading)
+  // Sync in useLayoutEffect so auto-patch timeouts (scheduled in useEffect)
+  // see the committed lock before paint. Writing the ref during render is
+  // forbidden by React Compiler (`react(refs)`).
   const readOnlyRef = useRef(readOnly)
-  readOnlyRef.current = readOnly
+  useLayoutEffect(() => {
+    readOnlyRef.current = readOnly
+  })
 
   const handleAddLanguages = useCallback(
     (addLanguageKeys: string[] | string) => {

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
+import {useCallback, useEffect, useMemo} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -142,17 +142,10 @@ export default function InternationalizedArray(
     schemaType.readOnly === true ||
     Boolean(formState?.readOnly) ||
     Boolean(isInitialValueLoading)
-  // Sync in useLayoutEffect so auto-patch timeouts (scheduled in useEffect)
-  // see the committed lock before paint. Writing the ref during render is
-  // forbidden by React Compiler (`react(refs)`).
-  const readOnlyRef = useRef(readOnly)
-  useLayoutEffect(() => {
-    readOnlyRef.current = readOnly
-  })
 
   const handleAddLanguages = useCallback(
     (addLanguageKeys: string[] | string) => {
-      if (readOnlyRef.current) {
+      if (readOnly) {
         return
       }
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion
@@ -171,7 +164,7 @@ export default function InternationalizedArray(
 
       onChange([setIfMissing([]), ...patches])
     },
-    [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path],
+    [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path, readOnly],
   )
 
   // The document only has a revision once it exists in the dataset. Patching
@@ -211,10 +204,9 @@ export default function InternationalizedArray(
       const languagesToAdd = defaultLanguages
         .filter((language) => !addedLanguages.includes(language))
         .filter((language) => languages.find((l) => l.id === language))
-      // Account for strict mode by scheduling the update. Re-check the ref
-      // so a document that became read-only between schedule and fire is skipped.
+      // Account for strict mode by scheduling the update.
       const timeout = setTimeout(() => {
-        if (!readOnlyRef.current) handleAddLanguages(languagesToAdd)
+        handleAddLanguages(languagesToAdd)
       })
       return () => clearTimeout(timeout)
     }
@@ -233,7 +225,7 @@ export default function InternationalizedArray(
 
   // NOTE: This is reordering and re-setting the whole array, it could be surgical
   const handleRestoreOrder = useCallback(() => {
-    if (readOnlyRef.current || !value?.length || !languages?.length) {
+    if (readOnly || !value?.length || !languages?.length) {
       return
     }
 
@@ -259,7 +251,7 @@ export default function InternationalizedArray(
     }
 
     onChange(set(updatedValue))
-  }, [toast, languages, onChange, value])
+  }, [toast, languages, onChange, value, readOnly])
 
   const allKeysAreLanguages = useMemo(() => {
     if (!value?.length || !languages?.length) {

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useMemo} from 'react'
+import {useCallback, useEffect, useMemo, useRef} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -40,9 +40,13 @@ import {MigrationBanner} from './MigrationBanner'
  *   `buttonLocations` config). Dispatches `setIfMissing` + `insert` patches.
  * - **Default languages**: Automatically adds entries for languages listed in
  *   `defaultLanguages` when those entries are missing. Only runs once the
- *   document exists in the dataset (it has a `_rev`), so the effect never
- *   recreates a just-deleted document or creates a draft before the user's
- *   first edit.
+ *   document exists in the dataset (it has a `_rev`) **and** the document is
+ *   writable — newly created documents stay read-only until initial value
+ *   templates resolve, and the field-level `readOnly` prop can lag that
+ *   document-level lock. Skipping the patch until both are ready avoids
+ *   "Attempted to patch a read-only document" toasts. The `_rev` guard also
+ *   prevents recreating a just-deleted document or creating a draft before
+ *   the user's first edit.
  * - **Ordering**: When `restoreOrder` is enabled (default), detects when value
  *   items are out of order relative to the master `languages` list and
  *   automatically re-sorts them. Set `restoreOrder: false` to keep the stored
@@ -60,7 +64,6 @@ export default function InternationalizedArray(
   const value = _value as InternationalizedArrayItem[]
   const itemsNeedingMigration = value?.filter((v) => !v[LANGUAGE_FIELD_NAME]) ?? []
   const shouldMigrateArray = itemsNeedingMigration.length > 0
-  const readOnly = Boolean(documentReadOnly) || schemaType.readOnly === true
   const toast = useToast()
 
   const getFormValue = useGetFormValue()
@@ -129,8 +132,24 @@ export default function InternationalizedArray(
     ],
   )
 
+  const {isDeleted, isDeleting, isInitialValueLoading, formState} = useDocumentPane()
+
+  // Document-level locks (initial-value templates, permissions, history) are
+  // not always reflected on the field's `readOnly` prop in the same tick as
+  // the patch channel. Gating on both prevents toasts from auto-patches.
+  const readOnly =
+    Boolean(documentReadOnly) ||
+    schemaType.readOnly === true ||
+    Boolean(formState?.readOnly) ||
+    Boolean(isInitialValueLoading)
+  const readOnlyRef = useRef(readOnly)
+  readOnlyRef.current = readOnly
+
   const handleAddLanguages = useCallback(
     (addLanguageKeys: string[] | string) => {
+      if (readOnlyRef.current) {
+        return
+      }
       // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       const formValue = getFormValue(props.path) as InternationalizedArrayItem[]
       if (!filteredLanguages?.length) {
@@ -149,8 +168,6 @@ export default function InternationalizedArray(
     },
     [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path],
   )
-
-  const {isDeleted, isDeleting} = useDocumentPane()
 
   // The document only has a revision once it exists in the dataset. Patching
   // a nonexistent document would create it: auto-adding default languages to
@@ -183,14 +200,16 @@ export default function InternationalizedArray(
       !isDeleting &&
       !isDeleted &&
       !hasAddedDefaultLanguages &&
-      !shouldMigrateArray
+      !shouldMigrateArray &&
+      !readOnly
     ) {
       const languagesToAdd = defaultLanguages
         .filter((language) => !addedLanguages.includes(language))
         .filter((language) => languages.find((l) => l.id === language))
-      // Account for strict mode by scheduling the update
+      // Account for strict mode by scheduling the update. Re-check the ref
+      // so a document that became read-only between schedule and fire is skipped.
       const timeout = setTimeout(() => {
-        if (!readOnly) handleAddLanguages(languagesToAdd)
+        if (!readOnlyRef.current) handleAddLanguages(languagesToAdd)
       })
       return () => clearTimeout(timeout)
     }
@@ -209,7 +228,7 @@ export default function InternationalizedArray(
 
   // NOTE: This is reordering and re-setting the whole array, it could be surgical
   const handleRestoreOrder = useCallback(() => {
-    if (!value?.length || !languages?.length) {
+    if (readOnlyRef.current || !value?.length || !languages?.length) {
       return
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SAPP-2921](https://linear.app/sanity/issue/SAPP-2921/sanity-plugin-internationalized-array-errors-starting-in-v382).

## Description

Starting in Studio v3.82, newly created documents stay read-only until initial value templates resolve. `sanity-plugin-internationalized-array` auto-patches `defaultLanguages` (and can restore language order) via `onChange`. If that patch runs while the document-level patch channel is still locked, Studio toasts **"Attempted to patch a read-only document"**.

The field's `readOnly` prop does not always match that lock in the same tick. This change waits on document-level signals from `useDocumentPane()` (`formState.readOnly` and `isInitialValueLoading`) before auto-patching. Auto-patch handlers close over that `readOnly` flag; the effects already depend on it, so a lock change cancels any scheduled timeout.

The existing `_rev` guard is unchanged: default languages are still only auto-added after the document exists in the dataset (after the user's first edit on a new document). This PR only stops the toast when a patch would otherwise race a temporary read-only window.

## What to review

- `InternationalizedArray` treats the document as read-only when **any** of: field `readOnly`, schema `readOnly`, `formState.readOnly`, or `isInitialValueLoading`.
- Auto-add and restore-order both close over that `readOnly` value.
- Unit tests cover the in-place loading → writable transition on the same mounted instance.
- E2E: create from `i18nPost-out-of-order` (FR before EN) so `restoreOrder` actually races the lock; assert sort order, default-language seeding, and no read-only toast.

## Testing

- [x] Unit tests for the initial-value / form-readOnly race, including in-place unlock
- [x] `pnpm format` / scoped oxlint on the edited files / plugin Vitest for internationalized-array
- [x] E2E create-flow (`i18nPost-out-of-order`) — chromium and firefox passed on CI

## Notes for release

Consumers with `defaultLanguages` configured should no longer see a read-only patch toast when creating or opening documents while Studio is still resolving initial value templates. Default-language seeding still waits until the document has a `_rev` (first edit on a new document).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b66d7d-20b2-4512-9f58-84f31f07a441?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b66d7d-20b2-4512-9f58-84f31f07a441&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

