### PR TITLE
fix: stabilize custom SpinnerIcon size in Safari

### DIFF
--- a/.changeset/async-list-spinner-safari.md
+++ b/.changeset/async-list-spinner-safari.md
@@ -1,0 +1,5 @@
+---
+"@sanity/sanity-plugin-async-list": patch
+---
+
+Stabilize the loading spinner size so it does not wobble while rotating in Safari

--- a/.changeset/unsplash-spinner-safari.md
+++ b/.changeset/unsplash-spinner-safari.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-asset-source-unsplash": patch
+---
+
+Stabilize the search loading spinner size so it does not wobble while rotating in Safari

--- a/plugins/@sanity/sanity-plugin-async-list/src/components/async-list.tsx
+++ b/plugins/@sanity/sanity-plugin-async-list/src/components/async-list.tsx
@@ -30,6 +30,9 @@ function LoadingIcon(): JSX.Element {
       <SpinnerIcon
         style={{
           animation: 'spin 2s linear infinite',
+          // Prevents a wobbly spinner on Safari
+          height: 'round(1em, 2px)',
+          width: 'round(1em, 2px)',
         }}
       />
     </>

--- a/plugins/sanity-plugin-asset-source-unsplash/src/components/SearchInput.tsx
+++ b/plugins/sanity-plugin-asset-source-unsplash/src/components/SearchInput.tsx
@@ -16,6 +16,9 @@ const rotate = keyframes`
 
 const AnimatedSpinnerIcon = styled(SpinnerIcon)`
   animation: ${rotate} 500ms linear infinite;
+  /* Prevents a wobbly spinner on Safari */
+  height: round(1em, 2px);
+  width: round(1em, 2px);
 `
 
 export function SearchInput({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

[sanity-io/ui#2897](https://github.com/sanity-io/ui/pull/2897) fixes a wobbly rotating spinner in Safari by giving `spinnerIcon` explicit `height`/`width` of `round(1em, 2px)` so the icon stays square on a stable pixel grid.

This repo has two custom `SpinnerIcon` rotations that do not go through `@sanity/ui`’s `Spinner` primitive, so they would not pick up that CSS:

- `@sanity/sanity-plugin-async-list` Autocomplete loading icon
- `sanity-plugin-asset-source-unsplash` search `iconRight` spinner

Other plugins that use `@sanity/ui` `Spinner` are covered by the upstream fix once that UI version lands. A rotating `SyncIcon` in Assist is a different glyph and was left alone.

## What

Apply the same sizing to those two custom `SpinnerIcon` instances.

## Testing

- `pnpm format`, `pnpm lint`, `pnpm knip`, `pnpm build`, `pnpm test run`
- Manual in test studio: Async List autocomplete loading icon; Unsplash picker search field spinner while a query is pending

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f71f7b-7d0c-4584-817d-37b86bdad109?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f71f7b-7d0c-4584-817d-37b86bdad109&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

