### PR TITLE
fix(internationalized-array): stop defaultLanguages from recreating deleted documents

### DIFF
--- a/.agents/skills/plugin-test-coverage/SKILL.md
+++ b/.agents/skills/plugin-test-coverage/SKILL.md
@@ -78,6 +78,7 @@ Do not dump plugin specs at the top level of `tests/`.
 - Auth: Playwright `storageState` seeds `__studio_auth_token_<projectId>`; preflight `/users/me`. Never use `SANITY_DEPLOY_TOKEN` for e2e session auth.
 - Local pitfall: stale server on `:3333` + `reuseExistingServer` → signed-out studio. Kill and restart.
 - Prefer accessible role/name locators; add `data-testid` + a **patch** changeset only when selectors are flaky or ambiguous (e.g. duplicate add-button grids).
+- Document action menuitems include the keyboard shortcut in the accessible name (`Delete Ctrl Alt D`). `/^Delete$/` will not match — use `{name: 'Delete'}` or `/^Delete\b/`, and scope to `getByRole('menu', {name: 'Open document actions'})`.
 - Seed documents via the Content Lake API; always `try/finally` cleanup.
 - Video: `SANITY_E2E_VIDEO=on` when debugging.
 - Document existence matters: some plugins only auto-seed after the document is in the pair store (draft/published/version snapshot) — seed empty persisted docs, don't rely on brand-new unsaved drafts. Form `_rev` can linger after delete, so it is not a reliable existence check.

--- a/.agents/skills/plugin-test-coverage/SKILL.md
+++ b/.agents/skills/plugin-test-coverage/SKILL.md
@@ -80,7 +80,7 @@ Do not dump plugin specs at the top level of `tests/`.
 - Prefer accessible role/name locators; add `data-testid` + a **patch** changeset only when selectors are flaky or ambiguous (e.g. duplicate add-button grids).
 - Seed documents via the Content Lake API; always `try/finally` cleanup.
 - Video: `SANITY_E2E_VIDEO=on` when debugging.
-- Document existence matters: some plugins only auto-seed after `_rev` exists — seed empty persisted docs, don’t rely on brand-new unsaved drafts.
+- Document existence matters: some plugins only auto-seed after the document is in the pair store (draft/published/version snapshot) — seed empty persisted docs, don't rely on brand-new unsaved drafts. Form `_rev` can linger after delete, so it is not a reliable existence check.
 
 ## PR checklist
 

--- a/.changeset/i18n-array-no-resurrect-on-delete.md
+++ b/.changeset/i18n-array-no-resurrect-on-delete.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Prevent `defaultLanguages` auto-add from recreating a document after it is deleted. The effect now follows the document pair store instead of form `_rev`, which can linger on the last displayed snapshot, and it will not patch once the document has left the store.

--- a/e2e/helpers/internationalized-array/internationalizedArray.ts
+++ b/e2e/helpers/internationalized-array/internationalizedArray.ts
@@ -91,7 +91,11 @@ export async function getI18nPost(
 
 export async function deleteI18nPostInStudio(page: Page): Promise<void> {
   await page.getByTestId('action-menu-button').click()
-  await page.getByRole('menuitem', {name: /^Delete$/}).click()
+  // Studio includes the shortcut in the accessible name ("Delete Ctrl Alt D").
+  await page
+    .getByRole('menu', {name: 'Open document actions'})
+    .getByRole('menuitem', {name: /^Delete\b/})
+    .click()
   await page.getByRole('button', {name: 'Delete document'}).click()
 }
 

--- a/e2e/helpers/internationalized-array/internationalizedArray.ts
+++ b/e2e/helpers/internationalized-array/internationalizedArray.ts
@@ -39,7 +39,7 @@ function item(language: string, value = ''): I18nArrayItem {
 /**
  * Create an i18nPost draft via the Content Lake API.
  * Pass `title` / `summary` arrays explicitly — use `[]` when testing
- * `defaultLanguages` seeding (requires a persisted `_rev`).
+ * `defaultLanguages` seeding (requires the document to exist in the pair store).
  */
 export async function seedI18nPost(
   projectName: string | undefined,
@@ -76,6 +76,23 @@ export async function deleteI18nPost(
     .delete(`drafts.${documentId}`)
     .commit({visibility: 'async'})
     .catch(() => undefined)
+}
+
+export async function getI18nPost(
+  projectName: string | undefined,
+  documentId: string,
+): Promise<Record<string, unknown> | null> {
+  const client = createE2EClient(datasetForProject(projectName))
+  const draft = await client.getDocument(`drafts.${documentId}`)
+  if (draft) return draft
+  const published = await client.getDocument(documentId)
+  return published ?? null
+}
+
+export async function deleteI18nPostInStudio(page: Page): Promise<void> {
+  await page.getByTestId('action-menu-button').click()
+  await page.getByRole('menuitem', {name: /^Delete$/}).click()
+  await page.getByRole('button', {name: 'Delete document'}).click()
 }
 
 export async function openI18nPost(page: Page, documentId: string): Promise<void> {

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -42,8 +42,10 @@ test.describe('sanity-plugin-internationalized-array', () => {
     try {
       await openI18nPost(page, doc.id)
       await expect(languageLabel(page, 'en')).toBeVisible()
+      await expect(page.getByText('This document has been deleted.')).toHaveCount(0)
 
       await deleteI18nPostInStudio(page)
+      await expect(page.getByText('This document has been deleted.')).toBeVisible()
 
       await expect.poll(async () => getI18nPost(projectName, doc.id), {timeout: 20_000}).toBeNull()
 

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -2,8 +2,10 @@ import {expect, test} from '@playwright/test'
 
 import {
   deleteI18nPost,
+  deleteI18nPostInStudio,
   documentAddButton,
   fieldAddButton,
+  getI18nPost,
   languageItem,
   languageLabel,
   openI18nPost,
@@ -14,7 +16,7 @@ import {
 test.describe('sanity-plugin-internationalized-array', () => {
   /**
    * `defaultLanguages` only auto-seeds after the document exists in the
-   * dataset (`_rev`). Opening a persisted empty array must create the EN item.
+   * pair store. Opening a persisted empty array must create the EN item.
    */
   test('seeds default language on an existing empty document', async ({page}, testInfo) => {
     const projectName = testInfo.project.name
@@ -26,6 +28,29 @@ test.describe('sanity-plugin-internationalized-array', () => {
       await expect(languageLabel(page, 'en')).toBeVisible()
       // EN is present → its field add button is disabled
       await expect(fieldAddButton(page, 'en')).toHaveAttribute('data-disabled', 'true')
+    } finally {
+      await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  test('does not recreate a document after deleting it from the studio', async ({
+    page,
+  }, testInfo) => {
+    const projectName = testInfo.project.name
+    const doc = await seedI18nPost(projectName, {title: [], summary: []})
+
+    try {
+      await openI18nPost(page, doc.id)
+      await expect(languageLabel(page, 'en')).toBeVisible()
+
+      await deleteI18nPostInStudio(page)
+
+      await expect.poll(async () => getI18nPost(projectName, doc.id), {timeout: 20_000}).toBeNull()
+
+      // Auto-add uses a setTimeout; wait long enough that a resurrecting patch
+      // would have landed, then confirm the document is still gone.
+      await new Promise((resolve) => setTimeout(resolve, 2_000))
+      expect(await getI18nPost(projectName, doc.id)).toBeNull()
     } finally {
       await deleteI18nPost(projectName, doc.id)
     }

--- a/plugins/sanity-plugin-internationalized-array/README.md
+++ b/plugins/sanity-plugin-internationalized-array/README.md
@@ -60,7 +60,7 @@ This will register two new fields to the schema, based on the settings passed in
 - `internationalizedArrayString` an array field of:
 - `internationalizedArrayStringValue` an object field, with a single `string` field inside called `value`
 
-The above config will also create an empty array item in new documents for each language in `defaultLanguages`. This is configured globally for all internationalized array fields.
+The above config will also create an empty array item for each language in `defaultLanguages` once the document exists in the dataset. Opening a new unsaved document does not create a draft on its own — default languages are added after the first edit. Deleted documents are not recreated.
 
 You can pass in more registered schema-type names to generate more internationalized arrays. Use them in your schema like this:
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -22,9 +22,30 @@ vi.mock('sanity', () => ({
   })),
 }))
 
+const EXISTING_EDIT_STATE = {
+  ready: true,
+  draft: {_id: 'drafts.doc', _rev: 'rev1'},
+  published: null,
+  version: null,
+}
+
+const EMPTY_EDIT_STATE = {
+  ready: true,
+  draft: null,
+  published: null,
+  version: null,
+}
+
 vi.mock('sanity/structure', () => ({
   useDocumentPane: vi.fn(() => ({
     isDeleting: false,
+    isDeleted: false,
+    editState: {
+      ready: true,
+      draft: {_id: 'drafts.doc', _rev: 'rev1'},
+      published: null,
+      version: null,
+    },
     onChange: vi.fn(),
   })),
 }))
@@ -89,6 +110,25 @@ function createMockArrayProps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function mockDocumentPane(
+  overrides: {
+    isDeleting?: boolean
+    isDeleted?: boolean
+    editState?: unknown
+  } = {},
+): void {
+  vi.mocked(useDocumentPane).mockReturnValue(
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    {
+      isDeleting: false,
+      isDeleted: false,
+      editState: EXISTING_EDIT_STATE,
+      onChange: vi.fn(),
+      ...overrides,
+    } as unknown as ReturnType<typeof useDocumentPane>,
+  )
+}
+
 function renderInternationalizedArray(props: ReturnType<typeof createMockArrayProps>) {
   mockGetFormValue.mockImplementation(() => props.value)
   return render(
@@ -106,6 +146,7 @@ describe('InternationalizedArray', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -470,66 +511,147 @@ describe('InternationalizedArray', () => {
     ])
   })
 
-  test('does not auto-add default languages when document is being deleted', () => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleting: true,
-    } as ReturnType<typeof useDocumentPane>)
+  test('does not auto-add default languages when document is being deleted', async () => {
+    mockDocumentPane({isDeleting: true, editState: EXISTING_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages when document has been deleted', async () => {
+    mockDocumentPane({isDeleted: true, isDeleting: false, editState: EMPTY_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages when the pair store has no snapshot', async () => {
+    mockDocumentPane({editState: EMPTY_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages when form _rev lingers after the store is empty', async () => {
+    // The deleted pane can keep the last displayed snapshot (including `_rev`)
+    // while draft/published/version are already null. Patching then recreates
+    // the document — this is the remaining hole after the `_rev` guard.
+    mockDocumentPane({editState: EMPTY_EDIT_STATE})
+    vi.mocked(useFormValue).mockImplementation((path) =>
+      Array.isArray(path) && path[0] === '_rev' ? 'stale-rev' : 'article',
+    )
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages after language items disappear', async () => {
+    mockDocumentPane({editState: EXISTING_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const value = createValues(['en'])
+    const props = createMockArrayProps({onChange, value})
+
+    const view = renderInternationalizedArray(props)
+    expect(onChange).not.toHaveBeenCalled()
+
+    mockGetFormValue.mockImplementation(() => undefined)
+    view.rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...createMockArrayProps({onChange, value: undefined})} />,
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages if the store empties before the scheduled patch runs', async () => {
+    vi.useFakeTimers()
+    mockDocumentPane({editState: EXISTING_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+    const view = renderInternationalizedArray(props)
+
+    mockDocumentPane({editState: EMPTY_EDIT_STATE})
+    view.rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...props} />,
+    )
+
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-reorder when the document is no longer in the pair store', () => {
+    mockDocumentPane({editState: EMPTY_EDIT_STATE})
 
     vi.mocked(useInternationalizedArrayContext).mockReturnValue(
       MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
     )
 
     const onChange = vi.fn()
-    const props = createMockArrayProps({onChange})
+    const value = createValues(['fr', 'en'])
+    const props = createMockArrayProps({onChange, value})
 
     renderInternationalizedArray(props)
-
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  test('does not auto-add default languages when document has been deleted', async () => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleted: true,
-      isDeleting: false,
-    } as ReturnType<typeof useDocumentPane>)
-
-    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
-      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
-      defaultLanguages: ['en'],
-    })
-
-    const onChange = vi.fn()
-    const props = createMockArrayProps({onChange})
-
-    renderInternationalizedArray(props)
-
-    // Allow the scheduled setTimeout in the useEffect to fire
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  test('does not auto-add default languages when the document does not exist yet (no _rev)', async () => {
-    // _type resolves as usual, but the document has no revision: it is either
-    // brand new (unsaved) or was just deleted while the pane is still open
-    vi.mocked(useFormValue).mockImplementation((path) =>
-      Array.isArray(path) && path[0] === '_rev' ? undefined : 'article',
-    )
-
-    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
-      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
-      defaultLanguages: ['en'],
-    })
-
-    const onChange = vi.fn()
-    const props = createMockArrayProps({onChange})
-
-    renderInternationalizedArray(props)
-
-    // Allow the scheduled setTimeout in the useEffect to fire
-    await new Promise((resolve) => setTimeout(resolve, 10))
 
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -652,10 +774,7 @@ describe('InternationalizedArray', () => {
   })
 
   test('renders MemberItemError for members with kind !== "item"', () => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    vi.mocked(useDocumentPane).mockReturnValue({
-      isDeleting: false,
-    } as ReturnType<typeof useDocumentPane>)
+    mockDocumentPane({isDeleting: false})
 
     vi.mocked(useLanguageFilterStudioContext).mockReturnValue({
       selectedLanguageIds: [],

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -640,6 +640,39 @@ describe('InternationalizedArray', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  test('still auto-adds default languages after a transient not-ready pair-store blip', async () => {
+    vi.useFakeTimers()
+    mockDocumentPane({editState: EXISTING_EDIT_STATE})
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+    const view = renderInternationalizedArray(props)
+
+    mockDocumentPane({
+      editState: {ready: false, draft: null, published: null, version: null},
+    })
+    view.rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...props} />,
+    )
+
+    mockDocumentPane({editState: EXISTING_EDIT_STATE})
+    view.rerender(
+      // @ts-expect-error - simplified mock props
+      <InternationalizedArray {...props} />,
+    )
+
+    await vi.runAllTimersAsync()
+    vi.useRealTimers()
+
+    expect(onChange).toHaveBeenCalled()
+  })
+
   test('does not auto-reorder when the document is no longer in the pair store', () => {
     mockDocumentPane({editState: EMPTY_EDIT_STATE})
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -20,7 +20,7 @@ import type {InternationalizedArrayItem} from '../types'
 import {checkAllLanguagesArePresent} from '../utils/checkAllLanguagesArePresent'
 import {createAddAllTitle} from '../utils/createAddAllTitle'
 import {createAddLanguagePatches} from '../utils/createAddLanguagePatches'
-import {documentExistsInStore} from '../utils/documentExistsInStore'
+import {documentExistsInStore, documentMissingFromStore} from '../utils/documentExistsInStore'
 import {internationalizedArrayLanguageFilter} from '../utils/internationalizedArrayLanguageFilter'
 import AddButtons from './AddButtons'
 import Feedback from './Feedback'
@@ -43,9 +43,10 @@ import {MigrationBanner} from './MigrationBanner'
  *   `defaultLanguages` when those entries are missing. Only runs while the
  *   document pair store still has a draft/published/version snapshot, so the
  *   effect never recreates a just-deleted document or creates a draft before
- *   the user's first edit. Form `_rev` is not used for this check — it can
- *   linger on the last displayed snapshot after delete, and Studio's Delete
- *   action does not set `useDocumentPane().isDeleting`.
+ *   the user's first edit. A not-ready store is treated as loading, not as a
+ *   delete. Form `_rev` is not used for this check — it can linger on the last
+ *   displayed snapshot after delete, and Studio's Delete action does not set
+ *   `useDocumentPane().isDeleting`.
  * - **Ordering**: When `restoreOrder` is enabled (default), detects when value
  *   items are out of order relative to the master `languages` list and
  *   automatically re-sorts them. Set `restoreOrder: false` to keep the stored
@@ -160,18 +161,21 @@ export default function InternationalizedArray(
   // linger on the last displayed snapshot after delete, and the built-in Delete
   // action never writes pane `isDeleting`, so neither of those is sufficient.
   const documentInStore = documentExistsInStore(editState)
+  const documentMissing = documentMissingFromStore(editState)
 
-  // Latch once this pane instance has observed the document leave the store, or
-  // once its language items disappear after being present. Either means delete
-  // (or equivalent) is in flight; auto-adding would resurrect the document.
-  // Adjusted during render (not in an effect) so the skip is applied on the
-  // same commit that observes the transition.
+  // Latch once this pane instance has observed confirmed absence (store ready
+  // with no snapshots), or once its language items disappear after being
+  // present. Either means delete (or equivalent) is in flight; auto-adding
+  // would resurrect the document. Do not latch on loading (`ready === false` /
+  // missing editState) — that is not a delete. Adjusted during render (not in
+  // an effect) so the skip is applied on the same commit that observes the
+  // transition.
   const [seenInStore, setSeenInStore] = useState(documentInStore)
   const [leftStore, setLeftStore] = useState(false)
   if (documentInStore && !seenInStore) {
     setSeenInStore(true)
   }
-  if (!documentInStore && seenInStore && !leftStore) {
+  if (documentMissing && seenInStore && !leftStore) {
     setLeftStore(true)
   }
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -210,7 +210,10 @@ export default function InternationalizedArray(
     !shouldMigrateArray
 
   const canAutoAddDefaultsRef = useRef(canAutoAddDefaults)
-  useEffect(() => {
+  // Layout effect so the timeout guard updates before paint / before a
+  // previously scheduled setTimeout can run. A passive useEffect write can
+  // land after that macrotask and still emit patches.
+  useLayoutEffect(() => {
     canAutoAddDefaultsRef.current = canAutoAddDefaults
   })
 

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useMemo} from 'react'
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -20,6 +20,7 @@ import type {InternationalizedArrayItem} from '../types'
 import {checkAllLanguagesArePresent} from '../utils/checkAllLanguagesArePresent'
 import {createAddAllTitle} from '../utils/createAddAllTitle'
 import {createAddLanguagePatches} from '../utils/createAddLanguagePatches'
+import {documentExistsInStore} from '../utils/documentExistsInStore'
 import {internationalizedArrayLanguageFilter} from '../utils/internationalizedArrayLanguageFilter'
 import AddButtons from './AddButtons'
 import Feedback from './Feedback'
@@ -39,10 +40,12 @@ import {MigrationBanner} from './MigrationBanner'
  *   missing languages" button (controlled by `buttonAddAll` and
  *   `buttonLocations` config). Dispatches `setIfMissing` + `insert` patches.
  * - **Default languages**: Automatically adds entries for languages listed in
- *   `defaultLanguages` when those entries are missing. Only runs once the
- *   document exists in the dataset (it has a `_rev`), so the effect never
- *   recreates a just-deleted document or creates a draft before the user's
- *   first edit.
+ *   `defaultLanguages` when those entries are missing. Only runs while the
+ *   document pair store still has a draft/published/version snapshot, so the
+ *   effect never recreates a just-deleted document or creates a draft before
+ *   the user's first edit. Form `_rev` is not used for this check — it can
+ *   linger on the last displayed snapshot after delete, and Studio's Delete
+ *   action does not set `useDocumentPane().isDeleting`.
  * - **Ordering**: When `restoreOrder` is enabled (default), detects when value
  *   items are out of order relative to the master `languages` list and
  *   automatically re-sorts them. Set `restoreOrder: false` to keep the stored
@@ -150,14 +153,34 @@ export default function InternationalizedArray(
     [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path],
   )
 
-  const {isDeleted, isDeleting} = useDocumentPane()
+  const {isDeleted, isDeleting, editState} = useDocumentPane()
 
-  // The document only has a revision once it exists in the dataset. Patching
-  // a nonexistent document would create it: auto-adding default languages to
-  // a just-deleted document resurrects it as an empty draft (and the deleted
-  // pane can outrace `isDeleted`), and auto-adding to an unsaved new document
-  // creates a draft before the user has made any edits.
-  const documentExists = Boolean(useFormValue(['_rev']))
+  // Pair-store snapshots are the existence check. Patching a document that is
+  // no longer in the store recreates it as an empty draft. Form `_rev` can
+  // linger on the last displayed snapshot after delete, and the built-in Delete
+  // action never writes pane `isDeleting`, so neither of those is sufficient.
+  const documentInStore = documentExistsInStore(editState)
+
+  // Latch once this pane instance has observed the document leave the store, or
+  // once its language items disappear after being present. Either means delete
+  // (or equivalent) is in flight; auto-adding would resurrect the document.
+  // Adjusted during render (not in an effect) so the skip is applied on the
+  // same commit that observes the transition.
+  const [seenInStore, setSeenInStore] = useState(documentInStore)
+  const [leftStore, setLeftStore] = useState(false)
+  if (documentInStore && !seenInStore) {
+    setSeenInStore(true)
+  }
+  if (!documentInStore && seenInStore && !leftStore) {
+    setLeftStore(true)
+  }
+
+  const [hadItems, setHadItems] = useState(() => Boolean(value?.length))
+  if (value?.length && !hadItems) {
+    setHadItems(true)
+  }
+
+  const itemsDisappeared = hadItems && !value?.length
 
   // Create a stable dependency string that only changes when language keys change
   const languageKeysFromValue = value
@@ -173,39 +196,46 @@ export default function InternationalizedArray(
     return languages.filter((l) => languageKeys?.find((key) => key === l.id)).map((l) => l.id)
   }, [languageKeysFromValue, languages])
 
+  const canAutoAddDefaults =
+    documentInStore &&
+    !leftStore &&
+    !itemsDisappeared &&
+    !isDeleting &&
+    !isDeleted &&
+    !readOnly &&
+    !shouldMigrateArray
+
+  const canAutoAddDefaultsRef = useRef(canAutoAddDefaults)
+  useEffect(() => {
+    canAutoAddDefaultsRef.current = canAutoAddDefaults
+  })
+
   useEffect(() => {
     const hasAddedDefaultLanguages = defaultLanguages
       .filter((language) => languages.find((l) => l.id === language))
       .every((language) => addedLanguages.includes(language))
 
-    if (
-      documentExists &&
-      !isDeleting &&
-      !isDeleted &&
-      !hasAddedDefaultLanguages &&
-      !shouldMigrateArray
-    ) {
-      const languagesToAdd = defaultLanguages
-        .filter((language) => !addedLanguages.includes(language))
-        .filter((language) => languages.find((l) => l.id === language))
-      // Account for strict mode by scheduling the update
-      const timeout = setTimeout(() => {
-        if (!readOnly) handleAddLanguages(languagesToAdd)
-      })
-      return () => clearTimeout(timeout)
+    if (!canAutoAddDefaults || hasAddedDefaultLanguages) {
+      return undefined
     }
-    return undefined
-  }, [
-    documentExists,
-    isDeleted,
-    isDeleting,
-    handleAddLanguages,
-    defaultLanguages,
-    addedLanguages,
-    languages,
-    readOnly,
-    shouldMigrateArray,
-  ])
+
+    const languagesToAdd = defaultLanguages
+      .filter((language) => !addedLanguages.includes(language))
+      .filter((language) => languages.find((l) => l.id === language))
+
+    if (languagesToAdd.length === 0) {
+      return undefined
+    }
+
+    // Account for strict mode by scheduling the update. Re-check the ref
+    // inside the timeout so a delete that lands before the macrotask cannot
+    // still emit setIfMissing and recreate the document.
+    const timeout = setTimeout(() => {
+      if (!canAutoAddDefaultsRef.current) return
+      handleAddLanguages(languagesToAdd)
+    })
+    return () => clearTimeout(timeout)
+  }, [canAutoAddDefaults, handleAddLanguages, defaultLanguages, addedLanguages, languages])
 
   // NOTE: This is reordering and re-setting the whole array, it could be surgical
   const handleRestoreOrder = useCallback(() => {
@@ -267,10 +297,23 @@ export default function InternationalizedArray(
 
   // Automatically restore order of fields (opt out with restoreOrder: false)
   useEffect(() => {
-    if (restoreOrder && languagesOutOfOrder.length > 0 && allKeysAreLanguages && !readOnly) {
+    if (
+      restoreOrder &&
+      languagesOutOfOrder.length > 0 &&
+      allKeysAreLanguages &&
+      !readOnly &&
+      canAutoAddDefaults
+    ) {
       handleRestoreOrder()
     }
-  }, [restoreOrder, languagesOutOfOrder, allKeysAreLanguages, handleRestoreOrder, readOnly])
+  }, [
+    restoreOrder,
+    languagesOutOfOrder,
+    allKeysAreLanguages,
+    handleRestoreOrder,
+    readOnly,
+    canAutoAddDefaults,
+  ])
 
   // compare value keys with possible languages
   const allLanguagesArePresent = useMemo(

--- a/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest'
 
-import {documentExistsInStore} from './documentExistsInStore'
+import {documentExistsInStore, documentMissingFromStore} from './documentExistsInStore'
 
 describe('documentExistsInStore', () => {
   test('returns false when editState is null', () => {
@@ -68,5 +68,44 @@ describe('documentExistsInStore', () => {
         draft: {_id: 'drafts.doc'},
       }),
     ).toBe(true)
+  })
+})
+
+describe('documentMissingFromStore', () => {
+  test('returns false when editState is null (loading, not missing)', () => {
+    expect(documentMissingFromStore(null)).toBe(false)
+  })
+
+  test('returns false when the pair store is not ready yet (loading, not missing)', () => {
+    expect(
+      documentMissingFromStore({
+        ready: false,
+        draft: null,
+        published: null,
+        version: null,
+      }),
+    ).toBe(false)
+  })
+
+  test('returns true when ready with no snapshots (confirmed absence)', () => {
+    expect(
+      documentMissingFromStore({
+        ready: true,
+        draft: null,
+        published: null,
+        version: null,
+      }),
+    ).toBe(true)
+  })
+
+  test('returns false when a snapshot is present', () => {
+    expect(
+      documentMissingFromStore({
+        ready: true,
+        draft: {_id: 'drafts.doc', _rev: 'rev1'},
+        published: null,
+        version: null,
+      }),
+    ).toBe(false)
   })
 })

--- a/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, test} from 'vitest'
+
+import {documentExistsInStore} from './documentExistsInStore'
+
+describe('documentExistsInStore', () => {
+  test('returns false when editState is null', () => {
+    expect(documentExistsInStore(null)).toBe(false)
+  })
+
+  test('returns false when the pair store is not ready yet', () => {
+    expect(
+      documentExistsInStore({
+        ready: false,
+        draft: {_id: 'drafts.doc'},
+        published: null,
+        version: null,
+      }),
+    ).toBe(false)
+  })
+
+  test('returns false when ready with no snapshots (new or deleted document)', () => {
+    expect(
+      documentExistsInStore({
+        ready: true,
+        draft: null,
+        published: null,
+        version: null,
+      }),
+    ).toBe(false)
+  })
+
+  test('returns true when a draft snapshot is present', () => {
+    expect(
+      documentExistsInStore({
+        ready: true,
+        draft: {_id: 'drafts.doc', _rev: 'rev1'},
+        published: null,
+        version: null,
+      }),
+    ).toBe(true)
+  })
+
+  test('returns true when only a published snapshot is present', () => {
+    expect(
+      documentExistsInStore({
+        ready: true,
+        draft: null,
+        published: {_id: 'doc'},
+        version: null,
+      }),
+    ).toBe(true)
+  })
+
+  test('returns true when only a version snapshot is present', () => {
+    expect(
+      documentExistsInStore({
+        ready: true,
+        draft: null,
+        published: null,
+        version: {_id: 'versions.r.doc'},
+      }),
+    ).toBe(true)
+  })
+
+  test('treats missing ready as ready so incomplete mocks still detect snapshots', () => {
+    expect(
+      documentExistsInStore({
+        draft: {_id: 'drafts.doc'},
+      }),
+    ).toBe(true)
+  })
+})

--- a/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.ts
@@ -1,0 +1,31 @@
+/**
+ * Pair-store snapshots used to decide whether a document currently exists.
+ *
+ * Intentionally structural: `useDocumentPane().editState` is the live source of
+ * truth, and we should not depend on form `_rev` (that field can linger on the
+ * last displayed snapshot after delete).
+ */
+export type DocumentPairSnapshots = {
+  ready?: boolean
+  draft?: unknown
+  published?: unknown
+  version?: unknown
+} | null
+
+/**
+ * Whether the document currently has a draft, published, or version snapshot
+ * in the pair store.
+ *
+ * Studio's delete action does not set `useDocumentPane().isDeleting` (that
+ * flag is a separate pane field the built-in Delete action never writes). After
+ * delete, form `_rev` can also remain on the last displayed snapshot. The pair
+ * store clearing `draft` / `published` / `version` is the signal that patching
+ * would recreate the document.
+ */
+export function documentExistsInStore(editState: DocumentPairSnapshots): boolean {
+  if (!editState || editState.ready === false) {
+    return false
+  }
+
+  return Boolean(editState.draft || editState.published || editState.version)
+}

--- a/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/utils/documentExistsInStore.ts
@@ -29,3 +29,21 @@ export function documentExistsInStore(editState: DocumentPairSnapshots): boolean
 
   return Boolean(editState.draft || editState.published || editState.version)
 }
+
+/**
+ * Whether the pair store has confirmed the document is absent: the store is
+ * ready but has no draft, published, or version snapshot.
+ *
+ * Intentionally not the negation of {@link documentExistsInStore}. Loading
+ * states (missing `editState` or `ready === false`) are neither "exists" nor
+ * "missing" — the pair listener can re-emit not-ready snapshots on
+ * subscription churn or reconnect, and treating those as missing would make a
+ * transient blip look like a delete.
+ */
+export function documentMissingFromStore(editState: DocumentPairSnapshots): boolean {
+  if (!editState || editState.ready === false) {
+    return false
+  }
+
+  return !editState.draft && !editState.published && !editState.version
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [SAPP-3761](https://linear.app/sanity/issue/SAPP-3761/sanity-plugin-internationalized-array-re-initializes-documents-when): deleting a document that uses `sanity-plugin-internationalized-array` with `defaultLanguages` no longer recreates an empty draft.

## Problem

`InternationalizedArray` auto-patches missing `defaultLanguages` entries from a `useEffect`. After delete, that patch (`setIfMissing([])` + `insert`) materializes a new document in the dataset.

A previous fix gated the effect on form `_rev` and `useDocumentPane().isDeleting` / `isDeleted`. That is not enough:

- Studio’s built-in Delete action keeps its own local `isDeleting` state and **never writes** `useDocumentPane().isDeleting`.
- After delete, form `_rev` can linger on the last displayed snapshot while the pair store has already cleared `draft` / `published` / `version`.
- The scheduled `setTimeout` (Strict Mode) did not re-check those flags before emitting patches.

## Fix

- Treat pair-store snapshots (`editState.draft` / `published` / `version`) as the existence check, not form `_rev`.
- Latch once this pane instance has seen **confirmed absence** (store ready with no snapshots), or once language items disappear after being present. A not-ready store is loading, not a delete.
- Re-check that “safe to auto-patch” flag inside the timeout so a delete that lands first cannot still `setIfMissing`.
- Skip `restoreOrder` auto-patches on the same path.

New documents still are not scaffolded until they exist in the dataset (first persist). Existing empty documents still get default languages on open.

## Tests

- Unit: `documentExistsInStore` / `documentMissingFromStore`, lingering `_rev` with an empty pair store, items disappearing, timeout cancelled when the store empties, auto-add still runs after a transient not-ready blip, no restore-order patch after the document is gone.
- E2e: delete an `i18nPost` from the studio and assert it stays absent in the dataset. The Delete menuitem accessible name includes the shortcut (`Delete Ctrl Alt D`); the helper matches `/^Delete\b/` inside the document actions menu.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a6ecdf1-0281-4668-80a1-14390f028eaf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a6ecdf1-0281-4668-80a1-14390f028eaf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

