### PR TITLE
docs(personalization-plugin): fix broken readme cross-links

### DIFF
--- a/.changeset/personalization-readme-links.md
+++ b/.changeset/personalization-readme-links.md
@@ -1,0 +1,5 @@
+---
+'@sanity/personalization-plugin': patch
+---
+
+Fix broken links between the plugin readme and the GrowthBook/LaunchDarkly guides

--- a/plugins/@sanity/personalization-plugin/README.md
+++ b/plugins/@sanity/personalization-plugin/README.md
@@ -49,9 +49,9 @@ Once configured you can query the values using the ids of the experiment and var
     - [Querying with Custom Field Names](#querying-with-custom-field-names)
   - [License](#license)
 
-> For Specific information about the Growthbook FieldLevel export see its [readme](/growthbook.md)
+> For Specific information about the Growthbook FieldLevel export see its [readme](./growthbook.md)
 >
-> For Specific information about the LaunchDarkly FieldLevel export see its [readme](/launchdarkly.md)
+> For Specific information about the LaunchDarkly FieldLevel export see its [readme](./launchdarkly.md)
 
 ## Installation
 
@@ -601,7 +601,7 @@ export default async function Page() {
 
 ### Third-Party Integration
 
-For advanced use cases, you can integrate with experimentation platforms like GrowthBook, LaunchDarkly, or Amplitude. These platforms handle variant assignment and provide analytics. See the [GrowthBook](/growthbook.md) and [LaunchDarkly](/launchdarkly.md) integration guides for details.
+For advanced use cases, you can integrate with experimentation platforms like GrowthBook, LaunchDarkly, or Amplitude. These platforms handle variant assignment and provide analytics. See the [GrowthBook](./growthbook.md) and [LaunchDarkly](./launchdarkly.md) integration guides for details.
 
 ## Split testing (URL-based)
 

--- a/plugins/@sanity/personalization-plugin/growthbook.md
+++ b/plugins/@sanity/personalization-plugin/growthbook.md
@@ -13,10 +13,10 @@ This plugin allows users to add a/b/n testing experiments to individual fields c
 
 This plugin is built on top of the `fieldLevelExperiments` export so see the main readme for details of:
 
-- [Using complex field configurations](/#using-complex-field-configurations)
-- [Validation of individual array items](/#validation-of-individual-array-items)
-- [Shape of stored data](/#shape-of-stored-data)
-- [Querying data](/#querying-data)
+- [Using complex field configurations](./README.md#using-complex-field-configurations)
+- [Validation of individual array items](./README.md#validation-of-individual-array-items)
+- [Shape of stored data](./README.md#shape-of-stored-data)
+- [Querying data](./README.md#querying-data)
 
 ## Installation
 

--- a/plugins/@sanity/personalization-plugin/launchdarkly.md
+++ b/plugins/@sanity/personalization-plugin/launchdarkly.md
@@ -13,10 +13,10 @@ This plugin allows users to add a/b/n testing experiments to individual fields c
 
 This plugin is built on top of the `fieldLevelExperiments` export so see the main readme for details of:
 
-- [Using complex field configurations](/#using-complex-field-configurations)
-- [Validation of individual array items](/#validation-of-individual-array-items)
-- [Shape of stored data](/#shape-of-stored-data)
-- [Querying data](/#querying-data)
+- [Using complex field configurations](./README.md#using-complex-field-configurations)
+- [Validation of individual array items](./README.md#validation-of-individual-array-items)
+- [Shape of stored data](./README.md#shape-of-stored-data)
+- [Querying data](./README.md#querying-data)
 
 ## Installation
 


### PR DESCRIPTION
## What

The GrowthBook and LaunchDarkly guide links in the personalization plugin README were 404ing. They used root-absolute paths (`/growthbook.md`), which GitHub resolves against the repo root rather than the plugin directory.

The same bug existed in the other direction: `growthbook.md` and `launchdarkly.md` both link back to the main readme's sections as `/#using-complex-field-configurations` etc., which resolve to anchors on the monorepo root README.

## Changes

- `README.md` — 4 links: `/growthbook.md` → `./growthbook.md`, `/launchdarkly.md` → `./launchdarkly.md` (the callout under the TOC, and the "Third-Party Integration" section)
- `growthbook.md` / `launchdarkly.md` — the four "see the main readme for details of" links now point at `./README.md#...`

All four target headings were verified to exist in the plugin README.

Docs-only change; added a `patch` changeset since the README ships with the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes with no runtime, security, or data-handling changes.
> 
> **Overview**
> Fixes **404ing documentation links** in `@sanity/personalization-plugin` by switching from repo-root paths to paths relative to the plugin folder.
> 
> The main **README** now links to `./growthbook.md` and `./launchdarkly.md` (TOC callout and Third-Party Integration). **growthbook.md** and **launchdarkly.md** link back to `./README.md#...` for shared field-level topics instead of `/#...` anchors on the monorepo root README.
> 
> Adds a **patch** changeset because the README ships with the published package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed1b71145e7279212a8c22906fccda0c8dd267d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->