### PR TITLE
fix(sanity-plugin-media): keep Media epics alive under React strict mode

### DIFF
--- a/.changeset/media-strict-mode-epic-end.md
+++ b/.changeset/media-strict-mode-epic-end.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-media": patch
+---
+
+Keep Media tool epics alive across React strict mode's simulated remount so the browser loads in `sanity dev`.

--- a/plugins/sanity-plugin-media/src/components/ReduxProvider/ReduxProvider.test.tsx
+++ b/plugins/sanity-plugin-media/src/components/ReduxProvider/ReduxProvider.test.tsx
@@ -1,0 +1,101 @@
+import {type Store} from '@reduxjs/toolkit'
+import {act, cleanup, render} from '@testing-library/react'
+import {StrictMode, useEffect} from 'react'
+import {useStore} from 'react-redux'
+import {of} from 'rxjs'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import {createMockSanityClient} from '../../__tests__/fixtures/mockSanityClient'
+import {assetsActions} from '../../modules/assets'
+import ReduxProvider from './index'
+
+function StoreProbe({onStore}: {onStore: (store: Store) => void}) {
+  const store = useStore()
+  useEffect(() => {
+    onStore(store)
+  }, [onStore, store])
+  return null
+}
+
+function dispatchFetch(store: Store) {
+  store.dispatch(
+    assetsActions.fetchRequest({
+      params: {},
+      queryFilter: '_type == "sanity.imageAsset"',
+      selector: '',
+      sort: '',
+    }),
+  )
+}
+
+describe('ReduxProvider store lifecycle', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('keeps epics listening after a React strict-mode remount', async () => {
+    const fetch = vi.fn(() => of({items: []}))
+    const client = createMockSanityClient({
+      observable: {fetch},
+    })
+    let store: Store | undefined
+
+    render(
+      <StrictMode>
+        <ReduxProvider client={client}>
+          <StoreProbe
+            onStore={(next) => {
+              store = next
+            }}
+          />
+        </ReduxProvider>
+      </StrictMode>,
+    )
+
+    expect(store).toBeDefined()
+    dispatchFetch(store!)
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalled()
+    })
+    await vi.waitFor(() => {
+      expect(store!.getState().assets.fetching).toBe(false)
+    })
+  })
+
+  it('ends the epics after a real unmount', async () => {
+    const fetch = vi.fn(() => of({items: []}))
+    const client = createMockSanityClient({
+      observable: {fetch},
+    })
+    let store: Store | undefined
+
+    const {unmount} = render(
+      <ReduxProvider client={client}>
+        <StoreProbe
+          onStore={(next) => {
+            store = next
+          }}
+        />
+      </ReduxProvider>,
+    )
+
+    expect(store).toBeDefined()
+    unmount()
+
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0)
+      })
+    })
+
+    dispatchFetch(store!)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(store!.getState().assets.fetching).toBe(true)
+  })
+})

--- a/plugins/sanity-plugin-media/src/components/ReduxProvider/index.tsx
+++ b/plugins/sanity-plugin-media/src/components/ReduxProvider/index.tsx
@@ -25,7 +25,8 @@ type Props = {
 }
 
 type CreatedStore = {
-  endEpics: () => void
+  cancelEnd: () => void
+  scheduleEnd: () => void
   store: Store
 }
 
@@ -98,22 +99,43 @@ function createReduxStore(props: Props): CreatedStore {
     rootEpic(action$, state$, dependencies).pipe(takeUntil(action$.pipe(ofType(EPIC_END_TYPE)))),
   )
 
+  /*
+   * Defer epicEnd by a tick. React strict mode runs mount → cleanup → mount
+   * synchronously in development. Ending the epics in that cleanup killed them
+   * on the first mount, and the remount reused this store (useState survives)
+   * with nothing listening — every fetch/listen aborted and the tool sat on
+   * "LOADING…" forever. A remount cancels the pending end; a real unmount
+   * lets the timer fire and ends the epics as before. Keep the eager
+   * `epicMiddleware.run` above: child effects dispatch the initial fetches
+   * before this parent's effect would run, so starting epics in the effect
+   * would drop those actions.
+   */
+  let pendingEnd: ReturnType<typeof setTimeout> | null = null
+
   return {
     store,
-    endEpics: () => {
-      store.dispatch({type: EPIC_END_TYPE})
+    scheduleEnd: () => {
+      if (pendingEnd !== null) return
+      pendingEnd = setTimeout(() => {
+        pendingEnd = null
+        store.dispatch({type: EPIC_END_TYPE})
+      }, 0)
+    },
+    cancelEnd: () => {
+      if (pendingEnd === null) return
+      clearTimeout(pendingEnd)
+      pendingEnd = null
     },
   }
 }
 
 function ReduxProvider({children, ...props}: Props) {
-  const [{endEpics, store}] = useState(() => createReduxStore(props))
+  const [{cancelEnd, scheduleEnd, store}] = useState(() => createReduxStore(props))
 
   useEffect(() => {
-    return () => {
-      endEpics()
-    }
-  }, [endEpics])
+    cancelEnd()
+    return () => scheduleEnd()
+  }, [cancelEnd, scheduleEnd])
 
   return <Provider store={store}>{children}</Provider>
 }


### PR DESCRIPTION
## Summary

- Fixes the Media tool (and the Media asset source) sitting on **LOADING…** forever in `sanity dev` when React strict mode is on (the CLI default).
- `ReduxProvider` kept the store in `useState` and ended the root epic in an effect cleanup. Strict mode runs mount → cleanup → mount synchronously, so the cleanup fired `media/epicEnd` on the first mount; the remount reused the same store with no epics listening, and every `data/query` / `data/listen` was aborted.
- The end is now deferred by a tick (`scheduleEnd` / `cancelEnd`). A simulated remount cancels the pending end; a real unmount still ends the epics. The eager `epicMiddleware.run` is unchanged so child-effect fetch actions are not dropped.

Fixes https://github.com/sanity-io/plugins/issues/1971

`sanity-io/sanity-plugin-media` is archived; this is the current plugin source.

## Test plan

- [x] `vitest run src/components/ReduxProvider/ReduxProvider.test.tsx` — strict-mode remount still fetches; real unmount still ends epics
- [x] `sanity dev` with default `reactStrictMode`, open `/media` — assets and tags load
- [x] Same studio, image field → Media source — list loads
- [x] Close the Media tool / dismiss the picker — no leftover listen subscriptions after the deferred end
- [x] `sanity build` / production still loads (strict mode does not double-mount)


<img width="2466" height="1534" alt="CleanShot 2026-09-02 at 16 38 31@2x" src="https://github.com/user-attachments/assets/88aaea86-1f6f-413f-9d6d-5fae9acd6510" />


