### PR TITLE
fix(internationalized-array): seed defaultLanguages on new documents

### DIFF
--- a/.changeset/internationalized-array-default-languages-new-docs.md
+++ b/.changeset/internationalized-array-default-languages-new-docs.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Seed `defaultLanguages` rows when opening a new document, not only after the first edit. Deleted documents are still not recreated.

--- a/e2e/helpers/internationalized-array/internationalizedArray.ts
+++ b/e2e/helpers/internationalized-array/internationalizedArray.ts
@@ -39,7 +39,7 @@ function item(language: string, value = ''): I18nArrayItem {
 /**
  * Create an i18nPost draft via the Content Lake API.
  * Pass `title` / `summary` arrays explicitly — use `[]` when testing
- * `defaultLanguages` seeding (requires a persisted `_rev`).
+ * `defaultLanguages` seeding on a persisted document.
  */
 export async function seedI18nPost(
   projectName: string | undefined,

--- a/e2e/tests/internationalized-array/internationalized-array.spec.ts
+++ b/e2e/tests/internationalized-array/internationalized-array.spec.ts
@@ -13,8 +13,7 @@ import {
 
 test.describe('sanity-plugin-internationalized-array', () => {
   /**
-   * `defaultLanguages` only auto-seeds after the document exists in the
-   * dataset (`_rev`). Opening a persisted empty array must create the EN item.
+   * `defaultLanguages` auto-seeds missing EN rows on persisted empty arrays.
    */
   test('seeds default language on an existing empty document', async ({page}, testInfo) => {
     const projectName = testInfo.project.name
@@ -28,6 +27,28 @@ test.describe('sanity-plugin-internationalized-array', () => {
       await expect(fieldAddButton(page, 'en')).toHaveAttribute('data-disabled', 'true')
     } finally {
       await deleteI18nPost(projectName, doc.id)
+    }
+  })
+
+  /**
+   * SAPP-4422: `defaultLanguages` must seed EN on a brand-new form, before
+   * the document has a `_rev`. Opening create and waiting is enough — do not
+   * type into another field first.
+   */
+  test('seeds default language on a new unsaved document', async ({page}, testInfo) => {
+    const projectName = testInfo.project.name
+    await page.goto('intent/create/template=i18nPost;type=i18nPost')
+    await expect(page.getByTestId('studio-navbar')).toBeVisible()
+    await expect(page.getByTestId('form-view').first()).toBeVisible()
+
+    try {
+      await expect(languageLabel(page, 'en', 'title')).toBeVisible()
+      await expect(languageLabel(page, 'en', 'summary')).toBeVisible()
+    } finally {
+      const docId = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.exec(
+        decodeURIComponent(page.url()),
+      )?.[0]
+      if (docId) await deleteI18nPost(projectName, docId)
     }
   })
 
@@ -145,8 +166,8 @@ test.describe('sanity-plugin-internationalized-array', () => {
         .locator('[data-ui="Label"]')
         .filter({hasText: /^(EN|FR)$/})
       await expect(codeLabels.first()).toHaveText('EN')
-      // That patch persists the draft (`_rev`), so defaultLanguages can seed
-      // EN on the untouched summary field.
+      // restoreOrder and defaultLanguages may both patch; summary EN must
+      // appear without a manual edit (SAPP-4422).
       await expect(languageLabel(page, 'en', 'summary')).toBeVisible()
       await expect(page.getByText('Attempted to patch a read-only document')).toHaveCount(0)
     } finally {

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.test.tsx
@@ -67,12 +67,18 @@ vi.mock('./Feedback', () => ({
 }))
 
 import {useLanguageFilterStudioContext} from '@sanity/language-filter'
+import type {ContextType} from 'react'
 import {useFormValue} from 'sanity'
+import {EventsContext} from 'sanity/_singletons'
 import {useDocumentPane} from 'sanity/structure'
 
 import {ThemeWrapper} from '../test/component-helpers'
 import InternationalizedArray from './InternationalizedArray'
 import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
+
+type EventsStub = {events: unknown[]; loading: boolean}
+
+const PRISTINE_EVENTS: EventsStub = {events: [], loading: false}
 
 /**
  * Creates minimal mock ArrayOfObjectsInputProps for InternationalizedArray.
@@ -89,13 +95,32 @@ function createMockArrayProps(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function renderInternationalizedArray(props: ReturnType<typeof createMockArrayProps>) {
-  mockGetFormValue.mockImplementation(() => props.value)
-  return render(
-    // @ts-expect-error - simplified mock props
-    <InternationalizedArray {...props} />,
-    {wrapper: ThemeWrapper},
+function eventsProviderValue(events: EventsStub | null): ContextType<typeof EventsContext> {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- test stub of EventsStore
+  return events as ContextType<typeof EventsContext>
+}
+
+function withEvents(
+  props: ReturnType<typeof createMockArrayProps>,
+  events: EventsStub | null = PRISTINE_EVENTS,
+) {
+  return (
+    <EventsContext.Provider
+      // oxlint-disable-next-line react/jsx-no-constructed-context-values -- test stub
+      value={eventsProviderValue(events)}
+    >
+      {/* @ts-expect-error - simplified mock props */}
+      <InternationalizedArray {...props} />
+    </EventsContext.Provider>
   )
+}
+
+function renderInternationalizedArray(
+  props: ReturnType<typeof createMockArrayProps>,
+  events: EventsStub | null = PRISTINE_EVENTS,
+) {
+  mockGetFormValue.mockImplementation(() => props.value)
+  return render(withEvents(props, events), {wrapper: ThemeWrapper})
 }
 
 describe('InternationalizedArray', () => {
@@ -519,9 +544,7 @@ describe('InternationalizedArray', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  test('does not auto-add default languages when the document does not exist yet (no _rev)', async () => {
-    // _type resolves as usual, but the document has no revision: it is either
-    // brand new (unsaved) or was just deleted while the pane is still open
+  test('auto-adds default languages on a pristine new document (no _rev, no events)', async () => {
     vi.mocked(useFormValue).mockImplementation((path) =>
       Array.isArray(path) && path[0] === '_rev' ? undefined : 'article',
     )
@@ -534,11 +557,84 @@ describe('InternationalizedArray', () => {
     const onChange = vi.fn()
     const props = createMockArrayProps({onChange})
 
-    renderInternationalizedArray(props)
+    renderInternationalizedArray(props, {events: [], loading: false})
 
-    // Allow the scheduled setTimeout in the useEffect to fire
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalled()
+    })
+  })
+
+  test('does not auto-add default languages while events are still loading', async () => {
+    vi.mocked(useFormValue).mockImplementation((path) =>
+      Array.isArray(path) && path[0] === '_rev' ? undefined : 'article',
+    )
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props, {events: [], loading: true})
+
     await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onChange).not.toHaveBeenCalled()
+  })
 
+  test('does not auto-add default languages when opening a deleted document with history', async () => {
+    // Fresh pane on a deleted id: no `_rev`, but the events store already
+    // knows the document existed (delete / prior edits). isDeleted can still
+    // be false for a tick.
+    vi.mocked(useFormValue).mockImplementation((path) =>
+      Array.isArray(path) && path[0] === '_rev' ? undefined : 'article',
+    )
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const props = createMockArrayProps({onChange})
+
+    renderInternationalizedArray(props, {
+      events: [{type: 'deleteDocumentVersion'}],
+      loading: false,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('does not auto-add default languages after a persisted document loses its _rev', async () => {
+    let revision: string | undefined = 'rev-1'
+    vi.mocked(useFormValue).mockImplementation((path) =>
+      Array.isArray(path) && path[0] === '_rev' ? revision : 'article',
+    )
+
+    vi.mocked(useInternationalizedArrayContext).mockReturnValue({
+      ...MOCK_INTERNATIONALIZED_ARRAY_CONTEXT,
+      defaultLanguages: ['en'],
+    })
+
+    const onChange = vi.fn()
+    const history = [{type: 'createDocumentVersion'}, {type: 'deleteDocumentVersion'}]
+    const existing = createMockArrayProps({onChange, value: createValues(['en'])})
+    const {rerender} = renderInternationalizedArray(existing, {
+      events: history,
+      loading: false,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(onChange).not.toHaveBeenCalled()
+
+    revision = undefined
+    const deleted = createMockArrayProps({onChange, value: undefined})
+    rerender(withEvents(deleted, {events: history, loading: false}))
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -638,10 +734,7 @@ describe('InternationalizedArray', () => {
 
     // Same mounted instance: the document pane flips loading in place.
     loading = false
-    rerender(
-      // @ts-expect-error - simplified mock props
-      <InternationalizedArray {...props} />,
-    )
+    rerender(withEvents(props))
 
     act(() => {
       vi.runAllTimers()

--- a/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
+++ b/plugins/sanity-plugin-internationalized-array/src/components/InternationalizedArray.tsx
@@ -3,7 +3,7 @@ import {useLanguageFilterStudioContext} from '@sanity/language-filter'
 import {Button, Card, Stack, Text} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
 import type React from 'react'
-import {useCallback, useEffect, useMemo} from 'react'
+import {useCallback, useContext, useEffect, useMemo} from 'react'
 import {
   type ArrayOfObjectsInputProps,
   ArrayOfObjectsItem,
@@ -13,6 +13,7 @@ import {
   useFormValue,
   useGetFormValue,
 } from 'sanity'
+import {EventsContext} from 'sanity/_singletons'
 import {useDocumentPane} from 'sanity/structure'
 
 import {LANGUAGE_FIELD_NAME} from '../constants'
@@ -27,6 +28,23 @@ import {useInternationalizedArrayContext} from './InternationalizedArrayContext'
 import {MigrationBanner} from './MigrationBanner'
 
 /**
+ * The events store has finished loading and recorded no history. That is a
+ * brand-new document.
+ *
+ * `sanity/_singletons` is internal; this is the same context `useEvents()`
+ * reads. Using the context directly avoids throwing when the events API is
+ * off (legacy timeline has no `EventsProvider`).
+ */
+function isPristineDocument(
+  events: {events: readonly unknown[]; loading: boolean} | null,
+): boolean {
+  if (!events || events.loading) {
+    return false
+  }
+  return events.events.length === 0
+}
+
+/**
  * Main array input component for internationalized array fields.
  *
  * Replaces the default Sanity array input and manages the full lifecycle of
@@ -39,14 +57,14 @@ import {MigrationBanner} from './MigrationBanner'
  *   missing languages" button (controlled by `buttonAddAll` and
  *   `buttonLocations` config). Dispatches `setIfMissing` + `insert` patches.
  * - **Default languages**: Automatically adds entries for languages listed in
- *   `defaultLanguages` when those entries are missing. Only runs once the
- *   document exists in the dataset (it has a `_rev`) **and** the document is
- *   writable — newly created documents stay read-only until initial value
- *   templates resolve, and the field-level `readOnly` prop can lag that
- *   document-level lock. Skipping the patch until both are ready avoids
- *   "Attempted to patch a read-only document" toasts. The `_rev` guard also
- *   prevents recreating a just-deleted document or creating a draft before
- *   the user's first edit.
+ *   `defaultLanguages` when those entries are missing. Seeds brand-new
+ *   documents once the events store reports they are pristine (no history),
+ *   and seeds persisted documents that already have a `_rev`. A document
+ *   that existed and was deleted is not pristine, so opening it — even in a
+ *   fresh pane — does not recreate it. Newly created documents stay
+ *   read-only until initial value templates resolve, and the field-level
+ *   `readOnly` prop can lag that document-level lock. Skipping the patch
+ *   until writable avoids "Attempted to patch a read-only document" toasts.
  * - **Ordering**: When `restoreOrder` is enabled (default), detects when value
  *   items are out of order relative to the master `languages` list and
  *   automatically re-sorts them. Set `restoreOrder: false` to keep the stored
@@ -76,7 +94,6 @@ export default function InternationalizedArray(
     restoreOrder,
     languageFilter: builtInLanguageFilter,
   } = useInternationalizedArrayContext()
-
   // Support updating the UI if languageFilter is installed
   const {selectedLanguageIds, options: languageFilterOptions} = useLanguageFilterStudioContext()
   const documentType = useFormValue(['_type'])
@@ -167,12 +184,13 @@ export default function InternationalizedArray(
     [filteredLanguages, languages, onChange, schemaType, getFormValue, props.path, readOnly],
   )
 
-  // The document only has a revision once it exists in the dataset. Patching
-  // a nonexistent document would create it: auto-adding default languages to
-  // a just-deleted document resurrects it as an empty draft (and the deleted
-  // pane can outrace `isDeleted`), and auto-adding to an unsaved new document
-  // creates a draft before the user has made any edits.
+  // `_rev` means the document is in the dataset. No `_rev` is either a
+  // brand-new form or a deleted one. The events store distinguishes those:
+  // pristine (loaded, zero events) has never existed; any history means it
+  // did — including a fresh open of a deleted id, where this pane never saw
+  // a `_rev`.
   const documentExists = Boolean(useFormValue(['_rev']))
+  const isPristine = isPristineDocument(useContext(EventsContext))
 
   // Create a stable dependency string that only changes when language keys change
   const languageKeysFromValue = value
@@ -194,7 +212,7 @@ export default function InternationalizedArray(
       .every((language) => addedLanguages.includes(language))
 
     if (
-      documentExists &&
+      (isPristine || documentExists) &&
       !isDeleting &&
       !isDeleted &&
       !hasAddedDefaultLanguages &&
@@ -212,6 +230,7 @@ export default function InternationalizedArray(
     }
     return undefined
   }, [
+    isPristine,
     documentExists,
     isDeleted,
     isDeleting,


### PR DESCRIPTION
Fixes [SAPP-4422](https://linear.app/sanity/issue/SAPP-4422/internationalized-array-defaultlanguages-default-language-rows-not).

## Description

[#965](https://github.com/sanity-io/plugins/pull/965) gated auto-add on `_rev` so a deleted document could not be patched back into existence. That also blocked `defaultLanguages` on new forms: editors only saw “+ English (Default)” until they typed in another field.

`_rev` cannot tell a brand-new document from a deleted one opened in a fresh pane. This change seeds when the document already has a `_rev`, or when the events store has loaded and reports no history. Deleted documents (history, no `_rev`) and events that are still loading are not seeded. Read-only and migration guards are unchanged. If the events API is off, seeding still requires `_rev`.

## What to review

- `InternationalizedArray` seeds on pristine create or existing `_rev`, not on deleted ids.
- Unit tests for pristine create, events still loading, deleted-with-history, and `_rev` lost after delete.
- E2E create intent asserts EN on `title` and `summary` without a first edit.

## Testing

- [x] Unit tests for the new vs deleted distinction
- [x] E2E create-flow (`i18nPost`) without typing first

## Notes for release

`defaultLanguages` now seed as soon as a new document form opens, matching the README. Deleted documents are still not recreated.