### PR TITLE
feat(assist): add assist.maxFieldSelectionDepth config option

### DIFF
--- a/.changeset/assist-max-field-selection-depth.md
+++ b/.changeset/assist-max-field-selection-depth.md
@@ -1,0 +1,5 @@
+---
+'@sanity/assist': minor
+---
+
+Add `assist.maxFieldSelectionDepth` config option to control how deep the AI Assist field picker (and per-field assist actions) traverses nested schemas. Previously this was hardcoded to 6, which silently hid deeply nested fields — e.g. locale string fields at depth 7 — from the "field" picker so instructions could not be attached to them. Defaults to 6 (unchanged behavior).

--- a/plugins/@sanity/assist/README.md
+++ b/plugins/@sanity/assist/README.md
@@ -180,6 +180,7 @@ assist({
   assist: {
     localeSettings: () => Intl.DateTimeFormat().resolvedOptions(),
     maxPathDepth: 4,
+    maxFieldSelectionDepth: 6,
     temperature: 0.3,
   },
   translate: {/* see sections about document and field translation */},
@@ -188,6 +189,7 @@ assist({
 
 - `localeSettings`: See section on [date and datetime](#date-and-datetime)
 - `maxPathDepth`: The max depth for document paths AI Assist will write to.
+- `maxFieldSelectionDepth`: The max depth for fields offered for selection in the AI Assist UI (the instruction field picker and per-field assist actions). Fields nested deeper than this cannot have instructions attached to them directly.
 - `temperature`: Influences how much the output of an instruction will vary between runs.
 
 For more details, please review the TSDocs of the individual config parameters in [assistTypes.ts](./src/assistTypes.ts).

--- a/plugins/@sanity/assist/src/assistInspector/helpers.test.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.test.ts
@@ -1,0 +1,90 @@
+import {Schema} from '@sanity/schema'
+import {defineArrayMember, defineField, defineType, type ObjectSchemaType, pathToString} from 'sanity'
+import {describe, expect, test} from 'vitest'
+
+import {getFieldRefs} from './helpers'
+
+// Mirrors a locale-object pattern where translated strings end up deeply
+// nested: array item -> object -> array item -> locale object -> string
+const schema = Schema.compile({
+  name: 'test',
+  types: [
+    defineType({
+      type: 'object',
+      name: 'localeString',
+      fields: [
+        {type: 'string', name: 'en'},
+        {type: 'string', name: 'fr'},
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'temporaryHours',
+      fields: [
+        {type: 'string', name: 'startDate'},
+        defineField({type: 'localeString', name: 'reason'}),
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'hoursOfOperation',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'temporaryHours',
+          of: [defineArrayMember({type: 'temporaryHours'})],
+        }),
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'overviewHours',
+      fields: [
+        defineField({type: 'localeString', name: 'title'}),
+        defineField({type: 'hoursOfOperation', name: 'hoursOfOperation'}),
+      ],
+    }),
+    defineType({
+      type: 'document',
+      name: 'displayControls',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'overviewHours',
+          of: [defineArrayMember({type: 'overviewHours'})],
+        }),
+      ],
+    }),
+  ],
+})
+
+const documentType = schema.get('displayControls') as ObjectSchemaType
+
+// overviewHours -> [_key] -> hoursOfOperation -> temporaryHours -> [_key] -> reason -> en
+const deepLocalePath =
+  'overviewHours[_key=="overviewHours"].hoursOfOperation.temporaryHours[_key=="temporaryHours"].reason.en'
+const localeObjectPath =
+  'overviewHours[_key=="overviewHours"].hoursOfOperation.temporaryHours[_key=="temporaryHours"].reason'
+
+function refPaths(maxDepth?: number) {
+  return getFieldRefs(documentType, undefined, 0, maxDepth).map((ref) => pathToString(ref.path))
+}
+
+describe('getFieldRefs', () => {
+  test('excludes fields deeper than the default max depth', () => {
+    const paths = refPaths()
+    expect(paths).toContain(localeObjectPath)
+    expect(paths).not.toContain(deepLocalePath)
+  })
+
+  test('includes deeper fields when maxDepth is raised', () => {
+    const paths = refPaths(8)
+    expect(paths).toContain(localeObjectPath)
+    expect(paths).toContain(deepLocalePath)
+  })
+
+  test('excludes shallower fields when maxDepth is lowered', () => {
+    const paths = refPaths(1)
+    expect(paths).toEqual(['overviewHours'])
+  })
+})

--- a/plugins/@sanity/assist/src/assistInspector/helpers.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.ts
@@ -35,7 +35,7 @@ export interface FieldRef {
   synthetic?: boolean
 }
 
-const maxDepth = 6
+export const DEFAULT_MAX_FIELD_SELECTION_DEPTH = 6
 
 function getTypeIcon(schemaType: SchemaType): ComponentType {
   let t: SchemaType | undefined = schemaType
@@ -78,6 +78,7 @@ export function getFieldRefs(
   schemaType: ObjectSchemaType,
   parent?: FieldRef,
   depth = 0,
+  maxDepth = DEFAULT_MAX_FIELD_SELECTION_DEPTH,
 ): FieldRef[] {
   if (depth >= maxDepth) {
     return []
@@ -97,10 +98,14 @@ export function getFieldRefs(
           icon: getTypeIcon(field.type),
         }
         const fields =
-          field.type.jsonType === 'object' ? getFieldRefs(field.type, fieldRef, depth + 1) : []
+          field.type.jsonType === 'object'
+            ? getFieldRefs(field.type, fieldRef, depth + 1, maxDepth)
+            : []
 
         const syntheticFields =
-          field.type.jsonType === 'array' ? getSyntheticFields(field.type, fieldRef, depth + 1) : []
+          field.type.jsonType === 'array'
+            ? getSyntheticFields(field.type, fieldRef, depth + 1, maxDepth)
+            : []
         if (!isAssistSupported(field.type)) {
           return [...fields, ...syntheticFields]
         }
@@ -109,7 +114,12 @@ export function getFieldRefs(
   )
 }
 
-function getSyntheticFields(schemaType: ArraySchemaType, parent?: FieldRef, depth = 0) {
+function getSyntheticFields(
+  schemaType: ArraySchemaType,
+  parent?: FieldRef,
+  depth = 0,
+  maxDepth = DEFAULT_MAX_FIELD_SELECTION_DEPTH,
+) {
   if (depth >= maxDepth) {
     return []
   }
@@ -131,7 +141,9 @@ function getSyntheticFields(schemaType: ArraySchemaType, parent?: FieldRef, dept
           synthetic: true,
         }
         const fields =
-          itemType.jsonType === 'object' ? getFieldRefs(itemType, fieldRef, depth + 1) : []
+          itemType.jsonType === 'object'
+            ? getFieldRefs(itemType, fieldRef, depth + 1, maxDepth)
+            : []
 
         if (!isAssistSupported(itemType)) {
           return fields

--- a/plugins/@sanity/assist/src/assistLayout/AiAssistanceConfigProvider.tsx
+++ b/plugins/@sanity/assist/src/assistLayout/AiAssistanceConfigProvider.tsx
@@ -28,7 +28,10 @@ export function AiAssistanceConfigProvider(props: {
 
   const schema = useSchema()
   const serializedTypes = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
-  const {getFieldRefs, getFieldRefsByTypePath} = useFieldRefGetters(schema)
+  const {getFieldRefs, getFieldRefsByTypePath} = useFieldRefGetters(
+    schema,
+    props.config.assist?.maxFieldSelectionDepth,
+  )
 
   useEffect(() => {
     getInstructStatus()
@@ -85,9 +88,9 @@ export function AiAssistanceConfigProvider(props: {
   )
 }
 
-function useFieldRefGetters(schema: Schema) {
+function useFieldRefGetters(schema: Schema, maxFieldSelectionDepth?: number) {
   return useMemo(() => {
-    const getForSchemaType = createFieldRefCache()
+    const getForSchemaType = createFieldRefCache(maxFieldSelectionDepth)
 
     function getRefsForType(documentType: string) {
       // oxlint-disable-next-line no-unsafe-type-assertion
@@ -103,5 +106,5 @@ function useFieldRefGetters(schema: Schema) {
       getFieldRefsByTypePath: (documentType: string) =>
         getRefsForType(documentType).fieldRefsByTypePath,
     }
-  }, [schema])
+  }, [schema, maxFieldSelectionDepth])
 }

--- a/plugins/@sanity/assist/src/assistLayout/fieldRefCache.tsx
+++ b/plugins/@sanity/assist/src/assistLayout/fieldRefCache.tsx
@@ -6,7 +6,7 @@ import {
   getFieldRefs as createFieldRefs,
 } from '../assistInspector/helpers'
 
-export function createFieldRefCache() {
+export function createFieldRefCache(maxFieldSelectionDepth?: number) {
   const byType: Record<
     string,
     | {
@@ -21,7 +21,7 @@ export function createFieldRefCache() {
     const cached = byType[documentType]
     if (cached) return cached
 
-    const fieldRefs = createFieldRefs(schemaType)
+    const fieldRefs = createFieldRefs(schemaType, undefined, 0, maxFieldSelectionDepth)
     const fieldRefsByTypePath = asFieldRefsByTypePath(fieldRefs)
     const refs = {
       fieldRefs,

--- a/plugins/@sanity/assist/src/assistTypes.ts
+++ b/plugins/@sanity/assist/src/assistTypes.ts
@@ -38,6 +38,24 @@ export interface AssistConfig {
   maxPathDepth?: number
 
   /**
+   * The max depth for fields offered for selection in the AI Assist UI —
+   * the instruction field picker and per-field assist actions.
+   *
+   * Depth is based on field path segments, counted from the document root:
+   * - `title` has depth 1
+   * - `array[_key="no"].title` has depth 3
+   *
+   * Fields nested deeper than this will not appear in the field picker and
+   * cannot have instructions attached to them directly.
+   *
+   * Be careful not to set this too high in studios with recursive document schemas, as it could have
+   * negative impact on performance.
+   *
+   * Default: 6
+   */
+  maxFieldSelectionDepth?: number
+
+  /**
    * Influences how much the output of an instruction will vary.
    *
    * Min: 0 – re-running an instruction will often produce the same outcomes

--- a/plugins/@sanity/assist/src/plugin.tsx
+++ b/plugins/@sanity/assist/src/plugin.tsx
@@ -54,6 +54,7 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
   const configWithDefaults = config ?? {}
   const styleguide = configWithDefaults.translate?.styleguide || ''
   const maxPathDepth = configWithDefaults.assist?.maxPathDepth
+  const maxFieldSelectionDepth = configWithDefaults.assist?.maxFieldSelectionDepth
   const temperature = configWithDefaults.assist?.temperature
 
   if (typeof styleguide === 'string') {
@@ -63,6 +64,15 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
   if (maxPathDepth !== undefined && (maxPathDepth < 1 || maxPathDepth > 12)) {
     throw new Error(
       `[${packageName}]: \`assist.maxPathDepth\` must be be in the range [1,12] inclusive, but was ${maxPathDepth}`,
+    )
+  }
+
+  if (
+    maxFieldSelectionDepth !== undefined &&
+    (maxFieldSelectionDepth < 1 || maxFieldSelectionDepth > 12)
+  ) {
+    throw new Error(
+      `[${packageName}]: \`assist.maxFieldSelectionDepth\` must be in the range [1,12] inclusive, but was ${maxFieldSelectionDepth}`,
     )
   }
 


### PR DESCRIPTION
Fixes #1992

## Problem

The AI Assist field picker ("field" autocomplete in the instruction editor) and per-field assist actions are built from a field-reference tree (`getFieldRefs` / `getSyntheticFields` in `assistInspector/helpers.ts`) that stops recursing at a hardcoded `const maxDepth = 6`. Fields nested deeper than 6 path segments silently disappear: they never show up in the picker and cannot have instructions attached to them, even though the rest of the pipeline (e.g. `assist.maxPathDepth`, `translate.field.maxPathDepth`) can be configured to handle them.

Real-world example from #1992 — a locale-object pattern where translated strings sit at depth 7:

```
overviewHours[_key].hoursOfOperation.temporaryHours[_key].reason.en
      1         2          3               4          5      6   7
```

The `reason` object gets a ref (so it shows assist affordances), but its language children never do — which looks inconsistent to editors, since the identical object mounted shallower on another document type works fine.

## Solution

Add `assist.maxFieldSelectionDepth` (default `6`, so behavior is unchanged unless opted into), threaded from the plugin config through `AiAssistanceConfigProvider` → `createFieldRefCache` → `getFieldRefs`/`getSyntheticFields`. Validated to `[1,12]` at plugin init, consistent with `assist.maxPathDepth`.

- New option documented in `assistTypes.ts` TSDoc and the README config section
- Unit tests for `getFieldRefs` covering default, raised, and lowered depths
- Changeset included (`@sanity/assist`: minor)

## Notes

Written against the depth semantics as they exist today (depth counted from the document root, arrays contributing a segment for the synthetic item ref). Happy to rename the option or adjust the validation range if you'd prefer different ergonomics — e.g. reusing `assist.maxPathDepth` was considered, but its default (4) is lower than the picker's current 6 and its documented semantics are relative to the instruction's field rather than absolute from the root, so a separate option seemed safer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Studio configuration and UI field enumeration only; default behavior unchanged unless opted in, with bounded depth to limit performance impact.
> 
> **Overview**
> Adds **`assist.maxFieldSelectionDepth`** so studios can control how deep the AI Assist field picker and per-field assist actions walk nested schemas. The previous limit of **6** was hardcoded in `getFieldRefs` / `getSyntheticFields`, which hid deeper fields (e.g. locale strings at depth 7) from instruction targeting. Default remains **6**; values are validated to **[1, 12]** at plugin init, matching `maxPathDepth`.
> 
> Config flows from **`assist()`** → **`AiAssistanceConfigProvider`** → **`createFieldRefCache`** into field-ref traversal. README and `assistTypes` TSDoc document the option; new **`getFieldRefs`** tests cover default, raised, and lowered depth. Minor changeset for `@sanity/assist`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f6a17083b9b06766c059ab66dd57b80f03b6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->