### PR TITLE
fix(sanity-plugin-internationalized-array): read field values from pane formState on Sanity 6

### DIFF
--- a/.changeset/internationalized-array-field-action-sanity-6.md
+++ b/.changeset/internationalized-array-field-action-sanity-6.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-internationalized-array": patch
+---
+
+Read internationalized array values from the document pane `formState` so field actions work on Sanity 6, where `useFormValue` is unavailable outside `FormValueProvider`.

--- a/plugins/sanity-plugin-internationalized-array/README.md
+++ b/plugins/sanity-plugin-internationalized-array/README.md
@@ -126,7 +126,7 @@ languages: async (client, {market = ``}) => {
 The "Add translation" buttons can be positioned in one or multiple locations by configuring `buttonLocations`:
 
 - `field` (default) Below the internationalized array field
-- `unstable__fieldAction` Inside a Field Action (currently unstable)
+- `unstable__fieldAction` Inside a Field Action (currently unstable). On Sanity 6 these actions read the current field value from the document pane, because they render outside `FormValueProvider` and cannot call `useFormValue`.
 - `document` Above the document fields, these buttons will add a new language item to every internationalized array field that can be found at the **root of the document**. Nested internationalized arrays are not yet supported.
 
 To control the "Add translation" button titles, configure `languageDisplay`. This also affects language field labels.

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
@@ -423,6 +423,31 @@ describe('internationalizedArrayFieldAction', () => {
     expect(actions[3]!.disabled).toBe(false)
   })
 
+  test('treats a non-array value at the field path as missing', () => {
+    mockFormState = {value: {translations: {not: 'an-array'}}}
+
+    const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
+
+    const fieldGroup = result.current.type === 'group' ? result.current : undefined
+    if (!fieldGroup) {
+      throw new Error('Field group not found')
+    }
+
+    fieldGroup.children
+      .slice(0, 4)
+      .filter(isActionItem)
+      .forEach((action) => {
+        expect(action.disabled).toBe(false)
+      })
+
+    const addMissing = fieldGroup.children[fieldGroup.children.length - 1]!
+    if (!isActionItem(addMissing)) {
+      throw new Error('Add missing action is not an action item')
+    }
+    expect(addMissing.hidden).toBe(false)
+    expect(addMissing.title).toBe('Add all languages')
+  })
+
   test('add-missing action disabled when document is readOnly', () => {
     mockFormState = {readOnly: true}
 

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.test.ts
@@ -11,17 +11,8 @@ import {LANGUAGE_FIELD_NAME} from '../constants'
 import {createValues, MOCK_INTERNATIONALIZED_ARRAY_CONTEXT, MOCK_LANGUAGES} from '../test/helpers'
 import {internationalizedArrayFieldAction} from './index'
 
-const mockUseFormValue = vi.fn()
 const mockOnChange = vi.fn()
 let mockFormState: Record<string, unknown> | undefined
-
-vi.mock('sanity', async (importOriginal) => {
-  const original = await importOriginal<typeof import('sanity')>()
-  return {
-    ...original,
-    useFormValue: (...args: unknown[]) => mockUseFormValue(...args),
-  }
-})
 
 vi.mock('sanity/structure', () => ({
   useDocumentPane: vi.fn(() => ({
@@ -29,6 +20,13 @@ vi.mock('sanity/structure', () => ({
     formState: mockFormState,
   })),
 }))
+
+function setFieldValue(value: unknown, extras: Record<string, unknown> = {}) {
+  mockFormState = {
+    ...extras,
+    value: {translations: value},
+  }
+}
 
 vi.mock('../components/InternationalizedArrayContext', () => ({
   useInternationalizedArrayContext: vi.fn(() => ({
@@ -60,7 +58,6 @@ const isActionItem = (action: DocumentFieldActionNode): action is DocumentFieldA
 
 describe('internationalizedArrayFieldAction', () => {
   beforeEach(() => {
-    mockUseFormValue.mockReturnValue(undefined)
     mockOnChange.mockClear()
     mockFormState = undefined
     vi.mocked(useInternationalizedArrayContext).mockReturnValue(
@@ -133,7 +130,7 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('translate action disabled when language exists in value via LANGUAGE_FIELD_NAME', () => {
     const value = createValues(['en', 'fr'])
-    mockUseFormValue.mockReturnValue(value)
+    setFieldValue(value)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -149,7 +146,7 @@ describe('internationalizedArrayFieldAction', () => {
   })
 
   test('all translate actions enabled when value is undefined', () => {
-    mockUseFormValue.mockReturnValue(undefined)
+    setFieldValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -188,7 +185,7 @@ describe('internationalizedArrayFieldAction', () => {
   })
 
   test('translate action onAction calls onChange with setIfMissing and insert patches', () => {
-    mockUseFormValue.mockReturnValue(undefined)
+    setFieldValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -233,7 +230,7 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('add-missing action hidden when all languages present', () => {
     const value = createValues(['en', 'fr', 'es', 'de'])
-    mockUseFormValue.mockReturnValue(value)
+    setFieldValue(value)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -250,7 +247,7 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('add-missing action not hidden when languages are missing', () => {
     const value = createValues(['en'])
-    mockUseFormValue.mockReturnValue(value)
+    setFieldValue(value)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -267,7 +264,7 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('add-missing action disabled when all filtered languages in value', () => {
     const value = createValues(['en', 'fr', 'es', 'de'])
-    mockUseFormValue.mockReturnValue(value)
+    setFieldValue(value)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
     const fieldGroup = result.current.type === 'group' ? result.current : undefined
@@ -282,7 +279,7 @@ describe('internationalizedArrayFieldAction', () => {
   })
 
   test('add-missing action not disabled when languages are missing', () => {
-    mockUseFormValue.mockReturnValue(undefined)
+    setFieldValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -298,7 +295,7 @@ describe('internationalizedArrayFieldAction', () => {
   })
 
   test('add-missing action title says "Add all languages" when no value', () => {
-    mockUseFormValue.mockReturnValue(undefined)
+    setFieldValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -315,7 +312,7 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('add-missing onAction calls onChange with patches for all missing languages', () => {
     const value = createValues(['en'])
-    mockUseFormValue.mockReturnValue(value)
+    setFieldValue(value)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -386,7 +383,6 @@ describe('internationalizedArrayFieldAction', () => {
 
   test('all translate actions disabled when document is readOnly', () => {
     mockFormState = {readOnly: true}
-    mockUseFormValue.mockReturnValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 
@@ -400,9 +396,35 @@ describe('internationalizedArrayFieldAction', () => {
     })
   })
 
+  test('reads field value from pane formState at a keyed nested path', () => {
+    const value = createValues(['en', 'fr'])
+    mockFormState = {
+      value: {
+        modules: [{_key: 'hero', translations: value}],
+      },
+    }
+
+    const {result} = renderHook(() =>
+      fieldAction.useAction(
+        createMockFieldActionProps({
+          path: ['modules', {_key: 'hero'}, 'translations'],
+        }),
+      ),
+    )
+
+    const fieldGroup = result.current.type === 'group' ? result.current : undefined
+    if (!fieldGroup) {
+      throw new Error('Field group not found')
+    }
+    const actions = fieldGroup.children.slice(0, 4).filter(isActionItem)
+    expect(actions[0]!.disabled).toBe(true)
+    expect(actions[1]!.disabled).toBe(true)
+    expect(actions[2]!.disabled).toBe(false)
+    expect(actions[3]!.disabled).toBe(false)
+  })
+
   test('add-missing action disabled when document is readOnly', () => {
     mockFormState = {readOnly: true}
-    mockUseFormValue.mockReturnValue(undefined)
 
     const {result} = renderHook(() => fieldAction.useAction(createMockFieldActionProps()))
 

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
@@ -37,6 +37,16 @@ function valueAtPath(doc: unknown, path: Path): unknown {
   return node
 }
 
+function internationalizedArrayValueAtPath(
+  doc: unknown,
+  path: Path,
+): InternationalizedArrayItem[] | undefined {
+  const raw = valueAtPath(doc, path)
+  if (!Array.isArray(raw)) return undefined
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return raw as InternationalizedArrayItem[]
+}
+
 type FieldActionContext = {
   languages: Language[]
   filteredLanguages: Language[]
@@ -119,10 +129,7 @@ export const internationalizedArrayFieldAction = defineDocumentFieldAction({
       fieldActionProps?.schemaType?.type?.name.startsWith('internationalizedArray')
     const {languages, filteredLanguages} = useInternationalizedArrayContext()
     const {onChange, formState} = useDocumentPane()
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    const value = valueAtPath(formState?.value, fieldActionProps.path) as
-      | InternationalizedArrayItem[]
-      | undefined
+    const value = internationalizedArrayValueAtPath(formState?.value, fieldActionProps.path)
     const context: FieldActionContext = {
       languages,
       filteredLanguages,

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
@@ -5,9 +5,9 @@ import {
   defineDocumentFieldAction,
   type DocumentFieldActionItem,
   type DocumentFieldActionProps,
+  type Path,
   PatchEvent,
   setIfMissing,
-  useFormValue,
 } from 'sanity'
 import {useDocumentPane} from 'sanity/structure'
 
@@ -18,6 +18,26 @@ import {checkAllLanguagesArePresent} from '../utils/checkAllLanguagesArePresent'
 import {createAddAllTitle} from '../utils/createAddAllTitle'
 import {createAddLanguagePatches} from '../utils/createAddLanguagePatches'
 
+/**
+ * Read `path` out of a document value. Field actions render outside the
+ * `FormValueProvider` on Sanity 6, so `useFormValue` cannot be used there; the
+ * pane's `formState.value` is the same document and is always available.
+ */
+function valueAtPath(doc: unknown, path: Path): unknown {
+  let node: unknown = doc
+  for (const seg of path || []) {
+    if (node == null) return undefined
+    if (typeof seg === 'string' || typeof seg === 'number') {
+      node = (node as Record<string | number, unknown>)[seg]
+    } else if (seg && typeof seg === 'object' && '_key' in seg && Array.isArray(node)) {
+      node = node.find((item) => item && (item as {_key?: string})._key === seg._key)
+    } else {
+      return undefined
+    }
+  }
+  return node
+}
+
 const createTranslateFieldActions: (
   fieldActionProps: DocumentFieldActionProps,
   context: {
@@ -26,9 +46,9 @@ const createTranslateFieldActions: (
   },
 ) => DocumentFieldActionItem[] = (fieldActionProps, {languages, filteredLanguages}) =>
   languages.map((language) => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
     const {onChange, formState} = useDocumentPane()
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    const value = valueAtPath(formState?.value, fieldActionProps.path) as InternationalizedArrayItem[]
     const disabled =
       Boolean(formState?.readOnly) ||
       (value && Array.isArray(value)
@@ -69,9 +89,9 @@ const AddMissingTranslationsFieldAction: (
     filteredLanguages: Language[]
   },
 ) => DocumentFieldActionItem = (fieldActionProps, {languages, filteredLanguages}) => {
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const value = useFormValue(fieldActionProps.path) as InternationalizedArrayItem[]
   const {onChange, formState} = useDocumentPane()
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  const value = valueAtPath(formState?.value, fieldActionProps.path) as InternationalizedArrayItem[]
   const disabled =
     Boolean(formState?.readOnly) || (value && value.length === filteredLanguages.length)
   const hidden = checkAllLanguagesArePresent(filteredLanguages, value)

--- a/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
+++ b/plugins/sanity-plugin-internationalized-array/src/fieldActions/index.ts
@@ -1,6 +1,5 @@
 import {AddIcon} from '@sanity/icons/Add'
 import {TranslateIcon} from '@sanity/icons/Translate'
-import {useCallback} from 'react'
 import {
   defineDocumentFieldAction,
   type DocumentFieldActionItem,
@@ -38,28 +37,64 @@ function valueAtPath(doc: unknown, path: Path): unknown {
   return node
 }
 
-const createTranslateFieldActions: (
+type FieldActionContext = {
+  languages: Language[]
+  filteredLanguages: Language[]
+  value: InternationalizedArrayItem[] | undefined
+  readOnly: boolean
+  onChange: (event: PatchEvent) => void
+}
+
+const createTranslateFieldActions = (
   fieldActionProps: DocumentFieldActionProps,
-  context: {
-    languages: Language[]
-    filteredLanguages: Language[]
-  },
-) => DocumentFieldActionItem[] = (fieldActionProps, {languages, filteredLanguages}) =>
+  {languages, filteredLanguages, value, readOnly, onChange}: FieldActionContext,
+): DocumentFieldActionItem[] =>
   languages.map((language) => {
-    const {onChange, formState} = useDocumentPane()
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-    const value = valueAtPath(formState?.value, fieldActionProps.path) as InternationalizedArrayItem[]
     const disabled =
-      Boolean(formState?.readOnly) ||
+      readOnly ||
       (value && Array.isArray(value)
         ? Boolean(value?.find((item) => item[LANGUAGE_FIELD_NAME] === language.id))
         : false)
     const hidden = !filteredLanguages.some((f) => f.id === language.id)
 
-    const onAction = useCallback(() => {
+    return {
+      type: 'action',
+      icon: AddIcon,
+      onAction: () => {
+        const {schemaType, path} = fieldActionProps
+
+        const addLanguageKeys = [language.id]
+        const patches = createAddLanguagePatches({
+          addLanguageKeys,
+          schemaTypeName: schemaType.name,
+          languages,
+          filteredLanguages,
+          value,
+          path,
+        })
+
+        onChange(PatchEvent.from([setIfMissing([], path), ...patches]))
+      },
+      title: language.title,
+      hidden,
+      disabled,
+    }
+  })
+
+const createAddMissingTranslationsFieldAction = (
+  fieldActionProps: DocumentFieldActionProps,
+  {languages, filteredLanguages, value, readOnly, onChange}: FieldActionContext,
+): DocumentFieldActionItem => {
+  const disabled = readOnly || Boolean(value && value.length === filteredLanguages.length)
+  const hidden = checkAllLanguagesArePresent(filteredLanguages, value)
+
+  return {
+    type: 'action',
+    icon: AddIcon,
+    onAction: () => {
       const {schemaType, path} = fieldActionProps
 
-      const addLanguageKeys = [language.id]
+      const addLanguageKeys: string[] = []
       const patches = createAddLanguagePatches({
         addLanguageKeys,
         schemaTypeName: schemaType.name,
@@ -70,52 +105,7 @@ const createTranslateFieldActions: (
       })
 
       onChange(PatchEvent.from([setIfMissing([], path), ...patches]))
-    }, [language.id, value, onChange])
-
-    return {
-      type: 'action',
-      icon: AddIcon,
-      onAction,
-      title: language.title,
-      hidden,
-      disabled,
-    }
-  })
-
-const AddMissingTranslationsFieldAction: (
-  fieldActionProps: DocumentFieldActionProps,
-  context: {
-    languages: Language[]
-    filteredLanguages: Language[]
-  },
-) => DocumentFieldActionItem = (fieldActionProps, {languages, filteredLanguages}) => {
-  const {onChange, formState} = useDocumentPane()
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  const value = valueAtPath(formState?.value, fieldActionProps.path) as InternationalizedArrayItem[]
-  const disabled =
-    Boolean(formState?.readOnly) || (value && value.length === filteredLanguages.length)
-  const hidden = checkAllLanguagesArePresent(filteredLanguages, value)
-
-  const onAction = useCallback(() => {
-    const {schemaType, path} = fieldActionProps
-
-    const addLanguageKeys: string[] = []
-    const patches = createAddLanguagePatches({
-      addLanguageKeys,
-      schemaTypeName: schemaType.name,
-      languages,
-      filteredLanguages,
-      value,
-      path,
-    })
-
-    onChange(PatchEvent.from([setIfMissing([], path), ...patches]))
-  }, [fieldActionProps, filteredLanguages, languages, onChange, value])
-
-  return {
-    type: 'action',
-    icon: AddIcon,
-    onAction,
+    },
     title: createAddAllTitle(value, filteredLanguages),
     disabled,
     hidden,
@@ -128,11 +118,18 @@ export const internationalizedArrayFieldAction = defineDocumentFieldAction({
     const isInternationalizedArrayField =
       fieldActionProps?.schemaType?.type?.name.startsWith('internationalizedArray')
     const {languages, filteredLanguages} = useInternationalizedArrayContext()
-
-    const translateFieldActions = createTranslateFieldActions(fieldActionProps, {
+    const {onChange, formState} = useDocumentPane()
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    const value = valueAtPath(formState?.value, fieldActionProps.path) as
+      | InternationalizedArrayItem[]
+      | undefined
+    const context: FieldActionContext = {
       languages,
       filteredLanguages,
-    })
+      value,
+      readOnly: Boolean(formState?.readOnly),
+      onChange,
+    }
 
     return {
       type: 'group',
@@ -141,11 +138,8 @@ export const internationalizedArrayFieldAction = defineDocumentFieldAction({
       renderAsButton: true,
       children: isInternationalizedArrayField
         ? [
-            ...translateFieldActions,
-            AddMissingTranslationsFieldAction(fieldActionProps, {
-              languages,
-              filteredLanguages,
-            }),
+            ...createTranslateFieldActions(fieldActionProps, context),
+            createAddMissingTranslationsFieldAction(fieldActionProps, context),
           ]
         : [],
       hidden: !isInternationalizedArrayField,


### PR DESCRIPTION
## Summary

- Field actions from `buttonLocations: ['unstable__fieldAction']` render **outside** `FormValueProvider` on Sanity 6.
- Calling `useFormValue()` there throws `useFormValue must be used within a FormValueProvider` and takes down the whole document editor.
- Read the same document from `useDocumentPane().formState.value` (via a small `valueAtPath` walker that supports string, number, and `{_key}` segments) so the documented [add translation buttons](https://github.com/sanity-io/plugins/tree/main/plugins/sanity-plugin-internationalized-array#configuring-the-add-translation-buttons) config works again.

This is the source-level equivalent of a pnpm patch we have been shipping against `sanity-plugin-internationalized-array@5.2.3`.

## Test plan

- [x] Updated `fieldActions` unit tests to supply values through pane `formState` instead of mocking `useFormValue`
- [x] Added a keyed nested-path case (`modules[_key=hero].translations`)
- [x] In Studio 6 with `buttonLocations: ['unstable__fieldAction', 'document']`, open a document that has an `internationalizedArray*` field
- [x] Confirm the field-action menu no longer crashes the document editor
- [x] Add a missing language from the field action and confirm the array item is inserted


Made with [Cursor](https://cursor.com)