### PR TITLE
Replace legacy lexorank with @sanity/lexorank

### DIFF
--- a/.changeset/lexorank-initial-release.md
+++ b/.changeset/lexorank-initial-release.md
@@ -1,0 +1,5 @@
+---
+"@sanity/lexorank": major
+---
+
+Initial release

--- a/.changeset/orderable-document-list-lexorank.md
+++ b/.changeset/orderable-document-list-lexorank.md
@@ -1,0 +1,5 @@
+---
+"@sanity/orderable-document-list": patch
+---
+
+Replace the legacy CommonJS LexoRank dependency so schema extraction and TypeGen work with current Sanity versions

--- a/.changeset/workflow-lexorank.md
+++ b/.changeset/workflow-lexorank.md
@@ -1,0 +1,5 @@
+---
+"sanity-plugin-workflow": patch
+---
+
+Replace the legacy CommonJS LexoRank dependency so schema extraction and TypeGen work with current Sanity versions

--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ Sessions can be compared in the DevTools UI to diff bundle changes between build
 
 ## Tooling Packages
 
-| Package                                               | Description                                             |
-| ----------------------------------------------------- | ------------------------------------------------------- |
-| [`@sanity/plugin-kit`](./packages/@sanity/plugin-kit) | CLI toolkit for developing and verifying Sanity plugins |
+| Package                                               | Description                                                           |
+| ----------------------------------------------------- | --------------------------------------------------------------------- |
+| [`@sanity/lexorank`](./packages/@sanity/lexorank)     | ESM-compatible ordering primitives for lexicographically ranked lists |
+| [`@sanity/plugin-kit`](./packages/@sanity/plugin-kit) | CLI toolkit for developing and verifying Sanity plugins               |
 
 ## Contributing
 

--- a/packages/@sanity/lexorank/README.md
+++ b/packages/@sanity/lexorank/README.md
@@ -1,0 +1,23 @@
+# @sanity/lexorank
+
+An ESM-compatible TypeScript implementation of the LexoRank algorithm for maintaining
+lexicographically ordered lists.
+
+This package preserves the rank format and behavior of `lexorank@1.0.5`, including existing values
+such as `0|000000:`. It is maintained in the Sanity plugins monorepo so Sanity Studio plugins can use
+LexoRank during browser builds and server-side schema extraction without loading legacy CommonJS.
+
+## Usage
+
+```ts
+import {LexoRank} from '@sanity/lexorank'
+
+const first = LexoRank.min()
+const last = LexoRank.max()
+const middle = first.between(last)
+
+console.log(middle.toString()) // 0|hzzzzz:
+```
+
+See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md) for the origin and license of the underlying
+implementation.

--- a/packages/@sanity/lexorank/THIRD_PARTY_NOTICES.md
+++ b/packages/@sanity/lexorank/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,7 @@
+# Third-party notices
+
+This package is based on [`lexorank-ts`](https://github.com/kvandake/lexorank-ts) version 1.0.5 by
+kvandake. The original package is distributed under the MIT license.
+
+The implementation has been reformatted and packaged as a modern ES module for use in the Sanity
+plugins monorepo. Its rank format and algorithmic behavior remain compatible with the original.

--- a/packages/@sanity/lexorank/package.json
+++ b/packages/@sanity/lexorank/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@sanity/lexorank",
+  "version": "0.0.1",
+  "description": "ESM-compatible LexoRank implementation for lexicographically ordered lists",
+  "keywords": [
+    "jira",
+    "lexorank",
+    "ordering",
+    "ranking",
+    "sanity"
+  ],
+  "homepage": "https://github.com/sanity-io/plugins/tree/main/packages/@sanity/lexorank#readme",
+  "bugs": {
+    "url": "https://github.com/sanity-io/plugins/issues"
+  },
+  "license": "MIT",
+  "author": "Sanity.io <hello@sanity.io>",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/sanity-io/plugins.git",
+    "directory": "packages/@sanity/lexorank"
+  },
+  "files": [
+    "dist",
+    "THIRD_PARTY_NOTICES.md"
+  ],
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "prepack": "turbo run build"
+  },
+  "devDependencies": {
+    "@sanity/tsconfig": "catalog:",
+    "@sanity/tsdown-config": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "engines": {
+    "node": ">=20.19 <22 || >=22.12"
+  }
+}

--- a/packages/@sanity/lexorank/src/index.test.ts
+++ b/packages/@sanity/lexorank/src/index.test.ts
@@ -1,0 +1,25 @@
+import {fileURLToPath} from 'node:url'
+
+import {expect, test} from 'vitest'
+import {getPackageExportsManifest} from 'vitest-package-exports'
+
+test('package exports', {timeout: 30_000}, async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: 'dist',
+    cwd: fileURLToPath(import.meta.url),
+  })
+
+  expect(manifest.exports).toMatchInlineSnapshot(`
+    {
+      ".": {
+        "LexoDecimal": "function",
+        "LexoInteger": "function",
+        "LexoNumeralSystem10": "function",
+        "LexoNumeralSystem36": "function",
+        "LexoNumeralSystem64": "function",
+        "LexoRank": "function",
+        "LexoRankBucket": "function",
+      },
+    }
+  `)
+})

--- a/packages/@sanity/lexorank/src/index.ts
+++ b/packages/@sanity/lexorank/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lexoRank'
+export * from './numeralSystems'

--- a/packages/@sanity/lexorank/src/lexoRank.test.ts
+++ b/packages/@sanity/lexorank/src/lexoRank.test.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it} from 'vitest'
+
+import {LexoRank} from './index'
+
+describe('LexoRank compatibility', () => {
+  it('preserves the legacy bounds and midpoint', () => {
+    expect(LexoRank.min().toString()).toBe('0|000000:')
+    expect(LexoRank.middle().toString()).toBe('0|hzzzzz:')
+    expect(LexoRank.max().toString()).toBe('0|zzzzzz:')
+  })
+
+  it('preserves boundary saturation behavior', () => {
+    expect(LexoRank.min().genPrev().toString()).toBe('0|000000:')
+    expect(LexoRank.max().genNext().toString()).toBe('0|zzzzzz:')
+  })
+
+  it('preserves repeated next-rank generation', () => {
+    const expected = [
+      '0|000000:',
+      '0|100000:',
+      '0|100008:',
+      '0|10000g:',
+      '0|10000o:',
+      '0|10000w:',
+      '0|100014:',
+      '0|10001c:',
+    ]
+
+    let rank = LexoRank.min()
+    const actual: string[] = []
+
+    for (let index = 0; index < expected.length; index++) {
+      actual.push(rank.toString())
+      rank = rank.genNext()
+    }
+
+    expect(actual).toEqual(expected)
+  })
+
+  it.each([
+    ['0|000000:', '0|100000:', '0|0i0000:'],
+    ['0|100000:', '0|100008:', '0|100004:'],
+    ['0|0i0000:', '0|100000:', '0|0r0000:'],
+    ['0|hzzzzz:', '0|zzzzzz:', '0|qzzzzz:'],
+    ['0|y00000:', '0|zzzzzz:', '0|yzzzzz:'],
+  ])('generates the legacy midpoint between %s and %s', (left, right, expected) => {
+    const rank = LexoRank.parse(left).between(LexoRank.parse(right))
+
+    expect(rank.toString()).toBe(expected)
+    expect(rank.compareTo(LexoRank.parse(left))).toBeGreaterThan(0)
+    expect(rank.compareTo(LexoRank.parse(right))).toBeLessThan(0)
+  })
+
+  it.each([
+    ['0', '1', '0|0i0000:'],
+    ['1', '0', '0|0i0000:'],
+    ['3', '5', '0|10000o:'],
+    ['5', '3', '0|10000o:'],
+    ['15', '30', '0|10004s:'],
+    ['31', '32', '0|10006s:'],
+    ['100', '200', '0|1000x4:'],
+    ['200', '100', '0|1000x4:'],
+  ])('preserves the upstream move vector %s → %s', (previousSteps, nextSteps, expected) => {
+    let previousRank = LexoRank.min()
+    for (let index = 0; index < Number(previousSteps); index++) {
+      previousRank = previousRank.genNext()
+    }
+
+    let nextRank = LexoRank.min()
+    for (let index = 0; index < Number(nextSteps); index++) {
+      nextRank = nextRank.genNext()
+    }
+
+    expect(previousRank.between(nextRank).toString()).toBe(expected)
+  })
+
+  it('parses stored ranks and keeps newly inserted ranks lexicographically ordered', () => {
+    const storedRanks = ['0|000000:', '0|100000:', '0|100008:', '0|hzzzzz:', '0|zzzzzz:']
+    const insertedRank = LexoRank.parse(storedRanks[1]!)
+      .between(LexoRank.parse(storedRanks[2]!))
+      .toString()
+
+    expect(insertedRank).toBe('0|100004:')
+    expect([...storedRanks, insertedRank].sort()).toEqual([
+      '0|000000:',
+      '0|100000:',
+      '0|100004:',
+      '0|100008:',
+      '0|hzzzzz:',
+      '0|zzzzzz:',
+    ])
+    expect([...storedRanks, insertedRank].map((rank) => LexoRank.parse(rank).toString())).toEqual([
+      ...storedRanks,
+      insertedRank,
+    ])
+  })
+})

--- a/packages/@sanity/lexorank/src/lexoRank/index.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/index.ts
@@ -1,0 +1,4 @@
+export * from './lexoRank'
+export {default as LexoRankBucket} from './lexoRankBucket'
+export * from './lexoDecimal'
+export * from './lexoInteger'

--- a/packages/@sanity/lexorank/src/lexoRank/lexoDecimal.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/lexoDecimal.ts
@@ -1,0 +1,210 @@
+import type {ILexoNumeralSystem} from '../numeralSystems'
+import StringBuilder from '../utils/stringBuilder'
+import {LexoInteger} from './lexoInteger'
+
+export class LexoDecimal {
+  public static half(sys: ILexoNumeralSystem): LexoDecimal {
+    const mid: number = (sys.getBase() / 2) | 0
+    return LexoDecimal.make(LexoInteger.make(sys, 1, [mid]), 1)
+  }
+
+  public static parse(str: string, system: ILexoNumeralSystem): LexoDecimal {
+    const partialIndex = str.indexOf(system.getRadixPointChar())
+    if (str.lastIndexOf(system.getRadixPointChar()) !== partialIndex) {
+      throw new Error('More than one ' + system.getRadixPointChar())
+    }
+
+    if (partialIndex < 0) {
+      return LexoDecimal.make(LexoInteger.parse(str, system), 0)
+    }
+
+    const intStr = str.substring(0, partialIndex) + str.substring(partialIndex + 1)
+    return LexoDecimal.make(LexoInteger.parse(intStr, system), str.length - 1 - partialIndex)
+  }
+
+  public static from(integer: LexoInteger): LexoDecimal {
+    return LexoDecimal.make(integer, 0)
+  }
+
+  public static make(integer: LexoInteger, sig: number): LexoDecimal {
+    if (integer.isZero()) {
+      return new LexoDecimal(integer, 0)
+    }
+
+    let zeroCount = 0
+    for (let i = 0; i < sig && integer.getMag(i) === 0; ++i) {
+      ++zeroCount
+    }
+
+    const newInteger = integer.shiftRight(zeroCount)
+    const newSig = sig - zeroCount
+    return new LexoDecimal(newInteger, newSig)
+  }
+
+  private readonly mag: LexoInteger
+  private readonly sig: number
+
+  private constructor(mag: LexoInteger, sig: number) {
+    this.mag = mag
+    this.sig = sig
+  }
+
+  public getSystem(): ILexoNumeralSystem {
+    return this.mag.getSystem()
+  }
+
+  public add(other: LexoDecimal): LexoDecimal {
+    let tmag = this.mag
+    let tsig = this.sig
+    let omag = other.mag
+    let osig: number
+    for (osig = other.sig; tsig < osig; ++tsig) {
+      tmag = tmag.shiftLeft()
+    }
+
+    while (tsig > osig) {
+      omag = omag.shiftLeft()
+      ++osig
+    }
+
+    return LexoDecimal.make(tmag.add(omag), tsig)
+  }
+
+  public subtract(other: LexoDecimal): LexoDecimal {
+    let thisMag = this.mag
+    let thisSig = this.sig
+    let otherMag = other.mag
+    let otherSig: number
+    for (otherSig = other.sig; thisSig < otherSig; ++thisSig) {
+      thisMag = thisMag.shiftLeft()
+    }
+
+    while (thisSig > otherSig) {
+      otherMag = otherMag.shiftLeft()
+      ++otherSig
+    }
+
+    return LexoDecimal.make(thisMag.subtract(otherMag), thisSig)
+  }
+
+  public multiply(other: LexoDecimal): LexoDecimal {
+    return LexoDecimal.make(this.mag.multiply(other.mag), this.sig + other.sig)
+  }
+
+  public floor(): LexoInteger {
+    return this.mag.shiftRight(this.sig)
+  }
+
+  public ceil(): LexoInteger {
+    if (this.isExact()) {
+      return this.mag
+    }
+
+    const floor = this.floor()
+    return floor.add(LexoInteger.one(floor.getSystem()))
+  }
+
+  public isExact(): boolean {
+    if (this.sig === 0) {
+      return true
+    }
+
+    for (let i = 0; i < this.sig; ++i) {
+      if (this.mag.getMag(i) !== 0) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  public getScale(): number {
+    return this.sig
+  }
+
+  public setScale(nsig: number, ceiling = false): LexoDecimal {
+    if (nsig >= this.sig) {
+      return this
+    }
+
+    if (nsig < 0) {
+      nsig = 0
+    }
+
+    const diff = this.sig - nsig
+    let nmag = this.mag.shiftRight(diff)
+    if (ceiling) {
+      nmag = nmag.add(LexoInteger.one(nmag.getSystem()))
+    }
+
+    return LexoDecimal.make(nmag, nsig)
+  }
+
+  public compareTo(other: LexoDecimal): number {
+    if (this === other) {
+      return 0
+    }
+
+    if (!other) {
+      return 1
+    }
+
+    let tMag = this.mag
+    let oMag = other.mag
+    if (this.sig > other.sig) {
+      oMag = oMag.shiftLeft(this.sig - other.sig)
+    } else if (this.sig < other.sig) {
+      tMag = tMag.shiftLeft(other.sig - this.sig)
+    }
+    return tMag.compareTo(oMag)
+  }
+
+  public format(): string {
+    const intStr = this.mag.format()
+    if (this.sig === 0) {
+      return intStr
+    }
+
+    const sb = new StringBuilder(intStr)
+    const head = sb[0]
+    const specialHead =
+      head === this.mag.getSystem().getPositiveChar() ||
+      head === this.mag.getSystem().getNegativeChar()
+
+    if (specialHead && head !== undefined) {
+      sb.remove(0, 1)
+    }
+
+    while (sb.length < this.sig + 1) {
+      sb.insert(0, this.mag.getSystem().toChar(0))
+    }
+
+    sb.insert(sb.length - this.sig, this.mag.getSystem().getRadixPointChar())
+
+    if (sb.length - this.sig === 0) {
+      sb.insert(0, this.mag.getSystem().toChar(0))
+    }
+
+    if (specialHead && head !== undefined) {
+      sb.insert(0, head)
+    }
+
+    return sb.toString()
+  }
+
+  public equals(other: LexoDecimal): boolean {
+    if (this === other) {
+      return true
+    }
+
+    if (!other) {
+      return false
+    }
+
+    return this.mag.equals(other.mag) && this.sig === other.sig
+  }
+
+  public toString(): string {
+    return this.format()
+  }
+}

--- a/packages/@sanity/lexorank/src/lexoRank/lexoHelper.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/lexoHelper.ts
@@ -1,0 +1,18 @@
+export const lexoHelper = {
+  arrayCopy,
+}
+
+function arrayCopy<T>(
+  sourceArray: readonly T[],
+  sourceIndex: number,
+  destinationArray: T[],
+  destinationIndex: number,
+  length: number,
+): void {
+  let destination = destinationIndex
+  const finalLength = sourceIndex + length
+  for (let i = sourceIndex; i < finalLength; i++) {
+    destinationArray[destination] = sourceArray[i]!
+    ++destination
+  }
+}

--- a/packages/@sanity/lexorank/src/lexoRank/lexoInteger.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/lexoInteger.ts
@@ -1,0 +1,381 @@
+import type {ILexoNumeralSystem} from '../numeralSystems'
+import StringBuilder from '../utils/stringBuilder'
+import {lexoHelper} from './lexoHelper'
+
+export class LexoInteger {
+  public static parse(strFull: string, system: ILexoNumeralSystem): LexoInteger {
+    let str = strFull
+    let sign = 1
+    if (strFull.indexOf(system.getPositiveChar()) === 0) {
+      str = strFull.substring(1)
+    } else if (strFull.indexOf(system.getNegativeChar()) === 0) {
+      str = strFull.substring(1)
+      sign = -1
+    }
+
+    const mag = Array.from({length: str.length}, () => 0)
+    let strIndex: number = mag.length - 1
+
+    for (let magIndex = 0; strIndex >= 0; ++magIndex) {
+      mag[magIndex] = system.toDigit(str.charAt(strIndex))
+      --strIndex
+    }
+
+    return LexoInteger.make(system, sign, mag)
+  }
+
+  public static zero(sys: ILexoNumeralSystem): LexoInteger {
+    return new LexoInteger(sys, 0, LexoInteger.ZERO_MAG)
+  }
+
+  public static one(sys: ILexoNumeralSystem): LexoInteger {
+    return LexoInteger.make(sys, 1, LexoInteger.ONE_MAG)
+  }
+
+  public static make(sys: ILexoNumeralSystem, sign: number, mag: number[]): LexoInteger {
+    let actualLength: number
+    for (
+      actualLength = mag.length;
+      actualLength > 0 && mag[actualLength - 1] === 0;
+      --actualLength
+    ) {
+      // ignore
+    }
+
+    if (actualLength === 0) {
+      return LexoInteger.zero(sys)
+    }
+
+    if (actualLength === mag.length) {
+      return new LexoInteger(sys, sign, mag)
+    }
+
+    const nmag = Array.from({length: actualLength}, () => 0)
+    lexoHelper.arrayCopy(mag, 0, nmag, 0, actualLength)
+    return new LexoInteger(sys, sign, nmag)
+  }
+
+  private static ZERO_MAG = [0]
+  private static ONE_MAG = [1]
+  private static add(sys: ILexoNumeralSystem, l: number[], r: number[]): number[] {
+    const estimatedSize = Math.max(l.length, r.length)
+    const result = Array.from({length: estimatedSize}, () => 0)
+    let carry = 0
+    for (let i = 0; i < estimatedSize; ++i) {
+      const lnum = l[i] ?? 0
+      const rnum = r[i] ?? 0
+      let sum = lnum + rnum + carry
+      for (carry = 0; sum >= sys.getBase(); sum -= sys.getBase()) {
+        ++carry
+      }
+
+      result[i] = sum
+    }
+
+    return LexoInteger.extendWithCarry(result, carry)
+  }
+
+  private static extendWithCarry(mag: number[], carry: number): number[] {
+    if (carry > 0) {
+      const extendedMag = Array.from({length: mag.length + 1}, () => 0)
+      lexoHelper.arrayCopy(mag, 0, extendedMag, 0, mag.length)
+      extendedMag[extendedMag.length - 1] = carry
+      return extendedMag
+    }
+
+    return mag
+  }
+
+  private static subtract(sys: ILexoNumeralSystem, l: number[], r: number[]): number[] {
+    const rComplement = LexoInteger.complement(sys, r, l.length)
+    const rSum = LexoInteger.add(sys, l, rComplement)
+    rSum[rSum.length - 1] = 0
+    return LexoInteger.add(sys, rSum, LexoInteger.ONE_MAG)
+  }
+
+  private static multiply(sys: ILexoNumeralSystem, l: number[], r: number[]): number[] {
+    const result = Array.from({length: l.length + r.length}, () => 0)
+    for (let li = 0; li < l.length; ++li) {
+      for (let ri = 0; ri < r.length; ++ri) {
+        const resultIndex = li + ri
+        result[resultIndex] = (result[resultIndex] ?? 0) + (l[li] ?? 0) * (r[ri] ?? 0)
+        for (; (result[resultIndex] ?? 0) >= sys.getBase();) {
+          result[resultIndex] = (result[resultIndex] ?? 0) - sys.getBase()
+          result[resultIndex + 1] = (result[resultIndex + 1] ?? 0) + 1
+        }
+      }
+    }
+
+    return result
+  }
+
+  private static complement(sys: ILexoNumeralSystem, mag: number[], digits: number): number[] {
+    if (digits <= 0) {
+      throw new Error('Expected at least 1 digit')
+    }
+
+    const nmag = Array.from({length: digits}, () => sys.getBase() - 1)
+    for (let i = 0; i < mag.length; ++i) {
+      nmag[i] = sys.getBase() - 1 - (mag[i] ?? 0)
+    }
+
+    return nmag
+  }
+
+  private static compare(l: number[], r: number[]): number {
+    if (l.length < r.length) {
+      return -1
+    }
+
+    if (l.length > r.length) {
+      return 1
+    }
+
+    for (let i = l.length - 1; i >= 0; --i) {
+      const left = l[i] ?? 0
+      const right = r[i] ?? 0
+      if (left < right) {
+        return -1
+      }
+      if (left > right) {
+        return 1
+      }
+    }
+
+    return 0
+  }
+
+  private readonly sys: ILexoNumeralSystem
+  private readonly sign: number
+  private readonly mag: number[]
+
+  constructor(system: ILexoNumeralSystem, sign: number, mag: number[]) {
+    this.sys = system
+    this.sign = sign
+    this.mag = mag
+  }
+
+  public add(other: LexoInteger): LexoInteger {
+    this.checkSystem(other)
+    if (this.isZero()) {
+      return other
+    }
+
+    if (other.isZero()) {
+      return this
+    }
+
+    if (this.sign !== other.sign) {
+      let pos
+      if (this.sign === -1) {
+        pos = this.negate()
+        const val = pos.subtract(other)
+        return val.negate()
+      }
+
+      pos = other.negate()
+      return this.subtract(pos)
+    }
+
+    const result = LexoInteger.add(this.sys, this.mag, other.mag)
+    return LexoInteger.make(this.sys, this.sign, result)
+  }
+
+  public subtract(other: LexoInteger): LexoInteger {
+    this.checkSystem(other)
+    if (this.isZero()) {
+      return other.negate()
+    }
+
+    if (other.isZero()) {
+      return this
+    }
+
+    if (this.sign !== other.sign) {
+      let negate
+      if (this.sign === -1) {
+        negate = this.negate()
+        const sum = negate.add(other)
+        return sum.negate()
+      }
+
+      negate = other.negate()
+      return this.add(negate)
+    }
+
+    const cmp = LexoInteger.compare(this.mag, other.mag)
+    if (cmp === 0) {
+      return LexoInteger.zero(this.sys)
+    }
+
+    return cmp < 0
+      ? LexoInteger.make(
+          this.sys,
+          this.sign === -1 ? 1 : -1,
+          LexoInteger.subtract(this.sys, other.mag, this.mag),
+        )
+      : LexoInteger.make(
+          this.sys,
+          this.sign === -1 ? -1 : 1,
+          LexoInteger.subtract(this.sys, this.mag, other.mag),
+        )
+  }
+
+  public multiply(other: LexoInteger): LexoInteger {
+    this.checkSystem(other)
+    if (this.isZero()) {
+      return this
+    }
+
+    if (other.isZero()) {
+      return other
+    }
+
+    if (this.isOneish()) {
+      return this.sign === other.sign
+        ? LexoInteger.make(this.sys, 1, other.mag)
+        : LexoInteger.make(this.sys, -1, other.mag)
+    }
+
+    if (other.isOneish()) {
+      return this.sign === other.sign
+        ? LexoInteger.make(this.sys, 1, this.mag)
+        : LexoInteger.make(this.sys, -1, this.mag)
+    }
+
+    const newMag = LexoInteger.multiply(this.sys, this.mag, other.mag)
+    return this.sign === other.sign
+      ? LexoInteger.make(this.sys, 1, newMag)
+      : LexoInteger.make(this.sys, -1, newMag)
+  }
+
+  public negate(): LexoInteger {
+    return this.isZero() ? this : LexoInteger.make(this.sys, this.sign === 1 ? -1 : 1, this.mag)
+  }
+
+  public shiftLeft(times = 1): LexoInteger {
+    if (times === 0) {
+      return this
+    }
+
+    if (times < 0) {
+      return this.shiftRight(Math.abs(times))
+    }
+
+    const nmag = Array.from({length: this.mag.length + times}, () => 0)
+    lexoHelper.arrayCopy(this.mag, 0, nmag, times, this.mag.length)
+    return LexoInteger.make(this.sys, this.sign, nmag)
+  }
+
+  public shiftRight(times = 1): LexoInteger {
+    if (this.mag.length - times <= 0) {
+      return LexoInteger.zero(this.sys)
+    }
+
+    const nmag = Array.from({length: this.mag.length - times}, () => 0)
+    lexoHelper.arrayCopy(this.mag, times, nmag, 0, nmag.length)
+    return LexoInteger.make(this.sys, this.sign, nmag)
+  }
+
+  public complement(): LexoInteger {
+    return this.complementDigits(this.mag.length)
+  }
+
+  public complementDigits(digits: number): LexoInteger {
+    return LexoInteger.make(this.sys, this.sign, LexoInteger.complement(this.sys, this.mag, digits))
+  }
+
+  public isZero(): boolean {
+    return this.sign === 0 && this.mag.length === 1 && this.mag[0] === 0
+  }
+
+  public isOne(): boolean {
+    return this.sign === 1 && this.mag.length === 1 && this.mag[0] === 1
+  }
+
+  public getMag(index: number): number {
+    return this.mag[index]!
+  }
+
+  public compareTo(other: LexoInteger): number {
+    if (this === other) {
+      return 0
+    }
+
+    if (!other) {
+      return 1
+    }
+
+    if (this.sign === -1) {
+      if (other.sign === -1) {
+        const cmp = LexoInteger.compare(this.mag, other.mag)
+        if (cmp === -1) {
+          return 1
+        }
+        return cmp === 1 ? -1 : 0
+      }
+
+      return -1
+    }
+
+    if (this.sign === 1) {
+      return other.sign === 1 ? LexoInteger.compare(this.mag, other.mag) : 1
+    }
+
+    if (other.sign === -1) {
+      return 1
+    }
+
+    return other.sign === 1 ? -1 : 0
+  }
+
+  public getSystem(): ILexoNumeralSystem {
+    return this.sys
+  }
+
+  public format(): string {
+    if (this.isZero()) {
+      return this.sys.toChar(0)
+    }
+
+    const sb = new StringBuilder()
+    const var2 = this.mag
+    const var3 = var2.length
+    for (let var4 = 0; var4 < var3; ++var4) {
+      const digit = var2[var4]!
+      sb.insert(0, this.sys.toChar(digit))
+    }
+
+    if (this.sign === -1) {
+      sb.insert(0, this.sys.getNegativeChar())
+    }
+
+    return sb.toString()
+  }
+
+  public equals(other: LexoInteger): boolean {
+    if (this === other) {
+      return true
+    }
+
+    if (!other) {
+      return false
+    }
+
+    return this.sys.getBase() === other.sys.getBase() && this.compareTo(other) === 0
+  }
+
+  public toString(): string {
+    return this.format()
+  }
+
+  private isOneish(): boolean {
+    return this.mag.length === 1 && this.mag[0] === 1
+  }
+
+  private checkSystem(other: LexoInteger): void {
+    if (this.sys.getBase() !== other.sys.getBase()) {
+      throw new Error('Expected numbers of same numeral sys')
+    }
+  }
+}

--- a/packages/@sanity/lexorank/src/lexoRank/lexoRank.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/lexoRank.ts
@@ -1,0 +1,361 @@
+import {LexoNumeralSystem36} from '../numeralSystems'
+import StringBuilder from '../utils/stringBuilder'
+import {LexoDecimal} from './lexoDecimal'
+import LexoRankBucket from './lexoRankBucket'
+
+export class LexoRank {
+  public static get NUMERAL_SYSTEM(): LexoNumeralSystem36 {
+    if (!this._NUMERAL_SYSTEM) {
+      this._NUMERAL_SYSTEM = new LexoNumeralSystem36()
+    }
+    return this._NUMERAL_SYSTEM
+  }
+
+  private static get ZERO_DECIMAL(): LexoDecimal {
+    if (!this._ZERO_DECIMAL) {
+      this._ZERO_DECIMAL = LexoDecimal.parse('0', LexoRank.NUMERAL_SYSTEM)
+    }
+
+    return this._ZERO_DECIMAL
+  }
+
+  private static get ONE_DECIMAL(): LexoDecimal {
+    if (!this._ONE_DECIMAL) {
+      this._ONE_DECIMAL = LexoDecimal.parse('1', LexoRank.NUMERAL_SYSTEM)
+    }
+
+    return this._ONE_DECIMAL
+  }
+
+  private static get EIGHT_DECIMAL(): LexoDecimal {
+    if (!this._EIGHT_DECIMAL) {
+      this._EIGHT_DECIMAL = LexoDecimal.parse('8', LexoRank.NUMERAL_SYSTEM)
+    }
+
+    return this._EIGHT_DECIMAL
+  }
+
+  private static get MIN_DECIMAL(): LexoDecimal {
+    if (!this._MIN_DECIMAL) {
+      this._MIN_DECIMAL = LexoRank.ZERO_DECIMAL
+    }
+
+    return this._MIN_DECIMAL
+  }
+
+  private static get MAX_DECIMAL(): LexoDecimal {
+    if (!this._MAX_DECIMAL) {
+      this._MAX_DECIMAL = LexoDecimal.parse('1000000', LexoRank.NUMERAL_SYSTEM).subtract(
+        LexoRank.ONE_DECIMAL,
+      )
+    }
+
+    return this._MAX_DECIMAL
+  }
+
+  private static get INITIAL_MIN_DECIMAL(): LexoDecimal {
+    if (!this._INITIAL_MIN_DECIMAL) {
+      this._INITIAL_MIN_DECIMAL = LexoDecimal.parse('100000', LexoRank.NUMERAL_SYSTEM)
+    }
+
+    return this._INITIAL_MIN_DECIMAL
+  }
+
+  private static get INITIAL_MAX_DECIMAL(): LexoDecimal {
+    if (!this._INITIAL_MAX_DECIMAL) {
+      this._INITIAL_MAX_DECIMAL = LexoDecimal.parse(
+        LexoRank.NUMERAL_SYSTEM.toChar(LexoRank.NUMERAL_SYSTEM.getBase() - 2) + '00000',
+        LexoRank.NUMERAL_SYSTEM,
+      )
+    }
+
+    return this._INITIAL_MAX_DECIMAL
+  }
+
+  public static min(): LexoRank {
+    return LexoRank.from(LexoRankBucket.BUCKET_0, LexoRank.MIN_DECIMAL)
+  }
+
+  public static middle(): LexoRank {
+    const minLexoRank = LexoRank.min()
+    return minLexoRank.between(LexoRank.max(minLexoRank.bucket))
+  }
+
+  public static max(bucket: LexoRankBucket = LexoRankBucket.BUCKET_0): LexoRank {
+    return LexoRank.from(bucket, LexoRank.MAX_DECIMAL)
+  }
+
+  public static initial(bucket: LexoRankBucket): LexoRank {
+    return bucket === LexoRankBucket.BUCKET_0
+      ? LexoRank.from(bucket, LexoRank.INITIAL_MIN_DECIMAL)
+      : LexoRank.from(bucket, LexoRank.INITIAL_MAX_DECIMAL)
+  }
+
+  public static between(oLeft: LexoDecimal, oRight: LexoDecimal): LexoDecimal {
+    if (oLeft.getSystem().getBase() !== oRight.getSystem().getBase()) {
+      throw new Error('Expected same system')
+    }
+
+    let left = oLeft
+    let right = oRight
+    let nLeft: LexoDecimal
+    if (oLeft.getScale() < oRight.getScale()) {
+      nLeft = oRight.setScale(oLeft.getScale(), false)
+      if (oLeft.compareTo(nLeft) >= 0) {
+        return LexoRank.mid(oLeft, oRight)
+      }
+
+      right = nLeft
+    }
+
+    if (oLeft.getScale() > right.getScale()) {
+      nLeft = oLeft.setScale(right.getScale(), true)
+      if (nLeft.compareTo(right) >= 0) {
+        return LexoRank.mid(oLeft, oRight)
+      }
+
+      left = nLeft
+    }
+
+    let nRight: LexoDecimal
+    for (let scale = left.getScale(); scale > 0; right = nRight) {
+      const nScale1 = scale - 1
+      const nLeft1 = left.setScale(nScale1, true)
+      nRight = right.setScale(nScale1, false)
+      const cmp = nLeft1.compareTo(nRight)
+      if (cmp === 0) {
+        return LexoRank.checkMid(oLeft, oRight, nLeft1)
+      }
+      if (nLeft1.compareTo(nRight) > 0) {
+        break
+      }
+
+      scale = nScale1
+      left = nLeft1
+    }
+
+    let mid = LexoRank.middleInternal(oLeft, oRight, left, right)
+
+    let nScale: number
+    for (let mScale = mid.getScale(); mScale > 0; mScale = nScale) {
+      nScale = mScale - 1
+      const nMid = mid.setScale(nScale)
+      if (oLeft.compareTo(nMid) >= 0 || nMid.compareTo(oRight) >= 0) {
+        break
+      }
+
+      mid = nMid
+    }
+
+    return mid
+  }
+
+  public static parse(str: string): LexoRank {
+    const parts = str.split('|')
+    const bucket = LexoRankBucket.from(parts[0]!)
+    const decimal = LexoDecimal.parse(parts[1]!, LexoRank.NUMERAL_SYSTEM)
+    return new LexoRank(bucket, decimal)
+  }
+
+  public static from(bucket: LexoRankBucket, decimal: LexoDecimal): LexoRank {
+    if (decimal.getSystem().getBase() !== LexoRank.NUMERAL_SYSTEM.getBase()) {
+      throw new Error('Expected different system')
+    }
+
+    return new LexoRank(bucket, decimal)
+  }
+
+  private static _NUMERAL_SYSTEM: LexoNumeralSystem36 | undefined
+
+  private static _ZERO_DECIMAL: LexoDecimal | undefined
+
+  private static _ONE_DECIMAL: LexoDecimal | undefined
+
+  private static _EIGHT_DECIMAL: LexoDecimal | undefined
+
+  private static _MIN_DECIMAL: LexoDecimal | undefined
+
+  private static _MAX_DECIMAL: LexoDecimal | undefined
+
+  private static _INITIAL_MIN_DECIMAL: LexoDecimal | undefined
+
+  private static _INITIAL_MAX_DECIMAL: LexoDecimal | undefined
+
+  private static middleInternal(
+    lbound: LexoDecimal,
+    rbound: LexoDecimal,
+    left: LexoDecimal,
+    right: LexoDecimal,
+  ): LexoDecimal {
+    const mid = LexoRank.mid(left, right)
+    return LexoRank.checkMid(lbound, rbound, mid)
+  }
+
+  private static checkMid(lbound: LexoDecimal, rbound: LexoDecimal, mid: LexoDecimal): LexoDecimal {
+    if (lbound.compareTo(mid) >= 0) {
+      return LexoRank.mid(lbound, rbound)
+    }
+
+    return mid.compareTo(rbound) >= 0 ? LexoRank.mid(lbound, rbound) : mid
+  }
+
+  private static mid(left: LexoDecimal, right: LexoDecimal): LexoDecimal {
+    const sum = left.add(right)
+    const mid = sum.multiply(LexoDecimal.half(left.getSystem()))
+    const scale = left.getScale() > right.getScale() ? left.getScale() : right.getScale()
+    if (mid.getScale() > scale) {
+      const roundDown = mid.setScale(scale, false)
+      if (roundDown.compareTo(left) > 0) {
+        return roundDown
+      }
+      const roundUp = mid.setScale(scale, true)
+      if (roundUp.compareTo(right) < 0) {
+        return roundUp
+      }
+    }
+    return mid
+  }
+
+  private static formatDecimal(decimal: LexoDecimal): string {
+    const formatVal = decimal.format()
+    const val = new StringBuilder(formatVal)
+    let partialIndex = formatVal.indexOf(LexoRank.NUMERAL_SYSTEM.getRadixPointChar())
+    const zero = LexoRank.NUMERAL_SYSTEM.toChar(0)
+    if (partialIndex < 0) {
+      partialIndex = formatVal.length
+      val.append(LexoRank.NUMERAL_SYSTEM.getRadixPointChar())
+    }
+
+    while (partialIndex < 6) {
+      val.insert(0, zero)
+      ++partialIndex
+    }
+
+    while (val[val.length - 1] === zero) {
+      val.length = val.length - 1
+    }
+
+    return val.toString()
+  }
+
+  private readonly value: string
+  private readonly bucket: LexoRankBucket
+  private readonly decimal: LexoDecimal
+
+  public constructor(bucket: LexoRankBucket, decimal: LexoDecimal) {
+    this.value = bucket.format() + '|' + LexoRank.formatDecimal(decimal)
+    this.bucket = bucket
+    this.decimal = decimal
+  }
+
+  public genPrev(): LexoRank {
+    if (this.isMax()) {
+      return new LexoRank(this.bucket, LexoRank.INITIAL_MAX_DECIMAL)
+    }
+
+    const floorInteger = this.decimal.floor()
+    const floorDecimal = LexoDecimal.from(floorInteger)
+    let nextDecimal = floorDecimal.subtract(LexoRank.EIGHT_DECIMAL)
+    if (nextDecimal.compareTo(LexoRank.MIN_DECIMAL) <= 0) {
+      nextDecimal = LexoRank.between(LexoRank.MIN_DECIMAL, this.decimal)
+    }
+
+    return new LexoRank(this.bucket, nextDecimal)
+  }
+
+  public genNext(): LexoRank {
+    if (this.isMin()) {
+      return new LexoRank(this.bucket, LexoRank.INITIAL_MIN_DECIMAL)
+    }
+    const ceilInteger = this.decimal.ceil()
+    const ceilDecimal = LexoDecimal.from(ceilInteger)
+    let nextDecimal = ceilDecimal.add(LexoRank.EIGHT_DECIMAL)
+    if (nextDecimal.compareTo(LexoRank.MAX_DECIMAL) >= 0) {
+      nextDecimal = LexoRank.between(this.decimal, LexoRank.MAX_DECIMAL)
+    }
+
+    return new LexoRank(this.bucket, nextDecimal)
+  }
+
+  public between(other: LexoRank): LexoRank {
+    if (!this.bucket.equals(other.bucket)) {
+      throw new Error('Between works only within the same bucket')
+    }
+
+    const cmp = this.decimal.compareTo(other.decimal)
+    if (cmp > 0) {
+      return new LexoRank(this.bucket, LexoRank.between(other.decimal, this.decimal))
+    }
+
+    if (cmp === 0) {
+      throw new Error(
+        'Try to rank between issues with same rank this=' +
+          this +
+          ' other=' +
+          other +
+          ' this.decimal=' +
+          this.decimal +
+          ' other.decimal=' +
+          other.decimal,
+      )
+    }
+
+    return new LexoRank(this.bucket, LexoRank.between(this.decimal, other.decimal))
+  }
+
+  public getBucket(): LexoRankBucket {
+    return this.bucket
+  }
+
+  public getDecimal(): LexoDecimal {
+    return this.decimal
+  }
+
+  public inNextBucket(): LexoRank {
+    return LexoRank.from(this.bucket.next(), this.decimal)
+  }
+
+  public inPrevBucket(): LexoRank {
+    return LexoRank.from(this.bucket.prev(), this.decimal)
+  }
+
+  public isMin(): boolean {
+    return this.decimal.equals(LexoRank.MIN_DECIMAL)
+  }
+
+  public isMax(): boolean {
+    return this.decimal.equals(LexoRank.MAX_DECIMAL)
+  }
+
+  public format(): string {
+    return this.value
+  }
+
+  public equals(other: LexoRank): boolean {
+    if (this === other) {
+      return true
+    }
+
+    if (!other) {
+      return false
+    }
+
+    return this.value === other.value
+  }
+
+  public toString(): string {
+    return this.value
+  }
+
+  public compareTo(other: LexoRank): number {
+    if (this === other) {
+      return 0
+    }
+
+    if (!other) {
+      return 1
+    }
+
+    return this.value.localeCompare(other.value)
+  }
+}

--- a/packages/@sanity/lexorank/src/lexoRank/lexoRankBucket.ts
+++ b/packages/@sanity/lexorank/src/lexoRank/lexoRankBucket.ts
@@ -1,0 +1,113 @@
+import {LexoInteger} from './lexoInteger'
+import {LexoRank} from './lexoRank'
+
+class LexoRankBucket {
+  public static get BUCKET_0(): LexoRankBucket {
+    if (!this._BUCKET_0) {
+      this._BUCKET_0 = new LexoRankBucket('0')
+    }
+
+    return this._BUCKET_0
+  }
+
+  private static get BUCKET_1(): LexoRankBucket {
+    if (!this._BUCKET_1) {
+      this._BUCKET_1 = new LexoRankBucket('1')
+    }
+
+    return this._BUCKET_1
+  }
+
+  private static get BUCKET_2(): LexoRankBucket {
+    if (!this._BUCKET_2) {
+      this._BUCKET_2 = new LexoRankBucket('2')
+    }
+
+    return this._BUCKET_2
+  }
+
+  private static get VALUES(): LexoRankBucket[] {
+    if (!this._VALUES) {
+      this._VALUES = [LexoRankBucket.BUCKET_0, LexoRankBucket.BUCKET_1, LexoRankBucket.BUCKET_2]
+    }
+
+    return this._VALUES
+  }
+
+  public static max(): LexoRankBucket {
+    return LexoRankBucket.VALUES[LexoRankBucket.VALUES.length - 1]!
+  }
+
+  public static from(str: string): LexoRankBucket {
+    const val = LexoInteger.parse(str, LexoRank.NUMERAL_SYSTEM)
+    for (const bucket of LexoRankBucket.VALUES) {
+      if (bucket.value.equals(val)) {
+        return bucket
+      }
+    }
+
+    throw new Error('Unknown bucket: ' + str)
+  }
+
+  public static resolve(bucketId: number): LexoRankBucket {
+    for (const bucket of LexoRankBucket.VALUES) {
+      if (bucket.equals(LexoRankBucket.from(bucketId.toString()))) {
+        return bucket
+      }
+    }
+
+    throw new Error('No bucket found with id ' + bucketId)
+  }
+
+  private static _BUCKET_0: LexoRankBucket | undefined
+
+  private static _BUCKET_1: LexoRankBucket | undefined
+
+  private static _BUCKET_2: LexoRankBucket | undefined
+
+  private static _VALUES: LexoRankBucket[] | undefined
+
+  private readonly value: LexoInteger
+
+  private constructor(val: string) {
+    this.value = LexoInteger.parse(val, LexoRank.NUMERAL_SYSTEM)
+  }
+
+  public format(): string {
+    return this.value.format()
+  }
+
+  public next(): LexoRankBucket {
+    if (this.equals(LexoRankBucket.BUCKET_0)) {
+      return LexoRankBucket.BUCKET_1
+    }
+    if (this.equals(LexoRankBucket.BUCKET_1)) {
+      return LexoRankBucket.BUCKET_2
+    }
+    return this.equals(LexoRankBucket.BUCKET_2) ? LexoRankBucket.BUCKET_0 : LexoRankBucket.BUCKET_2
+  }
+
+  public prev(): LexoRankBucket {
+    if (this.equals(LexoRankBucket.BUCKET_0)) {
+      return LexoRankBucket.BUCKET_2
+    }
+    if (this.equals(LexoRankBucket.BUCKET_1)) {
+      return LexoRankBucket.BUCKET_0
+    }
+    return this.equals(LexoRankBucket.BUCKET_2) ? LexoRankBucket.BUCKET_1 : LexoRankBucket.BUCKET_0
+  }
+
+  public equals(other: LexoRankBucket): boolean {
+    if (this === other) {
+      return true
+    }
+
+    if (!other) {
+      return false
+    }
+
+    return this.value.equals(other.value)
+  }
+}
+
+export default LexoRankBucket

--- a/packages/@sanity/lexorank/src/numeralSystems/index.ts
+++ b/packages/@sanity/lexorank/src/numeralSystems/index.ts
@@ -1,0 +1,4 @@
+export * from './lexoNumeralSystem'
+export * from './lexoNumeralSystem10'
+export * from './lexoNumeralSystem36'
+export * from './lexoNumeralSystem64'

--- a/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem.ts
+++ b/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem.ts
@@ -1,0 +1,13 @@
+export interface ILexoNumeralSystem {
+  getBase(): number
+
+  getPositiveChar(): string
+
+  getNegativeChar(): string
+
+  getRadixPointChar(): string
+
+  toDigit(var1: string): number
+
+  toChar(var1: number): string
+}

--- a/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem10.ts
+++ b/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem10.ts
@@ -1,0 +1,31 @@
+import type {ILexoNumeralSystem} from './lexoNumeralSystem'
+
+export class LexoNumeralSystem10 implements ILexoNumeralSystem {
+  public getBase(): number {
+    return 10
+  }
+
+  public getPositiveChar(): string {
+    return '+'
+  }
+
+  public getNegativeChar(): string {
+    return '-'
+  }
+
+  public getRadixPointChar(): string {
+    return '.'
+  }
+
+  public toDigit(ch: string): number {
+    if (ch >= '0' && ch <= '9') {
+      return ch.charCodeAt(0) - 48
+    }
+
+    throw new Error('Not valid digit: ' + ch)
+  }
+
+  public toChar(digit: number): string {
+    return String.fromCharCode(digit + 48)
+  }
+}

--- a/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem36.ts
+++ b/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem36.ts
@@ -1,0 +1,37 @@
+import type {ILexoNumeralSystem} from './lexoNumeralSystem'
+
+export class LexoNumeralSystem36 implements ILexoNumeralSystem {
+  private DIGITS = '0123456789abcdefghijklmnopqrstuvwxyz'.split('')
+
+  public getBase(): number {
+    return 36
+  }
+
+  public getPositiveChar(): string {
+    return '+'
+  }
+
+  public getNegativeChar(): string {
+    return '-'
+  }
+
+  public getRadixPointChar(): string {
+    return ':'
+  }
+
+  public toDigit(ch: string): number {
+    if (ch >= '0' && ch <= '9') {
+      return ch.charCodeAt(0) - 48
+    }
+
+    if (ch >= 'a' && ch <= 'z') {
+      return ch.charCodeAt(0) - 97 + 10
+    }
+
+    throw new Error('Not valid digit: ' + ch)
+  }
+
+  public toChar(digit: number): string {
+    return this.DIGITS[digit]!
+  }
+}

--- a/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem64.ts
+++ b/packages/@sanity/lexorank/src/numeralSystems/lexoNumeralSystem64.ts
@@ -1,0 +1,49 @@
+import type {ILexoNumeralSystem} from './lexoNumeralSystem'
+
+export class LexoNumeralSystem64 implements ILexoNumeralSystem {
+  public DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_abcdefghijklmnopqrstuvwxyz'.split('')
+
+  public getBase(): number {
+    return 64
+  }
+
+  public getPositiveChar(): string {
+    return '+'
+  }
+
+  public getNegativeChar(): string {
+    return '-'
+  }
+
+  public getRadixPointChar(): string {
+    return ':'
+  }
+
+  public toDigit(ch: string): number {
+    if (ch >= '0' && ch <= '9') {
+      return ch.charCodeAt(0) - 48
+    }
+
+    if (ch >= 'A' && ch <= 'Z') {
+      return ch.charCodeAt(0) - 65 + 10
+    }
+
+    if (ch === '^') {
+      return 36
+    }
+
+    if (ch === '_') {
+      return 37
+    }
+
+    if (ch >= 'a' && ch <= 'z') {
+      return ch.charCodeAt(0) - 97 + 38
+    }
+
+    throw new Error('Not valid digit: ' + ch)
+  }
+
+  public toChar(digit: number): string {
+    return this.DIGITS[digit]!
+  }
+}

--- a/packages/@sanity/lexorank/src/utils/stringBuilder.ts
+++ b/packages/@sanity/lexorank/src/utils/stringBuilder.ts
@@ -1,0 +1,38 @@
+class StringBuilder {
+  [index: number]: string | undefined
+
+  private str: string
+
+  constructor(str = '') {
+    this.str = str
+  }
+
+  get length() {
+    return this.str.length
+  }
+
+  set length(value: number) {
+    this.str = this.str.substring(0, value)
+  }
+
+  public append(str: string): StringBuilder {
+    this.str = this.str + str
+    return this
+  }
+
+  public remove(startIndex: number, length: number): StringBuilder {
+    this.str = this.str.slice(0, startIndex) + this.str.slice(startIndex + length)
+    return this
+  }
+
+  public insert(index: number, value: string): StringBuilder {
+    this.str = this.str.slice(0, index) + value + this.str.slice(index)
+    return this
+  }
+
+  public toString(): string {
+    return this.str
+  }
+}
+
+export default StringBuilder

--- a/packages/@sanity/lexorank/tsconfig.json
+++ b/packages/@sanity/lexorank/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["@sanity/tsconfig/strictest"],
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/@sanity/lexorank/tsdown.config.ts
+++ b/packages/@sanity/lexorank/tsdown.config.ts
@@ -1,0 +1,4 @@
+import {defineConfig} from '@sanity/tsdown-config'
+import type {UserConfig} from 'tsdown'
+
+export default defineConfig({}) satisfies Promise<UserConfig | UserConfig[]>

--- a/packages/@sanity/lexorank/vitest.config.ts
+++ b/packages/@sanity/lexorank/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        inline: ['vitest-package-exports'],
+      },
+    },
+  },
+})

--- a/plugins/@sanity/orderable-document-list/README.md
+++ b/plugins/@sanity/orderable-document-list/README.md
@@ -192,7 +192,10 @@ See the examples above.
 
 ## How it works
 
-Uses [kvandakes](https://github.com/kvandake)'s [TypeScript implementation](https://github.com/kvandake/lexorank-ts) of [Jira's Lexorank](https://www.youtube.com/watch?v=OjQv9xMoFbg) to create a "lexographical" Document order.
+Uses [`@sanity/lexorank`](../../../packages/@sanity/lexorank), an ESM-compatible port of
+[kvandake's TypeScript implementation](https://github.com/kvandake/lexorank-ts) of
+[Jira's LexoRank](https://www.youtube.com/watch?v=OjQv9xMoFbg), to create a lexicographical document
+order.
 
 Put simply it updates the position of an individual – or many – Documents in an ordered list without updating any others. It's fast.
 

--- a/plugins/@sanity/orderable-document-list/package.json
+++ b/plugins/@sanity/orderable-document-list/package.json
@@ -40,8 +40,8 @@
     "@hello-pangea/dnd": "catalog:",
     "@sanity/client": "catalog:",
     "@sanity/icons": "catalog:",
+    "@sanity/lexorank": "workspace:^",
     "@sanity/ui": "catalog:",
-    "lexorank": "catalog:",
     "sanity-plugin-utils": "workspace:^"
   },
   "devDependencies": {

--- a/plugins/@sanity/orderable-document-list/src/helpers/__tests__/initialRank.test.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/__tests__/initialRank.test.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 import {describe, expect, it} from 'vitest'
 
 import {initialRank} from '../initialRank'
@@ -16,5 +16,20 @@ describe('initialRank', () => {
   it('falls back to LexoRank.min when parse fails', () => {
     const rank = initialRank('not-a-rank', 'after')
     expect(() => LexoRank.parse(rank)).not.toThrow()
+  })
+
+  it('preserves the legacy default rank for documents appended to a list', () => {
+    expect(initialRank(undefined, 'after')).toBe('0|100008:')
+  })
+
+  it('preserves the legacy minimum rank for documents prepended to a list', () => {
+    expect(initialRank(undefined, 'before')).toBe('0|000000:')
+  })
+
+  it('generates ranks on the requested side of an existing rank', () => {
+    const compareRank = LexoRank.middle().toString()
+
+    expect(initialRank(compareRank, 'before') < compareRank).toBe(true)
+    expect(initialRank(compareRank, 'after') > compareRank).toBe(true)
   })
 })

--- a/plugins/@sanity/orderable-document-list/src/helpers/__tests__/parseOrderRank.test.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/__tests__/parseOrderRank.test.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 import {describe, expect, it} from 'vitest'
 
 import {parseOrderRank} from '../parseOrderRank'

--- a/plugins/@sanity/orderable-document-list/src/helpers/__tests__/reorderDocuments.test.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/__tests__/reorderDocuments.test.ts
@@ -1,9 +1,20 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 import {describe, expect, it} from 'vitest'
 
 import type {SanityDocumentWithOrder} from '../../types'
 import {ORDER_FIELD_NAME} from '../constants'
 import {reorderDocuments} from '../reorderDocuments'
+
+function createDocument(id: string, orderRank: string): SanityDocumentWithOrder {
+  return {
+    _id: id,
+    _type: 'orderableCategory',
+    orderRank,
+    _createdAt: '2026-01-01T00:00:00.000Z',
+    _updatedAt: '2026-01-01T00:00:00.000Z',
+    _rev: '1',
+  }
+}
 
 describe('reorderDocuments', () => {
   it('handles non-string orderRank values without throwing', () => {
@@ -45,5 +56,36 @@ describe('reorderDocuments', () => {
       throw new Error('Expected reordered rank to be a string')
     }
     expect(() => LexoRank.parse(updatedRank)).not.toThrow()
+  })
+
+  it('assigns ordered compatible ranks when moving multiple documents', () => {
+    const ranks = [
+      LexoRank.min().genNext(),
+      LexoRank.min().genNext().genNext(),
+      LexoRank.middle(),
+      LexoRank.max().genPrev(),
+    ]
+    const entities = ranks.map((rank, index) => createDocument(String(index), rank.toString()))
+
+    const result = reorderDocuments({
+      entities,
+      selectedIds: ['0', '1'],
+      source: {index: 0, droppableId: 'documentSortZone'},
+      destination: {index: 3, droppableId: 'documentSortZone'},
+    })
+
+    const patchedRanks = result.patches.map(([, patch]) => patch.set?.[ORDER_FIELD_NAME])
+    expect(patchedRanks).toHaveLength(2)
+    expect(patchedRanks.every((rank) => typeof rank === 'string')).toBe(true)
+
+    const stringRanks = patchedRanks.filter((rank): rank is string => typeof rank === 'string')
+    const [firstRank, secondRank] = stringRanks
+    if (firstRank === undefined || secondRank === undefined) {
+      throw new Error('Expected two reordered ranks')
+    }
+    expect(firstRank < secondRank).toBe(true)
+    expect(firstRank > ranks[3]!.toString()).toBe(true)
+    expect(stringRanks.every((rank) => LexoRank.parse(rank).toString() === rank)).toBe(true)
+    expect(result.newOrder.map((document) => document._id)).toEqual(['2', '3', '0', '1'])
   })
 })

--- a/plugins/@sanity/orderable-document-list/src/helpers/__tests__/resetOrder.test.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/__tests__/resetOrder.test.ts
@@ -1,0 +1,48 @@
+import type {SanityClient} from '@sanity/client'
+import {LexoRank} from '@sanity/lexorank'
+import {describe, expect, it, vi} from 'vitest'
+
+import {ORDER_FIELD_NAME} from '../constants'
+import {resetOrder} from '../resetOrder'
+
+describe('resetOrder', () => {
+  it('writes deterministic compatible ranks in document order', async () => {
+    const patches: Array<{id: string; rank: unknown}> = []
+    const transaction = {
+      patch: vi.fn((id: string, patch: {set?: Record<string, unknown>}) => {
+        patches.push({id, rank: patch.set?.[ORDER_FIELD_NAME]})
+        return transaction
+      }),
+      commit: vi.fn().mockResolvedValue({transactionId: 'reset-order'}),
+    }
+    const client = {
+      fetch: vi.fn().mockResolvedValue([
+        {_id: 'first', _type: 'orderableCategory', orderRank: 'legacy'},
+        {_id: 'second', _type: 'orderableCategory', orderRank: 'legacy'},
+        {_id: 'third', _type: 'orderableCategory', orderRank: 'legacy'},
+      ]),
+      transaction: vi.fn(() => transaction),
+    }
+
+    await resetOrder({
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+      client: client as unknown as SanityClient,
+      type: 'orderableCategory',
+    })
+
+    expect(patches).toEqual([
+      {id: 'first', rank: '0|100008:'},
+      {id: 'second', rank: '0|10000o:'},
+      {id: 'third', rank: '0|100014:'},
+    ])
+    expect(
+      patches.every(({rank}) =>
+        typeof rank === 'string' ? LexoRank.parse(rank).toString() === rank : false,
+      ),
+    ).toBe(true)
+    expect(transaction.commit).toHaveBeenCalledWith({
+      visibility: 'async',
+      tag: 'orderable-document-list.reset-order',
+    })
+  })
+})

--- a/plugins/@sanity/orderable-document-list/src/helpers/initialRank.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/initialRank.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 
 import type {NewItemPosition} from '../types'
 import {parseOrderRank} from './parseOrderRank'

--- a/plugins/@sanity/orderable-document-list/src/helpers/parseOrderRank.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/parseOrderRank.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 
 // Safely parse a LexoRank string; fall back if invalid
 export function parseOrderRank(value: unknown, fallback: LexoRank): LexoRank {

--- a/plugins/@sanity/orderable-document-list/src/helpers/reorderDocuments.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/reorderDocuments.ts
@@ -1,5 +1,5 @@
 import type {DraggableLocation} from '@hello-pangea/dnd'
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 import type {PatchOperations} from 'sanity'
 
 import type {SanityDocumentWithOrder} from '../types'

--- a/plugins/@sanity/orderable-document-list/src/helpers/resetOrder.ts
+++ b/plugins/@sanity/orderable-document-list/src/helpers/resetOrder.ts
@@ -1,5 +1,5 @@
 import type {MultipleMutationResult, SanityClient} from '@sanity/client'
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 
 import {ORDER_FIELD_NAME} from './constants'
 import {getDocumentQuery, type DocumentListQueryProps} from './query'

--- a/plugins/sanity-plugin-workflow/package.json
+++ b/plugins/sanity-plugin-workflow/package.json
@@ -53,9 +53,9 @@
   "dependencies": {
     "@hello-pangea/dnd": "catalog:",
     "@sanity/icons": "catalog:",
+    "@sanity/lexorank": "workspace:^",
     "@sanity/ui": "catalog:",
     "@tanstack/react-virtual": "^3.14.10",
-    "lexorank": "catalog:",
     "motion": "catalog:",
     "sanity-plugin-utils": "workspace:^"
   },

--- a/plugins/sanity-plugin-workflow/src/actions/useBeginWorkflow.tsx
+++ b/plugins/sanity-plugin-workflow/src/actions/useBeginWorkflow.tsx
@@ -1,6 +1,6 @@
 import {SplitVerticalIcon} from '@sanity/icons/SplitVertical'
+import {LexoRank} from '@sanity/lexorank'
 import {useToast} from '@sanity/ui/toast'
-import {LexoRank} from 'lexorank'
 import {useCallback, useState} from 'react'
 import {type DocumentActionDescription, type DocumentActionProps, useClient} from 'sanity'
 

--- a/plugins/sanity-plugin-workflow/src/components/Verify.tsx
+++ b/plugins/sanity-plugin-workflow/src/components/Verify.tsx
@@ -1,6 +1,6 @@
+import {LexoRank} from '@sanity/lexorank'
 import {Button} from '@sanity/ui'
 import {useToast} from '@sanity/ui/toast'
-import {LexoRank} from 'lexorank'
 import {useCallback, useMemo} from 'react'
 import {useClient} from 'sanity'
 import type {UserExtended} from 'sanity-plugin-utils'

--- a/plugins/sanity-plugin-workflow/src/components/WorkflowTool.tsx
+++ b/plugins/sanity-plugin-workflow/src/components/WorkflowTool.tsx
@@ -5,10 +5,10 @@ import {
   Droppable,
   type DropResult,
 } from '@hello-pangea/dnd'
+import {LexoRank} from '@sanity/lexorank'
 import {Box, Card, Container, Flex, Grid, Spinner, useTheme} from '@sanity/ui'
 import {getTheme_v2} from '@sanity/ui/theme'
 import {useToast} from '@sanity/ui/toast'
-import {LexoRank} from 'lexorank'
 import {useCallback, useMemo, useState} from 'react'
 import {type Tool, useCurrentUser} from 'sanity'
 import {Feedback, useProjectUsers} from 'sanity-plugin-utils'

--- a/plugins/sanity-plugin-workflow/src/helpers/generateMultipleOrderRanks.test.ts
+++ b/plugins/sanity-plugin-workflow/src/helpers/generateMultipleOrderRanks.test.ts
@@ -1,0 +1,27 @@
+import {LexoRank} from '@sanity/lexorank'
+import {describe, expect, it} from 'vitest'
+
+import {generateMultipleOrderRanks} from './generateMultipleOrderRanks'
+
+describe('generateMultipleOrderRanks', () => {
+  it('generates ordered compatible ranks within the legacy bounds', () => {
+    const ranks = generateMultipleOrderRanks(7)
+    const strings = ranks.map((rank) => rank.toString())
+
+    expect(strings).toEqual([...strings].sort())
+    expect(strings.every((rank) => LexoRank.parse(rank).toString() === rank)).toBe(true)
+    expect(strings[0]! > LexoRank.min().toString()).toBe(true)
+    expect(strings.at(-1)! < LexoRank.max().toString()).toBe(true)
+  })
+
+  it('generates ranks between stored boundary values', () => {
+    const start = LexoRank.parse('0|100000:')
+    const end = LexoRank.parse('0|y00000:')
+    const ranks = generateMultipleOrderRanks(5, start, end)
+    const strings = ranks.map((rank) => rank.toString())
+
+    expect(strings[0]).toBe(start.toString())
+    expect(strings.at(-1)).toBe(end.toString())
+    expect(strings).toEqual([...strings].sort())
+  })
+})

--- a/plugins/sanity-plugin-workflow/src/helpers/generateMultipleOrderRanks.ts
+++ b/plugins/sanity-plugin-workflow/src/helpers/generateMultipleOrderRanks.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 
 function generateMiddleValue(ranks: (LexoRank | undefined)[]) {
   // Has no undefined values

--- a/plugins/sanity-plugin-workflow/src/helpers/initialRank.test.ts
+++ b/plugins/sanity-plugin-workflow/src/helpers/initialRank.test.ts
@@ -1,0 +1,18 @@
+import {LexoRank} from '@sanity/lexorank'
+import {describe, expect, it} from 'vitest'
+
+import initialRank from './initialRank'
+
+describe('initialRank', () => {
+  it('preserves the legacy default rank', () => {
+    expect(initialRank()).toBe('0|100008:')
+  })
+
+  it('generates a compatible rank after a stored rank', () => {
+    const storedRank = LexoRank.middle().toString()
+    const rank = initialRank(storedRank)
+
+    expect(rank > storedRank).toBe(true)
+    expect(LexoRank.parse(rank).toString()).toBe(rank)
+  })
+})

--- a/plugins/sanity-plugin-workflow/src/helpers/initialRank.ts
+++ b/plugins/sanity-plugin-workflow/src/helpers/initialRank.ts
@@ -1,4 +1,4 @@
-import {LexoRank} from 'lexorank'
+import {LexoRank} from '@sanity/lexorank'
 
 // Use in initial value field by passing in the rank value of the last document
 // If no value passed, generate a sensibly low rank
@@ -9,6 +9,5 @@ export default function initialRank(lastRankValue = ``): string {
       : LexoRank.min()
   const nextRank = lastRank.genNext().genNext()
 
-  // oxlint-disable-next-line no-unsafe-type-assertion
-  return (nextRank as any).value
+  return nextRank.toString()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ catalogs:
     jsdom:
       specifier: ^29.1.1
       version: 29.1.1
-    lexorank:
-      specifier: ^1.0.5
-      version: 1.0.5
     lodash-es:
       specifier: ^4.18.1
       version: 4.18.1
@@ -505,6 +502,18 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+
+  packages/@sanity/lexorank:
+    devDependencies:
+      '@sanity/tsconfig':
+        specifier: 'catalog:'
+        version: 2.2.1
+      '@sanity/tsdown-config':
+        specifier: 'catalog:'
+        version: 0.27.1(@babel/core@7.29.7)(@rolldown/plugin-babel@0.2.3)(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(oxc-transform-react@0.145.0)(tsdown@0.22.14)(typescript@7.0.2)(vite@8.2.2)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(@vitejs/devtools@0.4.12)(oxc-resolver@11.24.2)(publint@0.3.24)(tsx@4.23.12)(typescript@7.0.2)
 
   packages/@sanity/plugin-kit:
     dependencies:
@@ -1375,6 +1384,9 @@ importers:
 
   plugins/@sanity/orderable-document-list:
     dependencies:
+      '@sanity/lexorank':
+        specifier: workspace:^
+        version: link:../../../packages/@sanity/lexorank
       '@hello-pangea/dnd':
         specifier: 'catalog:'
         version: 18.0.1(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -1387,9 +1399,6 @@ importers:
       '@sanity/ui':
         specifier: 'catalog:'
         version: 4.0.7(react-dom@19.2.8)(react@19.2.8)(styled-components@6.5.3)
-      lexorank:
-        specifier: 'catalog:'
-        version: 1.0.5
       sanity:
         specifier: next
         version: 6.13.0-next.85(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3)(@sanity/sdk@3.1.0)(@types/node@24.13.3)(@types/react-dom@19.2.4)(@types/react@19.2.18)(@vitejs/devtools@0.4.12)(babel-plugin-react-compiler@1.0.0)(esbuild@0.28.1)(immer@11.1.17)(jiti@2.7.0)(oxc-transform-react@0.147.0)(oxfmt@0.63.0)(react-dom@19.2.8)(react@19.2.8)(rolldown@1.2.6)(styled-components@6.5.3)(supports-color@10.2.2)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)
@@ -3050,6 +3059,9 @@ importers:
 
   plugins/sanity-plugin-workflow:
     dependencies:
+      '@sanity/lexorank':
+        specifier: workspace:^
+        version: link:../../packages/@sanity/lexorank
       '@hello-pangea/dnd':
         specifier: 'catalog:'
         version: 18.0.1(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -3062,9 +3074,6 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.10
         version: 3.14.10(react-dom@19.2.8)(react@19.2.8)
-      lexorank:
-        specifier: 'catalog:'
-        version: 1.0.5
       motion:
         specifier: 'catalog:'
         version: 13.1.0(react-dom@19.2.8)(react@19.2.8)
@@ -11802,9 +11811,6 @@ packages:
   leven@4.1.0:
     resolution: {integrity: sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  lexorank@1.0.5:
-    resolution: {integrity: sha512-K1B/Yr/gIU0wm68hk/yB0p/mv6xM3ShD5aci42vOwcjof8slG8Kpo3Q7+1WTv7DaRHKWRgLPqrFDt+4GtuFAtA==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -26696,8 +26702,6 @@ snapshots:
     optional: true
 
   leven@4.1.0: {}
-
-  lexorank@1.0.5: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,6 @@ catalog:
   dequal: ^2.0.3
   groq: ^6.11.0
   jsdom: ^29.1.1
-  lexorank: ^1.0.5
   lodash-es: ^4.18.1
   motion: ^13.1.0
   nanoid: ^6.0.1


### PR DESCRIPTION
## Why

Sanity schema extraction evaluates the legacy lexorank CommonJS bundle as ESM, causing TypeGen to fail with exports is not defined.

## What changed

- add a dependency-free, ESM-native @sanity/lexorank package compatible with lexorank 1.0.5 ranks and behavior
- migrate orderable-document-list and workflow without changing stored orderRank values or public APIs
- add compatibility vectors and plugin-level ordering coverage

## What to review

- API and persisted-rank compatibility in the new package
- dependency swaps in both consumers
- initial major and consumer patch changesets

## Verification

- pnpm format
- pnpm lint
- pnpm knip
- pnpm build
- pnpm test run: 1,395 tests across 226 files
- isolated schema extraction and TypeGen with the pinned Sanity next and 6.13.3-next.5

The one-time npm trusted-publishing bootstrap still requires an authenticated maintainer after review.