### PR TITLE
fix(orderable-document-list): revert to DocumentStatusIndicator

### DIFF
--- a/.changeset/orderable-document-list-revert-status-indicator.md
+++ b/.changeset/orderable-document-list-revert-status-indicator.md
@@ -1,0 +1,5 @@
+---
+"@sanity/orderable-document-list": patch
+---
+
+Revert to `DocumentStatusIndicator`, as `DocumentVersionsStatusIndicator` only exists in the unreleased `sanity` 6.11 line and broke builds on every released version

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -59,7 +59,7 @@ export function Document({
   }
 
   const tooltip = (
-    // oxlint-disable-next-line typescript/no-deprecated -- DocumentVersionsStatus takes documentGroupId; this tooltip still uses draft/published/versions from useDocumentVersionInfo
+    // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0
     <DocumentStatus
       draft={versionsInfo.draft}
       published={versionsInfo.published}

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -44,7 +44,7 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util
+  // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0
   const versionsInfo = useDocumentVersionInfo(doc._id)
 
   const {ChildLink, groupIndex, routerPanesState} = router
@@ -113,7 +113,7 @@ export function Document({
 
             <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
               <Flex align="center" style={{flexShrink: 0}}>
-                {/* oxlint-disable-next-line typescript/no-deprecated -- DocumentVersionsStatusIndicator only exists in sanity 6.11+, which is unreleased; migrate once it is stable */}
+                {/* oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0 */}
                 <DocumentStatusIndicator
                   draft={versionsInfo.draft}
                   published={versionsInfo.published}

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -8,11 +8,9 @@ import {
   useSchema,
   PreviewCard,
   Preview,
-  DocumentVersionsStatusIndicator,
+  DocumentStatusIndicator,
   DocumentStatus,
   useDocumentVersionInfo,
-  useDocumentVersions,
-  getPublishedId,
 } from 'sanity'
 import {usePaneRouter} from 'sanity/structure'
 
@@ -46,9 +44,8 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util for the DocumentStatus tooltip
+  // oxlint-disable-next-line typescript/no-deprecated -- the replacement, `useDocumentVersions`, would require reimplementing the internal (unexported) `getDocumentVersionInfoFromVersions` util
   const versionsInfo = useDocumentVersionInfo(doc._id)
-  const {versions} = useDocumentVersions({documentId: getPublishedId(doc._id)})
 
   const {ChildLink, groupIndex, routerPanesState} = router
 
@@ -116,7 +113,12 @@ export function Document({
 
             <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
               <Flex align="center" style={{flexShrink: 0}}>
-                <DocumentVersionsStatusIndicator documentVersions={versions} />
+                {/* oxlint-disable-next-line typescript/no-deprecated -- DocumentVersionsStatusIndicator only exists in sanity 6.11+, which is unreleased; migrate once it is stable */}
+                <DocumentStatusIndicator
+                  draft={versionsInfo.draft}
+                  published={versionsInfo.published}
+                  versions={versionsInfo.versions}
+                />
               </Flex>
             </Tooltip>
           </Flex>

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -44,7 +44,7 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0
+  // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only
   const versionsInfo = useDocumentVersionInfo(doc._id)
 
   const {ChildLink, groupIndex, routerPanesState} = router
@@ -59,7 +59,7 @@ export function Document({
   }
 
   const tooltip = (
-    // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0
+    // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only
     <DocumentStatus
       draft={versionsInfo.draft}
       published={versionsInfo.published}
@@ -113,7 +113,7 @@ export function Document({
 
             <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
               <Flex align="center" style={{flexShrink: 0}}>
-                {/* oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only, and this plugin's peer range admits ^5 || ^6.0.0-0 */}
+                {/* oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only */}
                 <DocumentStatusIndicator
                   draft={versionsInfo.draft}
                   published={versionsInfo.published}


### PR DESCRIPTION
`@sanity/orderable-document-list` 2.0.21 and 2.0.22 import `DocumentVersionsStatusIndicator` from `sanity`, an export that only exists in `sanity@6.11.0-next.*` and not in `6.10.1` (current stable `latest`) or v5. The plugin's peer range is `^5 || ^6.0.0-0`, so package managers install it against any released `sanity` with no warning, and every fresh install on a released Sanity breaks at build time with `[MISSING_EXPORT] "DocumentVersionsStatusIndicator" is not exported by "node_modules/sanity/lib/index.js"`.

Cause: commit a5b8bdbc7a500d6ce93fd75de8765a9bdfa0fade (#1936) swapped `DocumentStatusIndicator` for `DocumentVersionsStatusIndicator` while fixing an unrelated lint issue.

Fix: revert to `DocumentStatusIndicator`. It exists in both `sanity@6.10.1` and `sanity@6.11.0-next.109` (verified against the published tarballs), merely marked `@deprecated` in 6.11-next, so this is compatible with every released and upcoming version.

`main` also currently fails `pnpm lint` on this same file's `DocumentStatus` deprecation warning - a second symbol whose replacement, `DocumentVersionsStatus`, is likewise 6.11-next-only and not yet released. This PR suppresses all three deprecation warnings in the file (`useDocumentVersionInfo`, `DocumentStatus`, `DocumentStatusIndicator`) with one consistent `oxlint-disable` reason: the replacements only exist in sanity 6.11+, and this plugin's peer range admits `^5 || ^6.0.0-0`. Migrate once sanity 6.11 ships as stable.

The pre-existing suppression on `useDocumentVersionInfo` previously gave a different, inaccurate reason (that the replacement would require reimplementing an internal, unexported util). That reason was verified against `sanity` core and found false, and is corrected here to the same peer-range explanation as the other two.

Fixes https://github.com/sanity-io/plugins/issues/1946

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compatibility fix reverting to stable Sanity exports; no auth, data, or behavioral changes beyond restoring the prior status indicator API.
> 
> **Overview**
> Fixes **build failures** on released `sanity` versions (`^5` / `^6` peers) caused by importing **`DocumentVersionsStatusIndicator`**, which only exists on unreleased `sanity@6.11` lines.
> 
> **`Document.tsx`** switches the list row status UI back to **`DocumentStatusIndicator`** and **`DocumentStatus`**, driven only by **`useDocumentVersionInfo`**—removing **`useDocumentVersions`**, **`getPublishedId`**, and the `documentVersions` prop path. Deprecation lint for those three APIs is suppressed with a single rationale: newer replacements are **6.11+ only** until stable ships.
> 
> Patch release noted in **`.changeset/orderable-document-list-revert-status-indicator.md`** for `@sanity/orderable-document-list`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ca233e1c2eda734c4ce63ccb0c8e9b8e6a457b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->