### PR TITLE
fix(ci): pin npm 11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
           check-latest: true
           node-version: lts/*
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        # npm 12 wraps `pnpm info --json`; @changesets/cli 3.0.1 does not unwrap it (changesets/changesets#2274)
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin the release workflow to `npm@11` instead of `npm@latest`.

`npm@latest` is now 12. pnpm 10's `pnpm info --json` pass-through plus `@changesets/cli@3.0.1` does not unwrap npm 12's array-wrapped output, so `changeset publish` crashes:

`TypeError: Cannot read properties of undefined (reading 'includes')` at `getPublishPlan.mjs:613`

Confirmed on sanity-io/visual-editing run 33517457076. Trusted publishing still needs npm >= 11.5.1.

https://github.com/changesets/changesets/issues/2274

No other workflow changes. `@changesets/*` not bumped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a370e358-99ee-430d-9286-2003a9ad8bc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a370e358-99ee-430d-9286-2003a9ad8bc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

