### PR TITLE
feat(orderable-document-list)!: migrate to the document versions API (SAPP-4378)

### DIFF
--- a/.changeset/orderable-document-list-document-versions-status.md
+++ b/.changeset/orderable-document-list-document-versions-status.md
@@ -1,0 +1,7 @@
+---
+"@sanity/orderable-document-list": major
+---
+
+Requires `sanity` 6.11 or newer. Sanity Studio 5, and 6.0 to 6.10, are no longer supported.
+
+The status icons in the ordering list now match the ones the Studio shows in its own document lists, and they follow the selected perspective. A document that has never been published shows no icon, and neither does a document outside the selected release.

--- a/.changeset/orderable-document-list-document-versions-status.md
+++ b/.changeset/orderable-document-list-document-versions-status.md
@@ -5,3 +5,5 @@
 Requires `sanity` 6.11 or newer. Sanity Studio 5, and 6.0 to 6.10, are no longer supported.
 
 The status icons in the ordering list now match the ones the Studio shows in its own document lists, and they follow the selected perspective. A document that has never been published shows no icon, and neither does a document outside the selected release.
+
+These icons come from Studio APIs that are not yet public, so a future Studio minor may change how they look.

--- a/plugins/@sanity/orderable-document-list/README.md
+++ b/plugins/@sanity/orderable-document-list/README.md
@@ -10,6 +10,8 @@ This plugin aims to be OS-like in that you can select and move multiple document
 
 ## Requirements
 
+`sanity` 6.11 or newer.
+
 A Sanity Studio with [Desk Structure](https://www.sanity.io/docs/structure-builder-introduction) configured:
 
 ```ts

--- a/plugins/@sanity/orderable-document-list/package.json
+++ b/plugins/@sanity/orderable-document-list/package.json
@@ -59,7 +59,7 @@
   "peerDependencies": {
     "react": "catalog:peer",
     "react-dom": "catalog:peer",
-    "sanity": "catalog:peer",
+    "sanity": "^6.11.0-next.49",
     "styled-components": "catalog:peer"
   },
   "engines": {

--- a/plugins/@sanity/orderable-document-list/package.json
+++ b/plugins/@sanity/orderable-document-list/package.json
@@ -59,7 +59,7 @@
   "peerDependencies": {
     "react": "catalog:peer",
     "react-dom": "catalog:peer",
-    "sanity": "^6.11.0-next.49",
+    "sanity": "^6.11.0",
     "styled-components": "catalog:peer"
   },
   "engines": {

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -102,7 +102,14 @@ export function Document({
           </Flex>
         )}
         <Box style={{width: `100%`}}>
-          <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
+          <Tooltip
+            content={tooltip}
+            portal
+            placement="right"
+            fallbackPlacements={[`top-end`, `bottom-end`]}
+            delay={{open: 400}}
+            boundaryElement={null}
+          >
             <Flex flex={1} align="center" justify="space-between" paddingRight={3}>
               <Preview layout="default" value={doc} schemaType={schemaType} />
 

--- a/plugins/@sanity/orderable-document-list/src/Document.tsx
+++ b/plugins/@sanity/orderable-document-list/src/Document.tsx
@@ -8,9 +8,10 @@ import {
   useSchema,
   PreviewCard,
   Preview,
-  DocumentStatusIndicator,
-  DocumentStatus,
-  useDocumentVersionInfo,
+  DocumentVersionsStatus,
+  DocumentVersionsStatusIndicator,
+  getPublishedId,
+  useDocumentVersions,
 } from 'sanity'
 import {usePaneRouter} from 'sanity/structure'
 
@@ -44,8 +45,8 @@ export function Document({
   const {showIncrements} = useContext(OrderableContext)
   const schema = useSchema()
   const router = usePaneRouter()
-  // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only
-  const versionsInfo = useDocumentVersionInfo(doc._id)
+  const publishedId = getPublishedId(doc._id)
+  const {versions} = useDocumentVersions({documentId: publishedId})
 
   const {ChildLink, groupIndex, routerPanesState} = router
 
@@ -58,14 +59,7 @@ export function Document({
     return null
   }
 
-  const tooltip = (
-    // oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only
-    <DocumentStatus
-      draft={versionsInfo.draft}
-      published={versionsInfo.published}
-      versions={versionsInfo.versions}
-    />
-  )
+  const tooltip = <DocumentVersionsStatus documentGroupId={publishedId} />
 
   return (
     <PreviewCard
@@ -108,20 +102,15 @@ export function Document({
           </Flex>
         )}
         <Box style={{width: `100%`}}>
-          <Flex flex={1} align="center" justify="space-between" paddingRight={3}>
-            <Preview layout="default" value={doc} schemaType={schemaType} />
+          <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
+            <Flex flex={1} align="center" justify="space-between" paddingRight={3}>
+              <Preview layout="default" value={doc} schemaType={schemaType} />
 
-            <Tooltip content={tooltip} portal placement="right" boundaryElement={null}>
               <Flex align="center" style={{flexShrink: 0}}>
-                {/* oxlint-disable-next-line typescript/no-deprecated -- the replacements are sanity 6.11+ only */}
-                <DocumentStatusIndicator
-                  draft={versionsInfo.draft}
-                  published={versionsInfo.published}
-                  versions={versionsInfo.versions}
-                />
+                <DocumentVersionsStatusIndicator documentVersions={versions} />
               </Flex>
-            </Tooltip>
-          </Flex>
+            </Flex>
+          </Tooltip>
         </Box>
         {dragBadge && (
           <Card tone="default" marginRight={4} radius={5}>


### PR DESCRIPTION
> [!IMPORTANT]
> Hold this until the plugin next ships a major.
>
> The peer range narrows to `^6.11.0`, so this publishes as a major and consumers below 6.11 cannot install it.
>
> It also swaps three deprecated exports for three `@internal` ones, which carry no stability guarantee. `DocumentVersionsStatus` changed internals between `6.11.0-next.68` and `6.11.0`, and Studio extracted `PreviewTooltip` in the same window.
>
> Dropping support for Sanity 6 would need a major on its own. This migration can ride in that release.

## Summary

Migrates `@sanity/orderable-document-list` off three deprecated `sanity` exports: `DocumentStatusIndicator` becomes `DocumentVersionsStatusIndicator`, `DocumentStatus` becomes `DocumentVersionsStatus`, and `useDocumentVersionInfo` is replaced with `useDocumentVersions` fed by `getPublishedId`.

The three `oxlint typescript/no-deprecated` suppressions are removed. The shared lint config sets `reportUnusedDisableDirectives: 'error'`, so leaving them in would fail lint.

The `Tooltip` now anchors to the whole preview row. The new indicator renders nothing for a document that has never been published or one outside the selected release; anchoring to the indicator alone would collapse the trigger to a zero-size element. It opens after 400ms and can fall back to `top-end` or `bottom-end`, matching the Studio's own preview tooltip, since a full-width trigger with the `@sanity/ui` default of no delay opens on every row the pointer crosses.

The `sanity` peer range moves from the shared `catalog:peer` entry to an inline `^6.11.0`, following the precedent in `@sanity/block-insert-picker`. `pnpm-workspace.yaml` is untouched. Narrowing the range drops consumers on sanity 5.x and 6.0-6.10, so the changeset is major.

Both replacement components are tagged `@internal` in `sanity`; `useDocumentVersions` is `@hidden @beta`. Neither carries a stability guarantee.

## Notes

Context: https://github.com/sanity-io/plugins/issues/1946, fixed by the revert in #1954 and released as `@sanity/orderable-document-list@2.0.23`. This PR doesn't close that issue.

Tracked in SAPP-4378.
