### PR TITLE
feat(assist): add `assist.maxFieldSelectionDepth` config option

### DIFF
--- a/.changeset/assist-max-field-selection-depth.md
+++ b/.changeset/assist-max-field-selection-depth.md
@@ -1,0 +1,7 @@
+---
+"@sanity/assist": minor
+---
+
+author: @kevindice
+
+Add `assist.maxFieldSelectionDepth` to configure how deeply nested a field can be and still get AI Assist: the field action (sparkle button), the field picker in the instruction editor and field references in instructions. This depth was hardcoded to 6 path segments, so deeper fields silently disappeared from AI Assist and neither `assist.maxPathDepth` nor `translate.field.maxPathDepth` could change that. The default is still 6, so nothing changes unless the option is set.

--- a/dev/test-studio/src/assist/index.tsx
+++ b/dev/test-studio/src/assist/index.tsx
@@ -1,5 +1,5 @@
 import {assist} from '@sanity/assist'
-import {defineField, definePlugin, defineType} from 'sanity'
+import {defineArrayMember, defineField, definePlugin, defineType} from 'sanity'
 
 // Fixture for manually testing AI Assist together with field groups (tabs).
 // Reproduces SAPP-3970: opening / editing AI Assist instructions used to reset
@@ -25,12 +25,91 @@ const assistFieldGroupsRepro = defineType({
   ],
 })
 
+// Fixture for manually testing `assist.maxFieldSelectionDepth` (sanity-io/plugins#1992).
+// `hours[_key].hoursOfOperation.temporaryHours[_key].reason.en` is 7 path segments deep, so with
+// the default depth of 6 the locale strings under `reason` get no AI Assist field action and are
+// missing from the field picker, while `reason` itself (depth 6) has both.
+const assistLocaleString = defineType({
+  name: 'assistLocaleString',
+  title: 'Locale string',
+  type: 'object',
+  fields: [
+    defineField({name: 'en', title: 'English', type: 'string'}),
+    defineField({name: 'fr', title: 'French', type: 'string'}),
+  ],
+})
+
+const assistTemporaryHours = defineType({
+  name: 'assistTemporaryHours',
+  title: 'Temporary hours',
+  type: 'object',
+  fields: [
+    defineField({name: 'date', title: 'Date', type: 'date'}),
+    defineField({name: 'reason', title: 'Reason', type: 'assistLocaleString'}),
+  ],
+})
+
+const assistHoursOfOperation = defineType({
+  name: 'assistHoursOfOperation',
+  title: 'Hours of operation',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'temporaryHours',
+      title: 'Temporary hours',
+      type: 'array',
+      of: [defineArrayMember({type: 'assistTemporaryHours'})],
+    }),
+  ],
+})
+
+const assistOverviewHours = defineType({
+  name: 'assistOverviewHours',
+  title: 'Overview hours',
+  type: 'object',
+  fields: [
+    defineField({name: 'title', title: 'Title', type: 'assistLocaleString'}),
+    defineField({
+      name: 'hoursOfOperation',
+      title: 'Hours of operation',
+      type: 'assistHoursOfOperation',
+    }),
+  ],
+})
+
+const assistDeepNestingRepro = defineType({
+  name: 'assistDeepNestingRepro',
+  title: 'AI Assist: Deeply nested fields',
+  type: 'document',
+  fields: [
+    defineField({name: 'title', title: 'Title', type: 'string'}),
+    defineField({
+      name: 'hours',
+      title: 'Hours',
+      type: 'array',
+      of: [defineArrayMember({type: 'assistOverviewHours'})],
+    }),
+  ],
+})
+
 export const assistExample = definePlugin(() => ({
   schema: {
-    types: [assistFieldGroupsRepro],
+    types: [
+      assistFieldGroupsRepro,
+      assistLocaleString,
+      assistTemporaryHours,
+      assistHoursOfOperation,
+      assistOverviewHours,
+      assistDeepNestingRepro,
+    ],
   },
   plugins: [
     assist({
+      assist: {
+        // Raised from the default of 6 so the depth-7 locale strings in
+        // `assistDeepNestingRepro` get AI Assist too
+        maxFieldSelectionDepth: 8,
+      },
       translate: {
         document: {
           languageField: 'language',

--- a/plugins/@sanity/assist/README.md
+++ b/plugins/@sanity/assist/README.md
@@ -180,6 +180,7 @@ assist({
   assist: {
     localeSettings: () => Intl.DateTimeFormat().resolvedOptions(),
     maxPathDepth: 4,
+    maxFieldSelectionDepth: 6,
     temperature: 0.3,
   },
   translate: {/* see sections about document and field translation */},
@@ -188,6 +189,7 @@ assist({
 
 - `localeSettings`: See section on [date and datetime](#date-and-datetime)
 - `maxPathDepth`: The max depth for document paths AI Assist will write to.
+- `maxFieldSelectionDepth`: The max depth for fields that can be selected for AI Assist. Fields nested deeper than this get no AI Assist field action, are not listed in the field picker when editing instructions, and cannot be referenced from an instruction. Depth is counted in path segments from the document root (`title` has depth 1, `array[_key="no"].title` has depth 3). Be careful not to set this too high in studios with recursive document schemas, as it could have negative impact on performance.
 - `temperature`: Influences how much the output of an instruction will vary between runs.
 
 For more details, please review the TSDocs of the individual config parameters in [assistTypes.ts](./src/assistTypes.ts).
@@ -657,6 +659,8 @@ assist({
 
 Be careful not to set this too high in studios with recursive document schemas, as it could have negative impact on performance.
 maxPathDepth is hard-capped to 50.
+
+`translate.field.maxPathDepth` only affects the "Translate fields" action. Which fields get an AI Assist field action at all is controlled by `assist.maxFieldSelectionDepth` (see [Assist configuration](#assist-configuration-optional)).
 
 ### Loading field languages
 

--- a/plugins/@sanity/assist/src/assistInspector/helpers.test.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.test.ts
@@ -1,0 +1,106 @@
+import {Schema} from '@sanity/schema'
+import {defineArrayMember, defineField, defineType, type ObjectSchemaType} from 'sanity'
+import {describe, expect, test} from 'vitest'
+
+import {DEFAULT_MAX_FIELD_SELECTION_DEPTH, getFieldRefs} from './helpers'
+
+// Mirrors the shape from sanity-io/plugins#1992: array item -> object -> array item -> locale
+// object -> string, which puts the translated strings 7 path segments deep.
+const schema = Schema.compile({
+  name: 'test',
+  types: [
+    defineType({
+      type: 'object',
+      name: 'localeString',
+      fields: [
+        {type: 'string', name: 'en'},
+        {type: 'string', name: 'fr'},
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'temporaryHours',
+      fields: [
+        {type: 'string', name: 'startDate'},
+        defineField({type: 'localeString', name: 'reason'}),
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'hoursOfOperation',
+      fields: [
+        defineField({
+          type: 'array',
+          name: 'temporaryHours',
+          of: [defineArrayMember({type: 'temporaryHours'})],
+        }),
+      ],
+    }),
+    defineType({
+      type: 'object',
+      name: 'overviewHours',
+      fields: [
+        defineField({type: 'localeString', name: 'title'}),
+        defineField({type: 'hoursOfOperation', name: 'hoursOfOperation'}),
+      ],
+    }),
+    defineType({
+      type: 'document',
+      name: 'displayControls',
+      fields: [
+        defineField({type: 'string', name: 'title'}),
+        defineField({
+          type: 'array',
+          name: 'overviewHours',
+          of: [defineArrayMember({type: 'overviewHours'})],
+        }),
+      ],
+    }),
+  ],
+})
+
+// oxlint-disable-next-line no-unsafe-type-assertion
+const documentType = schema.get('displayControls') as ObjectSchemaType
+
+// Field ref keys are `pathToString` output made patch-safe: `[_key=="x"]` becomes `|_key:x|`
+const reasonKey =
+  'overviewHours|_key:overviewHours|.hoursOfOperation.temporaryHours|_key:temporaryHours|.reason'
+const reasonEnKey = `${reasonKey}.en`
+
+function keys(maxDepth?: number) {
+  return getFieldRefs(documentType, maxDepth).map((ref) => ref.key)
+}
+
+describe('getFieldRefs', () => {
+  test('collects fields up to 6 path segments by default', () => {
+    expect(DEFAULT_MAX_FIELD_SELECTION_DEPTH).toBe(6)
+
+    const defaultKeys = keys()
+    expect(defaultKeys).toEqual(keys(DEFAULT_MAX_FIELD_SELECTION_DEPTH))
+    expect(defaultKeys).toContain(reasonKey)
+    expect(defaultKeys).not.toContain(reasonEnKey)
+  })
+
+  test('collects deeper fields when maxDepth is raised', () => {
+    const deepKeys = keys(8)
+    expect(deepKeys).toContain(reasonKey)
+    expect(deepKeys).toContain(reasonEnKey)
+    expect(deepKeys).toContain(`${reasonKey}.fr`)
+    // everything that was collected by default is still there
+    for (const key of keys()) {
+      expect(deepKeys).toContain(key)
+    }
+  })
+
+  test('only collects root fields when maxDepth is 1', () => {
+    expect(keys(1)).toEqual(['title', 'overviewHours'])
+  })
+
+  test('keeps ancestor titles in the breadcrumb title of deep fields', () => {
+    const reasonEn = getFieldRefs(documentType, 8).find((ref) => ref.key === reasonEnKey)
+    expect(reasonEn?.title).toBe(
+      'Overview Hours / Overview Hours / Hours Of Operation / Temporary Hours / Temporary Hours / Reason / En',
+    )
+    expect(reasonEn?.schemaType.jsonType).toBe('string')
+  })
+})

--- a/plugins/@sanity/assist/src/assistInspector/helpers.ts
+++ b/plugins/@sanity/assist/src/assistInspector/helpers.ts
@@ -35,7 +35,11 @@ export interface FieldRef {
   synthetic?: boolean
 }
 
-const maxDepth = 6
+/**
+ * Default for `assist.maxFieldSelectionDepth`: how many path segments deep fields are collected
+ * for the field picker and the per-field assist actions.
+ */
+export const DEFAULT_MAX_FIELD_SELECTION_DEPTH = 6
 
 function getTypeIcon(schemaType: SchemaType): ComponentType {
   let t: SchemaType | undefined = schemaType
@@ -74,10 +78,25 @@ export function getDocumentFieldRef(schemaType: ObjectSchemaType): FieldRef {
   }
 }
 
+/**
+ * Collects every field (and synthetic array item) in `schemaType` that AI Assist can attach
+ * instructions to.
+ *
+ * @param maxDepth - max number of path segments a collected field can have; deeper fields are
+ * skipped. Arrays contribute one segment for the item type (`array[_key="type"]`).
+ */
 export function getFieldRefs(
   schemaType: ObjectSchemaType,
-  parent?: FieldRef,
-  depth = 0,
+  maxDepth = DEFAULT_MAX_FIELD_SELECTION_DEPTH,
+): FieldRef[] {
+  return getObjectFieldRefs(schemaType, undefined, 0, maxDepth)
+}
+
+function getObjectFieldRefs(
+  schemaType: ObjectSchemaType,
+  parent: FieldRef | undefined,
+  depth: number,
+  maxDepth: number,
 ): FieldRef[] {
   if (depth >= maxDepth) {
     return []
@@ -97,10 +116,14 @@ export function getFieldRefs(
           icon: getTypeIcon(field.type),
         }
         const fields =
-          field.type.jsonType === 'object' ? getFieldRefs(field.type, fieldRef, depth + 1) : []
+          field.type.jsonType === 'object'
+            ? getObjectFieldRefs(field.type, fieldRef, depth + 1, maxDepth)
+            : []
 
         const syntheticFields =
-          field.type.jsonType === 'array' ? getSyntheticFields(field.type, fieldRef, depth + 1) : []
+          field.type.jsonType === 'array'
+            ? getSyntheticFields(field.type, fieldRef, depth + 1, maxDepth)
+            : []
         if (!isAssistSupported(field.type)) {
           return [...fields, ...syntheticFields]
         }
@@ -109,7 +132,12 @@ export function getFieldRefs(
   )
 }
 
-function getSyntheticFields(schemaType: ArraySchemaType, parent?: FieldRef, depth = 0) {
+function getSyntheticFields(
+  schemaType: ArraySchemaType,
+  parent: FieldRef | undefined,
+  depth: number,
+  maxDepth: number,
+): FieldRef[] {
   if (depth >= maxDepth) {
     return []
   }
@@ -131,7 +159,9 @@ function getSyntheticFields(schemaType: ArraySchemaType, parent?: FieldRef, dept
           synthetic: true,
         }
         const fields =
-          itemType.jsonType === 'object' ? getFieldRefs(itemType, fieldRef, depth + 1) : []
+          itemType.jsonType === 'object'
+            ? getObjectFieldRefs(itemType, fieldRef, depth + 1, maxDepth)
+            : []
 
         if (!isAssistSupported(itemType)) {
           return fields

--- a/plugins/@sanity/assist/src/assistLayout/AiAssistanceConfigProvider.tsx
+++ b/plugins/@sanity/assist/src/assistLayout/AiAssistanceConfigProvider.tsx
@@ -28,7 +28,10 @@ export function AiAssistanceConfigProvider(props: {
 
   const schema = useSchema()
   const serializedTypes = useMemo(() => serializeSchema(schema, {leanFormat: true}), [schema])
-  const {getFieldRefs, getFieldRefsByTypePath} = useFieldRefGetters(schema)
+  const {getFieldRefs, getFieldRefsByTypePath} = useFieldRefGetters(
+    schema,
+    props.config.assist?.maxFieldSelectionDepth,
+  )
 
   useEffect(() => {
     getInstructStatus()
@@ -85,9 +88,9 @@ export function AiAssistanceConfigProvider(props: {
   )
 }
 
-function useFieldRefGetters(schema: Schema) {
+function useFieldRefGetters(schema: Schema, maxFieldSelectionDepth?: number) {
   return useMemo(() => {
-    const getForSchemaType = createFieldRefCache()
+    const getForSchemaType = createFieldRefCache(maxFieldSelectionDepth)
 
     function getRefsForType(documentType: string) {
       // oxlint-disable-next-line no-unsafe-type-assertion
@@ -103,5 +106,5 @@ function useFieldRefGetters(schema: Schema) {
       getFieldRefsByTypePath: (documentType: string) =>
         getRefsForType(documentType).fieldRefsByTypePath,
     }
-  }, [schema])
+  }, [schema, maxFieldSelectionDepth])
 }

--- a/plugins/@sanity/assist/src/assistLayout/fieldRefCache.test.ts
+++ b/plugins/@sanity/assist/src/assistLayout/fieldRefCache.test.ts
@@ -1,0 +1,39 @@
+import {Schema} from '@sanity/schema'
+import {defineField, defineType, type ObjectSchemaType} from 'sanity'
+import {expect, test} from 'vitest'
+
+import {createFieldRefCache} from './fieldRefCache'
+
+// nested objects: level1.level2.level3.level4.level5.level6.leaf (7 path segments)
+const leafKey = 'level1.level2.level3.level4.level5.level6.leaf'
+
+function nested(depth: number): ReturnType<typeof defineField> {
+  return depth > 6
+    ? defineField({type: 'string', name: 'leaf'})
+    : defineField({type: 'object', name: `level${depth}`, fields: [nested(depth + 1)]})
+}
+
+const schema = Schema.compile({
+  name: 'test',
+  types: [defineType({type: 'document', name: 'deep', fields: [nested(1)]})],
+})
+
+// oxlint-disable-next-line no-unsafe-type-assertion
+const documentType = schema.get('deep') as ObjectSchemaType
+
+test('uses the default depth when none is configured', () => {
+  const {fieldRefs, fieldRefsByTypePath} = createFieldRefCache()(documentType)
+  expect(fieldRefs.map((ref) => ref.key)).toContain('level1.level2.level3.level4.level5.level6')
+  expect(fieldRefsByTypePath[leafKey]).toBeUndefined()
+})
+
+test('builds the field refs with the configured maxFieldSelectionDepth', () => {
+  const {fieldRefs, fieldRefsByTypePath} = createFieldRefCache(7)(documentType)
+  expect(fieldRefs.map((ref) => ref.key)).toContain(leafKey)
+  expect(fieldRefsByTypePath[leafKey]?.schemaType.jsonType).toBe('string')
+})
+
+test('caches field refs per document type', () => {
+  const getRefsForType = createFieldRefCache(7)
+  expect(getRefsForType(documentType)).toBe(getRefsForType(documentType))
+})

--- a/plugins/@sanity/assist/src/assistLayout/fieldRefCache.tsx
+++ b/plugins/@sanity/assist/src/assistLayout/fieldRefCache.tsx
@@ -6,7 +6,11 @@ import {
   getFieldRefs as createFieldRefs,
 } from '../assistInspector/helpers'
 
-export function createFieldRefCache() {
+/**
+ * @param maxFieldSelectionDepth - see `AssistConfig.maxFieldSelectionDepth`; uses the plugin
+ * default when omitted
+ */
+export function createFieldRefCache(maxFieldSelectionDepth?: number) {
   const byType: Record<
     string,
     | {
@@ -21,7 +25,7 @@ export function createFieldRefCache() {
     const cached = byType[documentType]
     if (cached) return cached
 
-    const fieldRefs = createFieldRefs(schemaType)
+    const fieldRefs = createFieldRefs(schemaType, maxFieldSelectionDepth)
     const fieldRefsByTypePath = asFieldRefsByTypePath(fieldRefs)
     const refs = {
       fieldRefs,

--- a/plugins/@sanity/assist/src/assistTypes.ts
+++ b/plugins/@sanity/assist/src/assistTypes.ts
@@ -38,6 +38,24 @@ export interface AssistConfig {
   maxPathDepth?: number
 
   /**
+   * The max depth for fields that can be selected for AI Assist in the Studio: fields deeper than this
+   * get no AI Assist field action (the sparkle button), are not listed in the field picker when editing
+   * instructions, and cannot be referenced from an instruction prompt.
+   *
+   * Depth is based on field path segments, counted from the document root:
+   * - `title` has depth 1
+   * - `array[_key="no"].title` has depth 3
+   *
+   * Unlike `maxPathDepth`, this does not affect what an instruction can write to once it runs.
+   *
+   * Be careful not to set this too high in studios with recursive document schemas, as it could have
+   * negative impact on performance.
+   *
+   * Default: 6
+   */
+  maxFieldSelectionDepth?: number
+
+  /**
    * Influences how much the output of an instruction will vary.
    *
    * Min: 0 – re-running an instruction will often produce the same outcomes

--- a/plugins/@sanity/assist/src/plugin.tsx
+++ b/plugins/@sanity/assist/src/plugin.tsx
@@ -19,7 +19,7 @@ import {isSchemaAssistEnabled} from './helpers/assistSupported'
 import {validateStyleguide} from './helpers/styleguide'
 import {isImage} from './helpers/typeUtils'
 import {createAssistDocumentPresence} from './presence/AssistDocumentPresence'
-import {schemaTypes} from './schemas'
+import {createSchemaTypes} from './schemas'
 import type {TranslationConfig} from './translate/types'
 import {assistDocumentTypeName, type AssistPreset} from './types'
 
@@ -54,6 +54,7 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
   const configWithDefaults = config ?? {}
   const styleguide = configWithDefaults.translate?.styleguide || ''
   const maxPathDepth = configWithDefaults.assist?.maxPathDepth
+  const maxFieldSelectionDepth = configWithDefaults.assist?.maxFieldSelectionDepth
   const temperature = configWithDefaults.assist?.temperature
 
   if (typeof styleguide === 'string') {
@@ -63,6 +64,17 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
   if (maxPathDepth !== undefined && (maxPathDepth < 1 || maxPathDepth > 12)) {
     throw new Error(
       `[${packageName}]: \`assist.maxPathDepth\` must be be in the range [1,12] inclusive, but was ${maxPathDepth}`,
+    )
+  }
+
+  if (
+    maxFieldSelectionDepth !== undefined &&
+    (!Number.isInteger(maxFieldSelectionDepth) ||
+      maxFieldSelectionDepth < 1 ||
+      maxFieldSelectionDepth > 12)
+  ) {
+    throw new Error(
+      `[${packageName}]: \`assist.maxFieldSelectionDepth\` must be an integer in the range [1,12] inclusive, but was ${maxFieldSelectionDepth}`,
     )
   }
 
@@ -79,7 +91,7 @@ export const assist = definePlugin<AssistPluginConfig | void>((config) => {
     // oxlint-disable-next-line no-unsafe-type-assertion
     ...({handlesGDR: true} as any),
     schema: {
-      types: schemaTypes,
+      types: createSchemaTypes(maxFieldSelectionDepth),
     },
     i18n: {
       bundles: [{}],

--- a/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
+++ b/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
@@ -39,72 +39,78 @@ import {
 } from '../types'
 import {contextDocumentSchema} from './contextDocumentSchema'
 
-export const fieldReference = defineType({
-  type: 'object',
-  name: fieldReferenceTypeName,
-  title: 'Field',
-  icon: ThListIcon,
+/**
+ * The validation rule resolves the selected path against the same field-ref tree the field picker
+ * offers, so it has to be built with the same `assist.maxFieldSelectionDepth`.
+ */
+export function createFieldReferenceType(maxFieldSelectionDepth?: number) {
+  return defineType({
+    type: 'object',
+    name: fieldReferenceTypeName,
+    title: 'Field',
+    icon: ThListIcon,
 
-  fields: [
-    defineField({
-      type: 'string',
-      name: 'path',
-      title: 'Field',
-      components: {
-        input: FieldRefPathInput,
+    fields: [
+      defineField({
+        type: 'string',
+        name: 'path',
+        title: 'Field',
+        components: {
+          input: FieldRefPathInput,
+        },
+        validation: (rule) => {
+          const getForSchemaType = createFieldRefCache(maxFieldSelectionDepth)
+          return rule.custom((value, context) => {
+            if (!value) {
+              return 'Please select a field'
+            }
+            try {
+              const docId = context.document?._id
+              if (!docId) {
+                return `Field reference cannot be used outside document inspector context. Could not resolve document id.`
+              }
+              const targetDocType = docId.replace(new RegExp(`^${assistDocumentIdPrefix}`), '')
+              const schema = context.schema.get(targetDocType)
+              if (!schema) {
+                return `Field reference cannot be used outside document inspector context. Could not resolve schema: ${targetDocType}`
+              }
+              // oxlint-disable-next-line no-unsafe-type-assertion
+              const {fieldRefs} = getForSchemaType(schema as ObjectSchemaType)
+              const fieldRef = fieldRefs.find((r) => r.key === value)
+              if (!fieldRef) {
+                return `Field with path "${value}" does not exist in the schema.`
+              }
+              return true
+            } catch (e) {
+              console.error('Failed to resolve field reference', e)
+              return 'Invalid field reference.'
+            }
+          })
+        },
+      }),
+    ],
+    preview: {
+      select: {
+        path: 'path',
       },
-      validation: (rule) => {
-        const getForSchemaType = createFieldRefCache()
-        return rule.custom((value, context) => {
-          if (!value) {
-            return 'Please select a field'
-          }
-          try {
-            const docId = context.document?._id
-            if (!docId) {
-              return `Field reference cannot be used outside document inspector context. Could not resolve document id.`
-            }
-            const targetDocType = docId.replace(new RegExp(`^${assistDocumentIdPrefix}`), '')
-            const schema = context.schema.get(targetDocType)
-            if (!schema) {
-              return `Field reference cannot be used outside document inspector context. Could not resolve schema: ${targetDocType}`
-            }
-            // oxlint-disable-next-line no-unsafe-type-assertion
-            const {fieldRefs} = getForSchemaType(schema as ObjectSchemaType)
-            const fieldRef = fieldRefs.find((r) => r.key === value)
-            if (!fieldRef) {
-              return `Field with path "${value}" does not exist in the schema.`
-            }
-            return true
-          } catch (e) {
-            console.error('Failed to resolve field reference', e)
-            return 'Invalid field reference.'
-          }
-        })
+      prepare({path}) {
+        return {
+          title: path,
+          path,
+          icon: CodeIcon,
+        }
       },
-    }),
-  ],
-  preview: {
-    select: {
-      path: 'path',
     },
-    prepare({path}) {
-      return {
-        title: path,
-        path,
-        icon: CodeIcon,
-      }
+    components: {
+      preview: FieldRefPreview,
     },
-  },
-  components: {
-    preview: FieldRefPreview,
-  },
-  options: {
-    modal: {
-      type: 'popover',
+    options: {
+      modal: {
+        type: 'popover',
+      },
     },
-  },
-})
+  })
+}
 
 export const userInput = defineType({
   type: 'object',
@@ -196,7 +202,7 @@ export const prompt = defineType({
       },
       of: [
         defineArrayMember({
-          type: fieldReference.name,
+          type: fieldReferenceTypeName,
         }),
         defineArrayMember({
           type: promptContext.name,
@@ -207,7 +213,7 @@ export const prompt = defineType({
       ],
     }),
     /*    defineArrayMember({
-      type: fieldReference.name,
+      type: fieldReferenceTypeName,
     }),
     defineArrayMember({
       type: promptContext.name,

--- a/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
+++ b/plugins/@sanity/assist/src/schemas/assistDocumentSchema.tsx
@@ -69,7 +69,10 @@ export function createFieldReferenceType(maxFieldSelectionDepth?: number) {
               if (!docId) {
                 return `Field reference cannot be used outside document inspector context. Could not resolve document id.`
               }
-              const targetDocType = docId.replace(new RegExp(`^${assistDocumentIdPrefix}`), '')
+              if (!docId.startsWith(assistDocumentIdPrefix)) {
+                return `Field reference cannot be used outside document inspector context. Could not resolve document id: ${docId}`
+              }
+              const targetDocType = docId.slice(assistDocumentIdPrefix.length)
               const schema = context.schema.get(targetDocType)
               if (!schema) {
                 return `Field reference cannot be used outside document inspector context. Could not resolve schema: ${targetDocType}`

--- a/plugins/@sanity/assist/src/schemas/index.ts
+++ b/plugins/@sanity/assist/src/schemas/index.ts
@@ -2,9 +2,9 @@ import type {ArrayOfType, FieldProps, SchemaTypeDefinition} from 'sanity'
 
 import {
   assistDocumentSchema,
+  createFieldReferenceType,
   documentInstructionStatus,
   fieldInstructions,
-  fieldReference,
   instruction,
   instructionTask,
   outputFieldType,
@@ -49,21 +49,27 @@ function excludeComments<T extends SchemaTypeDefinition | ArrayOfType>(type: T):
   }
 }
 
-const instructionForm = [
-  fieldInstructions,
-  instruction,
-  fieldReference,
-  prompt,
-  userInput,
-  promptContext,
-].map(excludeComments)
+/**
+ * @param maxFieldSelectionDepth - see `AssistConfig.maxFieldSelectionDepth`; the field reference
+ * type validates picked paths against the field-ref tree, which must be built with the same depth
+ */
+export function createSchemaTypes(maxFieldSelectionDepth?: number) {
+  const instructionForm = [
+    fieldInstructions,
+    instruction,
+    createFieldReferenceType(maxFieldSelectionDepth),
+    prompt,
+    userInput,
+    promptContext,
+  ].map(excludeComments)
 
-export const schemaTypes = [
-  ...instructionForm,
-  outputFieldType,
-  outputTypeType,
-  assistDocumentSchema,
-  documentInstructionStatus,
-  instructionTask,
-  contextDocumentSchema,
-]
+  return [
+    ...instructionForm,
+    outputFieldType,
+    outputTypeType,
+    assistDocumentSchema,
+    documentInstructionStatus,
+    instructionTask,
+    contextDocumentSchema,
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1992. In-house take on #1993 (thanks @kevindice for the diagnosis and the proposed design), with the additional fix described below.

## Problem

`getFieldRefs` / `getSyntheticFields` in `assistInspector/helpers.ts` build the field-ref tree that gates the per-field AI Assist action (the sparkle button), the field picker in the instruction editor and field references inside instruction prompts. They stopped recursing at a module-level `const maxDepth = 6`, and neither `assist.maxPathDepth` nor `translate.field.maxPathDepth` reaches it, so fields deeper than 6 path segments silently disappeared from AI Assist with no escape hatch.

Real-world case from #1992 (locale strings at depth 7):

```
overviewHours[_key].hoursOfOperation.temporaryHours[_key].reason.en
      1         2          3               4          5      6   7
```

`reason` gets a field ref (sparkle shows), `reason.en` / `reason.fr` never do.

## Solution

- New `assist.maxFieldSelectionDepth` option. Default stays `6`, so nothing changes unless a studio opts in. Validated at plugin init to an integer in `[1,12]`, matching `assist.maxPathDepth`.
- `getFieldRefs(schemaType, maxDepth)` is now the public entry point over an internal recursive `getObjectFieldRefs` / `getSyntheticFields`; `createFieldRefCache(maxFieldSelectionDepth)` and `AiAssistanceConfigProvider` thread the configured value through.
- The `fieldReference` schema type's validation rule builds its **own** field-ref cache (`assistDocumentSchema.tsx`). #1993 left that at the default depth, so a depth-7 field picked in an instruction would fail validation with "Field with path ... does not exist in the schema". `schemaTypes` is now `createSchemaTypes(maxFieldSelectionDepth)` so the validation uses the same depth as the picker.
- TSDoc on `AssistConfig.maxFieldSelectionDepth`, README entry in the assist configuration section plus a pointer from the field-translation depth note (which is where the customer went looking first).
- Unit tests: `assistInspector/helpers.test.ts` (default / raised / lowered depth, breadcrumb titles) and `assistLayout/fieldRefCache.test.ts` (depth plumbing, caching).
- Test studio: `AI Assist: Deeply nested fields` fixture mirroring the reported schema shape, with `maxFieldSelectionDepth: 8` set on the assist example so the depth-7 fields can be checked manually.
- Changeset: `@sanity/assist` minor, crediting @kevindice.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm knip`, `pnpm build --filter=@sanity/assist --filter=test-studio^...` all pass.
- `@sanity/assist` Vitest suite: 8 files / 46 tests pass (including the new ones and the package exports test against `dist/`).
- Manual check in the test studio on the new fixture (`hours[_key].hoursOfOperation.temporaryHours[_key].reason.en`, depth 7):

With `maxFieldSelectionDepth: 8`, the depth-7 `English` field gets the AI Assist sparkle:

[English field at depth 7 showing the AI Assist sparkle with maxFieldSelectionDepth 8](https://cursor.com/agents/bc-b32b7b68-8599-55ed-83cc-545da7f93681/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_depth7_english_field_has_sparkle_with_max_field_selection_depth_8.webp)

Same fixture with the option removed (default 6): `Reason` (depth 6) has the sparkle, `English` / `French` (depth 7) do not, i.e. the reported bug and the unchanged default behavior:

[English field at depth 7 without the AI Assist sparkle at the default depth of 6](https://cursor.com/agents/bc-b32b7b68-8599-55ed-83cc-545da7f93681/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_depth7_english_field_no_sparkle_at_default_depth_6.webp)

Clicking the sparkle opens the inspector with the full 7-segment breadcrumb, and a field reference to the depth-7 field can be inserted into an instruction without the "does not exist in the schema" validation error:

[AI Assist inspector showing the depth-7 breadcrumb and an inserted field reference without validation errors](https://cursor.com/agents/bc-b32b7b68-8599-55ed-83cc-545da7f93681/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_inspector_depth7_breadcrumb_and_field_reference_without_validation_error.webp)

[assist_depth7_field_sparkle_inspector_and_field_picker.mp4](https://cursor.com/agents/bc-b32b7b68-8599-55ed-83cc-545da7f93681/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fassist_depth7_field_sparkle_inspector_and_field_picker.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sanity-io.slack.com/archives/C043ZRB9E4S/p1788470720461819?thread_ts=1788470720.461819&cid=C043ZRB9E4S)

<div><a href="https://cursor.com/agents/bc-b32b7b68-8599-55ed-83cc-545da7f93681?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b32b7b68-8599-55ed-83cc-545da7f93681&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

